### PR TITLE
Add some simple reprs for transformations, coordinate spaces, and axes

### DIFF
--- a/spatialdata/_core/coordinate_system.py
+++ b/spatialdata/_core/coordinate_system.py
@@ -18,6 +18,10 @@ class Axis:
         self.type = type
         self.unit = unit
 
+    def __repr__(self) -> str:
+        inner = ", ".join(f"'{v}'" for v in self.to_dict().values())
+        return f"Axis({inner})"
+
     def to_dict(self) -> Axis_t:
         d = {"name": self.name, "type": self.type}
         if self.unit is not None:
@@ -29,6 +33,9 @@ class CoordinateSystem:
     def __init__(self, name: Optional[str] = None, axes: Optional[List[Axis]] = None):
         self._name = name
         self._axes = axes if axes is not None else []
+
+    def __repr__(self) -> str:
+        return f"CoordinateSystem('{self.name}', {self._axes})"
 
     @staticmethod
     def from_dict(coord_sys: CoordSystem_t) -> "CoordinateSystem":

--- a/spatialdata/_core/transformations.py
+++ b/spatialdata/_core/transformations.py
@@ -63,6 +63,9 @@ class BaseTransformation(ABC):
         self.input_coordinate_system = input_coordinate_system
         self.output_coordinate_system = output_coordinate_system
 
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(input={self.input_coordinate_system}, output={self.output_coordinate_system})"
+
     @classmethod
     @abstractmethod
     def _from_dict(cls, d: Transformation_t) -> BaseTransformation:

--- a/tests/_core/test_coordinate_system.py
+++ b/tests/_core/test_coordinate_system.py
@@ -64,3 +64,18 @@ def test_coordinate_system_roundtrip():
     assert input_json == output_json
     cs2 = CoordinateSystem.from_json(output_json)
     assert cs == cs2
+
+
+def test_repr():
+    cs = CoordinateSystem(
+        "some coordinate system",
+        [
+            Axis("X", "space", "micrometers"),
+            Axis("Y", "space", "meters"),
+            Axis("T", "time"),
+        ],
+    )
+    expected = """CoordinateSystem('some coordinate system', [Axis('X', 'space', 'micrometers'), Axis('Y', 'space', 'meters'), Axis('T', 'time')])"""
+    as_str = repr(cs)
+
+    assert as_str == expected

--- a/tests/_core/test_transformations.py
+++ b/tests/_core/test_transformations.py
@@ -97,6 +97,12 @@ def _test_transformation(
         BaseTransformation.from_dict(json.loads(json.dumps(transformation.to_dict()))).to_dict()
     )
 
+    # test repr
+    as_str = repr(transformation)
+    assert repr(transformation.input_coordinate_system) in as_str
+    assert repr(transformation.output_coordinate_system) in as_str
+    assert type(transformation).__name__ in as_str
+
 
 def test_identity():
     _test_transformation(


### PR DESCRIPTION
Added simple repr functions for `BaseTransformation`, `CoordinateSpace`, and `Axis` types.

They're pretty simple, and for the `CoordinateSpace` and `Axis` types can actually be copied and pasted directly into code.

```python
sdata.points["transcripts"].attrs["transform"]
```

```
Scale(input=None, output=CoordinateSystem('xyz', [Axis('x', 'space', 'unit'), Axis('y', 'space', 'unit'), Axis('z', 'space', 'unit')]))
```

I figure these are decent starting point, and a massive improvement over the current reprs.