### PR TITLE
fixed BaseTransformation.transform(); print(sdata) shows coord systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Work in progress ⚠
 
+-   **The library is not ready.** We aim at a beta release in the following months. If interested in a demo/early beta, please reach out to us.
 -   To get involved in the discussion you are welcome to join our Zulip workspace and/or our community meetings every second week; [more info here](https://imagesc.zulipchat.com/#narrow/stream/329057-scverse/topic/SpatialData.20meetings).
--   **We aim at a beta release in the following months. If interested in a demo/early beta, please reach out to us.
 -   Links to the OME-NGFF specification: [0.4](https://ngff.openmicroscopy.org/latest/), [0.5-dev (tables)](https://github.com/ome/ngff/pull/64), [0.5-dev (transformations and coordinate systems)](https://github.com/ome/ngff/pull/138)
 
 # spatialdata

--- a/spatialdata/_core/_spatialdata.py
+++ b/spatialdata/_core/_spatialdata.py
@@ -873,7 +873,9 @@ class SpatialData:
             gen = self._gen_elements()
             elements_in_cs = []
             for k, name, obj in gen:
-                coordinate_systems = get_transformation(obj, get_all=True).keys()
+                transformations = get_transformation(obj, get_all=True)
+                assert isinstance(transformations, dict)
+                coordinate_systems = transformations.keys()
                 if cs in coordinate_systems:
                     elements_in_cs.append(f"/{k}/{name}")
             if len(elements_in_cs) > 0:

--- a/spatialdata/_core/_spatialdata.py
+++ b/spatialdata/_core/_spatialdata.py
@@ -253,21 +253,40 @@ class SpatialData:
 
     def _locate_spatial_element(self, element: SpatialElement) -> tuple[str, str]:
         found: list[SpatialElement] = []
-        found_element_type: str = ""
-        found_element_name: str = ""
+        found_element_type: list[str] = []
+        found_element_name: list[str] = []
         for element_type in ["images", "labels", "points", "shapes"]:
             for element_name, element_value in getattr(self, element_type).items():
                 if id(element_value) == id(element):
                     found.append(element_value)
-                    found_element_type = element_type
-                    found_element_name = element_name
+                    found_element_type.append(element_type)
+                    found_element_name.append(element_name)
         if len(found) == 0:
             raise ValueError("Element not found in the SpatialData object.")
         elif len(found) > 1:
-            raise ValueError("Element found multiple times in the SpatialData object.")
-        return found_element_name, found_element_type
+            raise ValueError(
+                f"Element found multiple times in the SpatialData object. Found {len(found)} elements with names: {found_element_name}, and types: {found_element_type}"
+            )
+        assert len(found_element_name) == 1
+        assert len(found_element_type) == 1
+        return found_element_name[0], found_element_type[0]
 
     def contains_element(self, element: SpatialElement, raise_exception: bool = False) -> bool:
+        """
+        Check if the spatial element is contained in the SpatialData object.
+
+        Parameters
+        ----------
+        element
+            The spatial element to check
+        raise_exception
+            If True, raise an exception if the element is not found. If False, return False if the element is not found.
+
+        Returns
+        -------
+        True if the element is found; False otherwise (if raise_exception is False).
+
+        """
         try:
             self._locate_spatial_element(element)
             return True

--- a/spatialdata/_core/_spatialdata_ops.py
+++ b/spatialdata/_core/_spatialdata_ops.py
@@ -64,8 +64,8 @@ def set_transformation(
             assert to_coordinate_system is None
             _set_transformations(element, transformation)
     else:
-        if not write_to_sdata.contains_element(element):
-            raise ValueError("The element is not part of the SpatialData object.")
+        if not write_to_sdata.contains_element(element, raise_exception=True):
+            raise RuntimeError("contains_element() failed without raising an exception.")
         if not write_to_sdata.is_backed():
             raise ValueError(
                 "The SpatialData object is not backed. You can either set a transformation to an element "
@@ -146,8 +146,8 @@ def remove_transformation(
             assert to_coordinate_system is None
             _set_transformations(element, {})
     else:
-        if not write_to_sdata.contains_element(element):
-            raise ValueError("The element is not part of the SpatialData object.")
+        if not write_to_sdata.contains_element(element, raise_exception=True):
+            raise RuntimeError("contains_element() failed without raising an exception.")
         if not write_to_sdata.is_backed():
             raise ValueError(
                 "The SpatialData object is not backed. You can either remove a transformation from an "

--- a/spatialdata/_core/models.py
+++ b/spatialdata/_core/models.py
@@ -547,7 +547,7 @@ class PointsModel:
             if instance_key is not None:
                 table[instance_key] = annotation[instance_key]
             for c in set(annotation.columns) - {feature_key, instance_key}:
-                table[c] = dd.from_pandas(annotation[c], **kwargs)
+                table[c] = dd.from_pandas(annotation[c], **kwargs)  # type: ignore[attr-defined]
             return cls._add_metadata_and_validate(
                 table, feature_key=feature_key, instance_key=instance_key, transformations=transformations
             )
@@ -570,11 +570,11 @@ class PointsModel:
         ndim = len(coordinates)
         axes = [X, Y, Z][:ndim]
         if isinstance(data, pd.DataFrame):
-            table: DaskDataFrame = dd.from_pandas(
+            table: DaskDataFrame = dd.from_pandas(  # type: ignore[attr-defined]
                 pd.DataFrame(data[[coordinates[ax] for ax in axes]].to_numpy(), columns=axes), **kwargs
             )
             if feature_key is not None:
-                feature_categ = dd.from_pandas(data[feature_key].astype(str).astype("category"), **kwargs)
+                feature_categ = dd.from_pandas(data[feature_key].astype(str).astype("category"), **kwargs)  # type: ignore[attr-defined]
                 table[feature_key] = feature_categ
         elif isinstance(data, dd.DataFrame):  # type: ignore[attr-defined]
             table = data[[coordinates[ax] for ax in axes]]

--- a/spatialdata/_core/transformations.py
+++ b/spatialdata/_core/transformations.py
@@ -206,27 +206,33 @@ class BaseTransformation(ABC):
         element
             Spatial element to transform.
         maintain_positioning
-            If True, each transformation of the transformed element will be prepended with the inverse of the current
-            transformation. In this way the data is transformed but the global positioning is maintained. An use case
-            changing the orientation/scale/etc of the data but keeping the alignment of the data within each coordinate
-            system. Please see notes for more details of how this parameter interact with xarray.DataArray for raster
-            data.
+            If True, in the transformed element, each transformation that was present in the original element will be
+            prepended with the inverse of the transformation used to transform the data (i.e. the current
+            transformation for which .transform() is called). In this way the data is transformed but the
+            positioning (for each coordinate system) is maintained. A use case is changing the orientation/scale/etc. of
+            the data but keeping the alignment of the data within each coordinate system.
+            If False, the data is simply transformed and the positioning (for each coordinate system) changes. For
+            raster data, the translation part of the transformation is prepended to any tranformation already present in
+            the element (see Notes below for more details). Furthermore, again in the case of raster data,
+            if the transformation being applied has a rotation-like component, then the translation that is prepended
+            also takes into account for the fact that the rotated data will have some paddings on each corner, and so
+            it's origin must be shifted accordingly.
+            Please see notes for more details of how this parameter interact with xarray.DataArray for raster data.
 
         Returns
         -------
-        SpatialElement
-            Transformed spatial element.
+        SpatialElement: Transformed spatial element.
 
         Notes
         -----
         An affine transformation contains a linear transformation and a translation. For raster types,
-        only the the linear transformation is applied to the data (e.g. the data is rotated or resized), but not the
+        only the linear transformation is applied to the data (e.g. the data is rotated or resized), but not the
         translation part.
         This means that calling Translation(...).transform(raster_element) will have the same effect as pre-pending the
         translation to each transformation of the raster element.
         Similarly, Translation(...).transform(raster_element, maintain_positioning=True) will not modify the raster
         element. We are considering to change this behavior by letting translations modify the coordinates stored with
-        xarray.DataArray. If you are interested in this usecase please get in touch by opening a GitHub Issue.
+        xarray.DataArray. If you are interested in this use case please get in touch by opening a GitHub Issue.
         """
         from spatialdata._core._transform_elements import _transform
 

--- a/spatialdata/_core/transformations.py
+++ b/spatialdata/_core/transformations.py
@@ -197,10 +197,40 @@ class BaseTransformation(ABC):
             raise ValueError(f"Invalid axes: {axes}")
         return valid_axes[axes]
 
-    def transform(self, element: SpatialElement) -> SpatialElement:
+    def transform(self, element: SpatialElement, maintain_positioning: bool = False) -> SpatialElement:
+        """
+        Transform a spatial element using this transformation and returns the transformed element.
+
+        Parameters
+        ----------
+        element
+            Spatial element to transform.
+        maintain_positioning
+            If True, each transformation of the transformed element will be prepended with the inverse of the current
+            transformation. In this way the data is transformed but the global positioning is maintained. An use case
+            changing the orientation/scale/etc of the data but keeping the alignment of the data within each coordinate
+            system. Please see notes for more details of how this parameter interact with xarray.DataArray for raster
+            data.
+
+        Returns
+        -------
+        SpatialElement
+            Transformed spatial element.
+
+        Notes
+        -----
+        An affine transformation contains a linear transformation and a translation. For raster types,
+        only the the linear transformation is applied to the data (e.g. the data is rotated or resized), but not the
+        translation part.
+        This means that calling Translation(...).transform(raster_element) will have the same effect as pre-pending the
+        translation to each transformation of the raster element.
+        Similarly, Translation(...).transform(raster_element, maintain_positioning=True) will not modify the raster
+        element. We are considering to change this behavior by letting translations modify the coordinates stored with
+        xarray.DataArray. If you are interested in this usecase please get in touch by opening a GitHub Issue.
+        """
         from spatialdata._core._transform_elements import _transform
 
-        transformed = _transform(element, self)
+        transformed = _transform(element, self, maintain_positioning=maintain_positioning)
         return transformed
 
     @abstractmethod

--- a/tests/_core/test_spatialdata_operations.py
+++ b/tests/_core/test_spatialdata_operations.py
@@ -167,3 +167,15 @@ def test_concatenate_sdatas(full_sdata):
     filtered1 = filtered.filter_by_coordinate_system(coordinate_system="my_space1", filter_table=False)
     concatenated = concatenate([filtered0, filtered1])
     assert len(list(concatenated._gen_elements())) == 2
+
+
+def test_locate_spatial_element(full_sdata):
+    assert full_sdata._locate_spatial_element(full_sdata.images["image2d"]) == ("image2d", "images")
+    im = full_sdata.images["image2d"]
+    del full_sdata.images["image2d"]
+    with pytest.raises(ValueError, match="Element not found in the SpatialData object."):
+        full_sdata._locate_spatial_element(im)
+    full_sdata.images["image2d"] = im
+    full_sdata.images["image2d_again"] = im
+    with pytest.raises(ValueError):
+        full_sdata._locate_spatial_element(im)


### PR DESCRIPTION
This PR finishes some work on transformations that was incomplete. In details:
* `print(sdata)` now shows which coordinate systems are available and which elements are in.
* transforming a raster type now prepends the correct translation to the transformed element. This is crucial when the transformation is rotation, so padding is added on the rotated image (for a visualization of this, see last three plots of the [transformations notebook](https://github.com/scverse/spatialdata-notebooks/blob/main/notebooks/transformations_examples.ipynb)).
* added util `_get_affine_for_element()`, which given an element and a transformation, gives an affine transformation with the correct input and output axes.
* added util `_decompose_affine_into_linear_and_translation()`, to split an affine transformation into an affine with no translation part and and a translation part. Useful when plotting.
* fixed bug in `_get_current_output_axes()` discovered when composing an affine 2D -> 3D and a translation 3D -> 3D. Added tests
* Added more tests based on real use cases that I had left commented out in the previous transform PR.
