### PR TITLE
Add transformations to polygons and points bounding box query

### DIFF
--- a/spatialdata/_compat.py
+++ b/spatialdata/_compat.py
@@ -22,4 +22,5 @@ def _check_geopandas_using_shapely() -> None:
                     "If you intended to use PyGEOS, set the option to False."
                 ),
                 UserWarning,
+                stacklevel=2,
             )

--- a/spatialdata/_core/_query_requests.py
+++ b/spatialdata/_core/_query_requests.py
@@ -1,0 +1,18 @@
+from typing import Callable
+
+
+from spatialdata._core.core_utils import SpatialElement
+
+
+class RequestSequence:
+    pass
+
+
+#
+def _dict_query_dispatcher(
+    elements: dict[str, SpatialElement], query_function: Callable, **kwargs
+) -> dict[str, SpatialElement]:
+    queried_elements = {}
+    for key, element in elements.items():
+        queried_elements[key] = query_function(element, **kwargs)
+    return queried_elements

--- a/spatialdata/_core/_query_requests.py
+++ b/spatialdata/_core/_query_requests.py
@@ -1,5 +1,4 @@
-from typing import Callable
-
+from typing import Any, Callable
 
 from spatialdata._core.core_utils import SpatialElement
 
@@ -10,9 +9,12 @@ class RequestSequence:
 
 #
 def _dict_query_dispatcher(
-    elements: dict[str, SpatialElement], query_function: Callable, **kwargs
+    elements: dict[str, SpatialElement], query_function: Callable[[SpatialElement], SpatialElement], **kwargs: Any
 ) -> dict[str, SpatialElement]:
     queried_elements = {}
     for key, element in elements.items():
-        queried_elements[key] = query_function(element, **kwargs)
+        result = query_function(element, **kwargs)
+        if result is not None:
+            # query returns None if it is empty
+            queried_elements[key] = result
     return queried_elements

--- a/spatialdata/_core/_spatial_query.py
+++ b/spatialdata/_core/_spatial_query.py
@@ -271,7 +271,16 @@ def _(
         max_coordinate=max_coordinate,
         target_coordinate_system=target_coordinate_system,
     )
-    return _bounding_box_query_points(points, request)
+    from spatialdata._core._spatialdata_ops import get_transformation, set_transformation
+    t = get_transformation(points, to_coordinate_system=target_coordinate_system)
+    from spatialdata._core.core_utils import get_dims
+    dims = get_dims(points)
+    # which one is needed?
+    t.inverse().to_affine_matrix(input_axes=axes, output_axes=axes)
+    t.inverse().to_affine_matrix(input_axes=dims, output_axes=dims)
+    set_transformation(points, t.inverse(), to_coordinate_system='new_target')
+    set_transformation(points, {'new_target': t.inverse()}, set_all=True)
+    return _bounding_box_query_points(points, request, transformation=t)
 
 
 # def bounding_box_query_request(sdata: SpatialData, request: BoundingBoxRequest) -> SpatialData:

--- a/spatialdata/_core/_spatial_query.py
+++ b/spatialdata/_core/_spatial_query.py
@@ -268,48 +268,6 @@ def _bounding_box_query_image_dict(
     return requested_images
 
 
-#
-# def _bounding_box_query_polygons(
-#     polygons_table: GeoDataFrame, max_coordinate: ArrayLike, min_coordinate: ArrayLike, axes: tuple[str, ...]
-# ) -> ArrayLike:
-#     """Perform a spatial bounding box query on a polygons element.
-#
-#     Parameters
-#     ----------
-#     polygons_table
-#         The polygons element to perform the query on.
-#     min_coordinate
-#         The upper left hand corner of the bounding box (i.e., minimum coordinates
-#         along all dimensions).
-#     max_coordinate
-#         The lower right hand corner of the bounding box (i.e., the maximum coordinates
-#         along all dimensions
-#     axes
-#         The axes for the min/max coordinates.
-#
-#     Returns
-#     -------
-#     The mask for the polygons inside of the bounding box
-#     """
-#     # get the polygon bounding boxes
-#     polygons_min_column_keys = [f"min{axis}" for axis in axes]
-#     polygons_min_coordinates = polygons_table.bounds[polygons_min_column_keys].values
-#
-#     polygons_max_column_keys = [f"max{axis}" for axis in axes]
-#     polygons_max_coordinates = polygons_table.bounds[polygons_max_column_keys].values
-#
-#     # check that the min coordinates are inside the bounding box
-#     min_inside = np.all(min_coordinate < polygons_min_coordinates, axis=1)
-#
-#     # check that the max coordinates are inside the bounding box
-#     max_inside = np.all(max_coordinate > polygons_max_coordinates, axis=1)
-#
-#     # polygons inside the bounding box satisfy both
-#     inside_mask: ArrayLike = np.logical_and(min_inside, max_inside)
-#
-#     return inside_mask
-
-
 @singledispatch
 def bounding_box_query(
     element: Union[SpatialElement, SpatialData],
@@ -424,5 +382,5 @@ def _(
     )
 
     bounding_box_non_axes_aligned = Polygon(intrinsic_bounding_box_corners)
-    queried = polygons[polygons.geometry.intersects(bounding_box_non_axes_aligned)]
+    queried = polygons[polygons.geometry.within(bounding_box_non_axes_aligned)]
     return queried

--- a/spatialdata/_core/_spatialdata.py
+++ b/spatialdata/_core/_spatialdata.py
@@ -37,6 +37,7 @@ from spatialdata._io.write import (
     write_table,
 )
 from spatialdata._logging import logger
+from spatialdata._types import ArrayLike
 
 # schema for elements
 Label2D_s = Labels2DModel()
@@ -880,8 +881,8 @@ class QueryManager:
     def bounding_box(
         self,
         axes: tuple[str, ...],
-        min_coordinate: np.ndarray,
-        max_coordinate: np.ndarray,
+        min_coordinate: ArrayLike,
+        max_coordinate: ArrayLike,
         target_coordinate_system: str,
     ) -> SpatialData:
         """Perform a bounding box query on the SpatialData object.

--- a/spatialdata/_core/_spatialdata.py
+++ b/spatialdata/_core/_spatialdata.py
@@ -899,7 +899,7 @@ class QueryManager:
         """
         from spatialdata._core._spatial_query import bounding_box_query
 
-        return bounding_box_query(
+        return bounding_box_query(  # type: ignore[return-value]
             self._sdata,
             axes=axes,
             min_coordinate=min_coordinate,

--- a/spatialdata/_core/_spatialdata.py
+++ b/spatialdata/_core/_spatialdata.py
@@ -17,13 +17,6 @@ from ome_zarr.io import parse_url
 from ome_zarr.types import JSONDict
 from spatial_image import SpatialImage
 
-from spatialdata._core._spatial_query import (
-    BaseSpatialRequest,
-    BoundingBoxRequest,
-    _bounding_box_query_image_dict,
-    _bounding_box_query_points_dict,
-    _bounding_box_query_polygons_dict,
-)
 from spatialdata._core.core_utils import SpatialElement, get_dims
 from spatialdata._core.models import (
     Image2DModel,
@@ -881,7 +874,16 @@ class QueryManager:
     def __init__(self, sdata: SpatialData):
         self._sdata = sdata
 
-    def bounding_box(self, request: BoundingBoxRequest) -> SpatialData:
+    # def bounding_box(self, request: BoundingBoxRequest) -> SpatialData:
+    # type: ignore[type-arg]
+
+    def bounding_box(
+        self,
+        axes: tuple[str, ...],
+        min_coordinate: np.ndarray,
+        max_coordinate: np.ndarray,
+        target_coordinate_system: str,
+    ) -> SpatialData:
         """Perform a bounding box query on the SpatialData object.
 
         Parameters
@@ -894,20 +896,18 @@ class QueryManager:
         The SpatialData object containing the requested data.
         Elements with no valid data are omitted.
         """
-        requested_points = _bounding_box_query_points_dict(points_dict=self._sdata.points, request=request)
-        requested_images = _bounding_box_query_image_dict(image_dict=self._sdata.images, request=request)
-        requested_polygons = _bounding_box_query_polygons_dict(polygons_dict=self._sdata.polygons, request=request)
+        from spatialdata._core._spatial_query import bounding_box_query
 
-        return SpatialData(
-            points=requested_points,
-            images=requested_images,
-            polygons=requested_polygons,
-            shapes=self._sdata.shapes,
-            table=self._sdata.table,
+        return bounding_box_query(
+            self._sdata,
+            axes=axes,
+            min_coordinate=min_coordinate,
+            max_coordinate=max_coordinate,
+            target_coordinate_system=target_coordinate_system,
         )
 
-    def __call__(self, request: BaseSpatialRequest) -> SpatialData:
-        if isinstance(request, BoundingBoxRequest):
-            return self.bounding_box(request)
-        else:
-            raise TypeError("unknown request type")
+    # def __call__(self, request: BaseSpatialRequest) -> SpatialData:
+    #     if isinstance(request, BoundingBoxRequest):
+    #         return self.bounding_box(**request.to_dict())
+    #     else:
+    #         raise TypeError("unknown request type")

--- a/tests/_core/test_spatial_query.py
+++ b/tests/_core/test_spatial_query.py
@@ -32,7 +32,12 @@ def _make_points_element():
 
 def test_bounding_box_request_immutable():
     """Test that the bounding box request is immutable."""
-    request = BoundingBoxRequest(axes=("y", "x"), min_coordinate=np.array([0, 0]), max_coordinate=np.array([10, 10]))
+    request = BoundingBoxRequest(
+        axes=("y", "x"),
+        min_coordinate=np.array([0, 0]),
+        max_coordinate=np.array([10, 10]),
+        target_coordinate_system="global",
+    )
     isinstance(request, BaseSpatialRequest)
 
     # fields should be immutable
@@ -49,27 +54,50 @@ def test_bounding_box_request_immutable():
 def test_bounding_box_request_only_spatial_axes():
     """Requests with axes that are not spatial should raise an error"""
     with pytest.raises(ValueError):
-        _ = BoundingBoxRequest(axes=("c", "x"), min_coordinate=np.array([0, 0]), max_coordinate=np.array([10, 10]))
+        _ = BoundingBoxRequest(
+            axes=("c", "x"),
+            min_coordinate=np.array([0, 0]),
+            max_coordinate=np.array([10, 10]),
+            target_coordinate_system="global",
+        )
 
 
 def test_bounding_box_request_wrong_number_of_coordinates():
     """Requests which specify coordinates not consistent with the axes should raise an error"""
     with pytest.raises(ValueError):
-        _ = BoundingBoxRequest(axes=("y", "x"), min_coordinate=np.array([0, 0, 0]), max_coordinate=np.array([10, 10]))
-
-    with pytest.raises(ValueError):
-        _ = BoundingBoxRequest(axes=("y", "x"), min_coordinate=np.array([0, 0]), max_coordinate=np.array([10, 10, 10]))
+        _ = BoundingBoxRequest(
+            axes=("y", "x"),
+            min_coordinate=np.array([0, 0, 0]),
+            max_coordinate=np.array([10, 10]),
+            target_coordinate_system="global",
+        )
 
     with pytest.raises(ValueError):
         _ = BoundingBoxRequest(
-            axes=("y", "x"), min_coordinate=np.array([0, 0, 0]), max_coordinate=np.array([10, 10, 10])
+            axes=("y", "x"),
+            min_coordinate=np.array([0, 0]),
+            max_coordinate=np.array([10, 10, 10]),
+            target_coordinate_system="global",
+        )
+
+    with pytest.raises(ValueError):
+        _ = BoundingBoxRequest(
+            axes=("y", "x"),
+            min_coordinate=np.array([0, 0, 0]),
+            max_coordinate=np.array([10, 10, 10]),
+            target_coordinate_system="global",
         )
 
 
 def test_bounding_box_request_wrong_coordinate_order():
     """Requests where the min coordinate is greater than the max coordinate should raise an error"""
     with pytest.raises(ValueError):
-        _ = BoundingBoxRequest(axes=("y", "x"), min_coordinate=np.array([0, 10]), max_coordinate=np.array([10, 0]))
+        _ = BoundingBoxRequest(
+            axes=("y", "x"),
+            min_coordinate=np.array([0, 10]),
+            max_coordinate=np.array([10, 0]),
+            target_coordinate_system="global",
+        )
 
 
 def test_bounding_box_points():
@@ -122,9 +150,14 @@ def test_bounding_box_image_2d(n_channels):
     image_element = Image2DModel.parse(image)
 
     # bounding box: y: [5, 9], x: [0, 4]
-    request = BoundingBoxRequest(axes=("y", "x"), min_coordinate=np.array([5, 0]), max_coordinate=np.array([9, 4]))
+    request = BoundingBoxRequest(
+        axes=("y", "x"),
+        min_coordinate=np.array([5, 0]),
+        max_coordinate=np.array([9, 4]),
+        target_coordinate_system="global",
+    )
 
-    image_result = bounding_box_query(image_element, request)
+    image_result = _bounding_box_query_image(image_element, request)
     expected_image = np.ones((n_channels, 5, 5))  # c dimension is preserved
     np.testing.assert_allclose(image_result, expected_image)
 
@@ -140,7 +173,9 @@ def test_bounding_box_image_3d(n_channels):
 
     # bounding box: z: [5, 9], y: [5, 9], x: [0, 4]
     request = BoundingBoxRequest(
-        axes=("z", "y", "x"), min_coordinate=np.array([5, 0, 2]), max_coordinate=np.array([9, 4, 6])
+        axes=("z", "y", "x"),
+        min_coordinate=np.array([5, 0, 2]),
+        max_coordinate=np.array([9, 4, 6], target_coordinate_system="global"),
     )
 
     image_result = _bounding_box_query_image(image_element, request)
@@ -156,7 +191,12 @@ def test_bounding_box_labels_2d():
     labels_element = Labels2DModel.parse(image)
 
     # bounding box: y: [5, 9], x: [0, 4]
-    request = BoundingBoxRequest(axes=("y", "x"), min_coordinate=np.array([5, 0]), max_coordinate=np.array([9, 4]))
+    request = BoundingBoxRequest(
+        axes=("y", "x"),
+        min_coordinate=np.array([5, 0]),
+        max_coordinate=np.array([9, 4]),
+        target_coordinate_system="global",
+    )
 
     labels_result = _bounding_box_query_image(labels_element, request)
     expected_image = np.ones((5, 5))
@@ -172,7 +212,10 @@ def test_bounding_box_labels_3d():
 
     # bounding box: z: [5, 9], y: [5, 9], x: [0, 4]
     request = BoundingBoxRequest(
-        axes=("z", "y", "x"), min_coordinate=np.array([5, 0, 2]), max_coordinate=np.array([9, 4, 6])
+        axes=("z", "y", "x"),
+        min_coordinate=np.array([5, 0, 2]),
+        max_coordinate=np.array([9, 4, 6]),
+        target_coordinate_system="global",
     )
 
     image_result = _bounding_box_query_image(labels_element, request)

--- a/tests/_core/test_spatial_query.py
+++ b/tests/_core/test_spatial_query.py
@@ -79,8 +79,23 @@ def test_bounding_box_points():
     original_x = np.array(points_element["x"])
     original_y = np.array(points_element["y"])
 
-    request = BoundingBoxRequest(axes=("x", "y"), min_coordinate=np.array([18, 25]), max_coordinate=np.array([22, 35]))
-    points_result = _bounding_box_query_points(points_element, request)
+    ##
+    from spatialdata import SpatialData
+
+    sdata = SpatialData(points={"points": points_element})
+    queried_sdata = sdata.query.bounding_box(
+        axes=("x", "y"),
+        min_coordinate=np.array([18, 25]),
+        max_coordinate=np.array([22, 35]),
+        target_coordinate_system="global",
+    )
+    points_result = queried_sdata.points["points"]
+    ##
+
+    # TODO: this commented part should remain and the current code should be in a new test (also for images, labels, polygons, shapes)
+    # request = BoundingBoxRequest(axes=("x", "y"), min_coordinate=np.array([18, 25]), max_coordinate=np.array([22, 35]))
+    # points_result = _bounding_box_query_points(points_element, request)
+    ##
     np.testing.assert_allclose(points_result["x"], [20])
     np.testing.assert_allclose(points_result["y"], [30])
 
@@ -90,6 +105,7 @@ def test_bounding_box_points():
     # original element should be unchanged
     np.testing.assert_allclose(points_element["x"], original_x)
     np.testing.assert_allclose(points_element["y"], original_y)
+    ##
 
 
 def test_bounding_box_points_no_points():

--- a/tests/_core/test_spatial_query.py
+++ b/tests/_core/test_spatial_query.py
@@ -18,7 +18,6 @@ from spatialdata._core._spatial_query import (
     BaseSpatialRequest,
     BoundingBoxRequest,
     _bounding_box_query_image,
-    _bounding_box_query_polygons,
     bounding_box_query,
 )
 
@@ -97,7 +96,6 @@ def test_bounding_box_points():
     # original element should be unchanged
     np.testing.assert_allclose(points_element["x"].compute(), original_x)
     np.testing.assert_allclose(points_element["y"].compute(), original_y)
-    ##
 
 
 def test_bounding_box_points_no_points():
@@ -209,10 +207,13 @@ def test_bounding_box_polygons():
     cell_polygon_table = gpd.GeoDataFrame(geometry=polygon_series)
     sd_polygons = PolygonsModel.parse(cell_polygon_table)
 
-    request = BoundingBoxRequest(
-        axes=("y", "x"), min_coordinate=np.array([40, 40]), max_coordinate=np.array([100, 100])
+    polygons_result = bounding_box_query(
+        sd_polygons,
+        axes=("y", "x"),
+        target_coordinate_system="global",
+        min_coordinate=np.array([40, 40]),
+        max_coordinate=np.array([100, 100]),
     )
-    polygons_result = _bounding_box_query_polygons(sd_polygons, request)
 
     assert len(polygons_result) == 1
     assert polygons_result.index[0] == 3

--- a/tests/_core/test_spatial_query.py
+++ b/tests/_core/test_spatial_query.py
@@ -18,8 +18,8 @@ from spatialdata._core._spatial_query import (
     BaseSpatialRequest,
     BoundingBoxRequest,
     _bounding_box_query_image,
-    _bounding_box_query_points,
     _bounding_box_query_polygons,
+    bounding_box_query,
 )
 
 
@@ -79,32 +79,24 @@ def test_bounding_box_points():
     original_x = np.array(points_element["x"])
     original_y = np.array(points_element["y"])
 
-    ##
-    from spatialdata import SpatialData
-
-    sdata = SpatialData(points={"points": points_element})
-    queried_sdata = sdata.query.bounding_box(
+    points_result = bounding_box_query(
+        points_element,
         axes=("x", "y"),
         min_coordinate=np.array([18, 25]),
         max_coordinate=np.array([22, 35]),
         target_coordinate_system="global",
     )
-    points_result = queried_sdata.points["points"]
-    ##
 
-    # TODO: this commented part should remain and the current code should be in a new test (also for images, labels, polygons, shapes)
-    # request = BoundingBoxRequest(axes=("x", "y"), min_coordinate=np.array([18, 25]), max_coordinate=np.array([22, 35]))
-    # points_result = _bounding_box_query_points(points_element, request)
-    ##
-    np.testing.assert_allclose(points_result["x"], [20])
-    np.testing.assert_allclose(points_result["y"], [30])
+    # Check that the correct point was selected
+    np.testing.assert_allclose(points_result["x"].compute(), [20])
+    np.testing.assert_allclose(points_result["y"].compute(), [30])
 
     # result should be valid points element
     PointsModel.validate(points_result)
 
     # original element should be unchanged
-    np.testing.assert_allclose(points_element["x"], original_x)
-    np.testing.assert_allclose(points_element["y"], original_y)
+    np.testing.assert_allclose(points_element["x"].compute(), original_x)
+    np.testing.assert_allclose(points_element["y"].compute(), original_y)
     ##
 
 
@@ -113,12 +105,14 @@ def test_bounding_box_points_no_points():
     return a points element with length 0.
     """
     points_element = _make_points_element()
-    request = BoundingBoxRequest(axes=("x", "y"), min_coordinate=np.array([40, 50]), max_coordinate=np.array([45, 55]))
-    points_result = _bounding_box_query_points(points_element, request)
-    assert len(points_result) == 0
-
-    # result should be valid points element
-    PointsModel.validate(points_result)
+    request = bounding_box_query(
+        points_element,
+        axes=("x", "y"),
+        min_coordinate=np.array([40, 50]),
+        max_coordinate=np.array([45, 55]),
+        target_coordinate_system="global",
+    )
+    assert request is None
 
 
 @pytest.mark.parametrize("n_channels", [1, 2, 3])
@@ -132,7 +126,7 @@ def test_bounding_box_image_2d(n_channels):
     # bounding box: y: [5, 9], x: [0, 4]
     request = BoundingBoxRequest(axes=("y", "x"), min_coordinate=np.array([5, 0]), max_coordinate=np.array([9, 4]))
 
-    image_result = _bounding_box_query_image(image_element, request)
+    image_result = bounding_box_query(image_element, request)
     expected_image = np.ones((n_channels, 5, 5))  # c dimension is preserved
     np.testing.assert_allclose(image_result, expected_image)
 


### PR DESCRIPTION
Hey @LucaMarconato . Here are the transforms added to the bounding box query for points and polygons. This gets the main infrastructure in. We can extend the tests for a few corner cases in a follow up PR.

A couple of notes:
- the queries now return None if no data matches the query. This way the user doesn't have to figure out the specific way to check in an element is empty for each of the different types of elements.
- I had to reset the index on the DaskDataFrame when subsetting the points. Otherwise, the tables get misaligned during the transform because the index doesn't start from 0 and the index of the transformed points that are re-inserted do start from 0. This feels a bit hacky, but I think it's okay for now.

I won't be able to work on this tomorrow, so please feel free to take the PR over and directly push to it!