### PR TITLE
remove links to readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,10 @@
 # spatialdata
 
 [![Tests][badge-tests]][link-tests]
-[![Documentation][badge-docs]][link-docs]
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/scverse/spatialdata/main.svg)](https://results.pre-commit.ci/latest/github/scverse/spatialdata/main)
 
 [badge-tests]: https://img.shields.io/github/workflow/status/scverse/spatialdata/Test/main
 [link-tests]: https://github.com/scverse/spatialdata.git/actions/workflows/test.yml
-[badge-docs]: https://img.shields.io/readthedocs/spatialdata
 
 Spatial data format.
 
@@ -45,7 +43,5 @@ If you found a bug, please use the [issue tracker][issue-tracker].
 [scverse-discourse]: https://discourse.scverse.org/
 [issue-tracker]: https://github.com/scverse/spatialdata/issues
 [changelog]: https://spatialdata.readthedocs.io/latest/changelog.html
-[link-docs]: https://spatialdata.readthedocs.io/latest/
-[link-api]: https://spatialdata.readthedocs.io/latest/api.html
 
 <img src='https://github.com/giovp/spatialdata-sandbox/raw/main/graphics/overview.png'/>

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ Spatial data format.
 
 ## Getting started
 
-Please refer to the [documentation][link-docs]. In particular, the
-
--   [API documentation][link-api].
+coming soon
 
 ## Installation
 


### PR DESCRIPTION
As pointed out be @berl in #49 , there are links to docs that point to https://spatialdata.readthedocs.io/en/latest/ on the readme. As those are docs for a different project, this PR removes those links/references.

closes #49 