### PR TITLE
Export get_dims

### DIFF
--- a/spatialdata/__init__.py
+++ b/spatialdata/__init__.py
@@ -29,10 +29,16 @@ __all__ = [
     "SpatialElement",
     "get_transform",
     "set_transform",
+    "get_dims",
 ]
 
 from spatialdata._core._spatialdata import SpatialData
-from spatialdata._core.core_utils import SpatialElement, get_transform, set_transform
+from spatialdata._core.core_utils import (
+    SpatialElement,
+    get_dims,
+    get_transform,
+    set_transform,
+)
 from spatialdata._core.models import (
     Image2DModel,
     Image3DModel,


### PR DESCRIPTION
`spatialdata_io` tries to import this from the top level namespace

I'm assuming it was meant to be part of the public API.