### PR TITLE
cleanup format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+line_length = 120
 
 [Makefile]
 indent_style = tab

--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 # Can't yet be moved to the pyproject.toml due to https://github.com/PyCQA/flake8/issues/234
 [flake8]
-max-line-length = 88
+max-line-length = 120
 ignore =
     # line break before a binary operator -> black does not adhere to PEP8
     W503

--- a/spatialdata/_io/format.py
+++ b/spatialdata/_io/format.py
@@ -113,7 +113,7 @@ class ShapesFormatV01(SpatialDataFormatV01):
 
         typ = GeometryType(metadata_[Shapes_s.GEOS_KEY][Shapes_s.TYPE_KEY])
         assert typ.name == metadata_[Shapes_s.GEOS_KEY][Shapes_s.NAME_KEY]
-        assert self.spatialdata_version == metadata_["version"]
+        assert self.version == metadata_["version"]
         return typ
 
     def attrs_to_dict(self, geometry: GeometryType) -> dict[str, Union[str, dict[str, Any]]]:
@@ -131,7 +131,7 @@ class PointsFormatV01(SpatialDataFormatV01):
         if Points_s.ATTRS_KEY not in metadata:
             raise KeyError(f"Missing key {Points_s.ATTRS_KEY} in points metadata.")
         metadata_ = metadata[Points_s.ATTRS_KEY]
-        assert self.spatialdata_version == metadata_["version"]
+        assert self.version == metadata_["version"]
         d = {}
         if Points_s.FEATURE_KEY in metadata_:
             d[Points_s.FEATURE_KEY] = metadata_[Points_s.FEATURE_KEY]

--- a/spatialdata/_io/format.py
+++ b/spatialdata/_io/format.py
@@ -17,31 +17,11 @@ Points_s = PointsModel()
 
 
 class SpatialDataFormatV01(CurrentFormat):
-    """
-    SpatialDataFormat defines the format of the spatialdata
-    package.
-    """
+    """SpatialDataFormat defines the format of the spatialdata package."""
 
-    @property
-    def spatialdata_version(self) -> str:
-        return "0.1"
 
-    def validate_table(
-        self,
-        table: AnnData,
-        region_key: Optional[str] = None,
-        instance_key: Optional[str] = None,
-    ) -> None:
-        if not isinstance(table, AnnData):
-            raise TypeError(f"`tables` must be `anndata.AnnData`, was {type(table)}.")
-        if region_key is not None:
-            if not is_categorical_dtype(table.obs[region_key]):
-                raise ValueError(
-                    f"`tables.obs[region_key]` must be of type `categorical`, not `{type(table.obs[region_key])}`."
-                )
-        if instance_key is not None:
-            if table.obs[instance_key].isnull().values.any():
-                raise ValueError("`tables.obs[instance_key]` must not contain null values, but it does.")
+class RasterFormatV01(SpatialDataFormatV01):
+    """Formatter for raster data."""
 
     def generate_coordinate_transformations(self, shapes: list[tuple[Any]]) -> Optional[list[list[dict[str, Any]]]]:
         data_shape = shapes[0]
@@ -114,8 +94,12 @@ class SpatialDataFormatV01(CurrentFormat):
         return [d["labels"] for d in omero_metadata["channels"]]
 
 
-class ShapesFormat(SpatialDataFormatV01):
+class ShapesFormatV01(SpatialDataFormatV01):
     """Formatter for shapes."""
+
+    @property
+    def version(self) -> str:
+        return "0.1"
 
     def attrs_from_dict(self, metadata: dict[str, Any]) -> GeometryType:
         if Shapes_s.ATTRS_KEY not in metadata:
@@ -136,8 +120,12 @@ class ShapesFormat(SpatialDataFormatV01):
         return {Shapes_s.GEOS_KEY: {Shapes_s.NAME_KEY: geometry.name, Shapes_s.TYPE_KEY: geometry.value}}
 
 
-class PointsFormat(SpatialDataFormatV01):
+class PointsFormatV01(SpatialDataFormatV01):
     """Formatter for points."""
+
+    @property
+    def version(self) -> str:
+        return "0.1"
 
     def attrs_from_dict(self, metadata: dict[str, Any]) -> dict[str, dict[str, Any]]:
         if Points_s.ATTRS_KEY not in metadata:
@@ -159,3 +147,34 @@ class PointsFormat(SpatialDataFormatV01):
             if Points_s.FEATURE_KEY in data[Points_s.ATTRS_KEY]:
                 d[Points_s.FEATURE_KEY] = data[Points_s.ATTRS_KEY][Points_s.FEATURE_KEY]
         return d
+
+
+class TablesFormatV01(SpatialDataFormatV01):
+    """Formatter for tables."""
+
+    @property
+    def version(self) -> str:
+        return "0.1"
+
+    def validate_table(
+        self,
+        table: AnnData,
+        region_key: Optional[str] = None,
+        instance_key: Optional[str] = None,
+    ) -> None:
+        if not isinstance(table, AnnData):
+            raise TypeError(f"`tables` must be `anndata.AnnData`, was {type(table)}.")
+        if region_key is not None:
+            if not is_categorical_dtype(table.obs[region_key]):
+                raise ValueError(
+                    f"`tables.obs[region_key]` must be of type `categorical`, not `{type(table.obs[region_key])}`."
+                )
+        if instance_key is not None:
+            if table.obs[instance_key].isnull().values.any():
+                raise ValueError("`tables.obs[instance_key]` must not contain null values, but it does.")
+
+
+CurrentRasterFormat = RasterFormatV01
+CurrentShapesFormat = ShapesFormatV01
+CurrentPointsFormat = PointsFormatV01
+CurrentTablesFormat = TablesFormatV01

--- a/spatialdata/_io/read.py
+++ b/spatialdata/_io/read.py
@@ -28,7 +28,12 @@ from spatialdata._core.models import TableModel
 from spatialdata._core.ngff.ngff_transformations import NgffBaseTransformation
 from spatialdata._core.transformations import BaseTransformation
 from spatialdata._io._utils import ome_zarr_logger
-from spatialdata._io.format import PointsFormat, ShapesFormat, SpatialDataFormatV01
+from spatialdata._io.format import (
+    CurrentPointsFormat,
+    CurrentRasterFormat,
+    CurrentShapesFormat,
+    SpatialDataFormatV01,
+)
 
 
 def read_zarr(store: Union[str, Path, zarr.Group]) -> SpatialData:
@@ -122,7 +127,7 @@ def _get_transformations_from_ngff_dict(
 
 
 def _read_multiscale(
-    store: str, raster_type: Literal["image", "labels"], fmt: SpatialDataFormatV01 = SpatialDataFormatV01()
+    store: str, raster_type: Literal["image", "labels"], fmt: SpatialDataFormatV01 = CurrentRasterFormat()
 ) -> Union[SpatialImage, MultiscaleSpatialImage]:
     assert isinstance(store, str)
     assert raster_type in ["image", "labels"]
@@ -159,7 +164,7 @@ def _read_multiscale(
     # if image, read channels metadata
     if raster_type == "image":
         omero = multiscales[0]["omero"]
-        channels = fmt.channels_from_metadata(omero)
+        channels: list[Any] = fmt.channels_from_metadata(omero)
     axes = [i["name"] for i in node.metadata["axes"]]
     if len(datasets) > 1:
         multiscale_image = {}
@@ -188,7 +193,7 @@ def _read_multiscale(
         return compute_coordinates(si)
 
 
-def _read_shapes(store: Union[str, Path, MutableMapping, zarr.Group], fmt: SpatialDataFormatV01 = ShapesFormat()) -> GeoDataFrame:  # type: ignore[type-arg]
+def _read_shapes(store: Union[str, Path, MutableMapping, zarr.Group], fmt: SpatialDataFormatV01 = CurrentShapesFormat()) -> GeoDataFrame:  # type: ignore[type-arg]
     """Read shapes from a zarr store."""
     assert isinstance(store, str)
     f = zarr.open(store, mode="r")
@@ -212,7 +217,7 @@ def _read_shapes(store: Union[str, Path, MutableMapping, zarr.Group], fmt: Spati
 
 
 def _read_points(
-    store: Union[str, Path, MutableMapping, zarr.Group], fmt: SpatialDataFormatV01 = PointsFormat()  # type: ignore[type-arg]
+    store: Union[str, Path, MutableMapping, zarr.Group], fmt: SpatialDataFormatV01 = CurrentPointsFormat()  # type: ignore[type-arg]
 ) -> DaskDataFrame:
     """Read points from a zarr store."""
     assert isinstance(store, str)

--- a/spatialdata/_io/write.py
+++ b/spatialdata/_io/write.py
@@ -326,7 +326,7 @@ def write_table(
     fmt.validate_table(table, region_key, instance_key)
     write_adata(group, name, table)  # creates group[name]
     tables_group = group[name]
-    tables_group.attrs["encoding_type"] = group_type
+    tables_group.attrs["encoding-type"] = group_type
     tables_group.attrs["region"] = region
     tables_group.attrs["region_key"] = region_key
     tables_group.attrs["instance_key"] = instance_key

--- a/spatialdata/_io/write.py
+++ b/spatialdata/_io/write.py
@@ -272,7 +272,7 @@ def write_shapes(
         shapes_group.create_dataset(name=ShapesModel.RADIUS_KEY, data=shapes[ShapesModel.RADIUS_KEY].values)
 
     attrs = fmt.attrs_to_dict(geometry)
-    attrs["version"] = fmt.spatialdata_version
+    attrs["version"] = fmt.version
 
     _write_metadata(
         shapes_group,
@@ -300,7 +300,7 @@ def write_points(
     points.to_parquet(path)
 
     attrs = fmt.attrs_to_dict(points.attrs)
-    attrs["version"] = fmt.spatialdata_version
+    attrs["version"] = fmt.version
 
     _write_metadata(
         points_groups,
@@ -326,11 +326,11 @@ def write_table(
     fmt.validate_table(table, region_key, instance_key)
     write_adata(group, name, table)  # creates group[name]
     tables_group = group[name]
-    tables_group.attrs["@type"] = group_type
+    tables_group.attrs["encoding_type"] = group_type
     tables_group.attrs["region"] = region
     tables_group.attrs["region_key"] = region_key
     tables_group.attrs["instance_key"] = instance_key
-    tables_group.attrs["version"] = fmt.spatialdata_version
+    tables_group.attrs["version"] = fmt.version
 
 
 def _iter_multiscale(

--- a/spatialdata/_io/write.py
+++ b/spatialdata/_io/write.py
@@ -326,7 +326,7 @@ def write_table(
     fmt.validate_table(table, region_key, instance_key)
     write_adata(group, name, table)  # creates group[name]
     tables_group = group[name]
-    tables_group.attrs["encoding-type"] = group_type
+    tables_group.attrs["spatialdata-encoding-type"] = group_type
     tables_group.attrs["region"] = region
     tables_group.attrs["region_key"] = region_key
     tables_group.attrs["instance_key"] = instance_key

--- a/tests/_io/test_format.py
+++ b/tests/_io/test_format.py
@@ -1,11 +1,13 @@
 from typing import Any, Optional
 
 import pytest
+from shapely import GeometryType
 
-from spatialdata._core.models import PointsModel
-from spatialdata._io.format import CurrentPointsFormat
+from spatialdata._core.models import PointsModel, ShapesModel
+from spatialdata._io.format import CurrentPointsFormat, CurrentShapesFormat
 
 Points_f = CurrentPointsFormat()
+Shapes_f = CurrentShapesFormat()
 
 
 class TestFormat:
@@ -20,7 +22,7 @@ class TestFormat:
         feature_key: Optional[str],
         instance_key: Optional[str],
     ) -> None:
-        metadata: dict[str, Any] = {attrs_key: {"version": Points_f.spatialdata_version}}
+        metadata: dict[str, Any] = {attrs_key: {"version": Points_f.version}}
         format_metadata: dict[str, Any] = {attrs_key: {}}
         if feature_key is not None:
             metadata[attrs_key][feature_key] = "target"
@@ -31,3 +33,31 @@ class TestFormat:
         assert metadata[attrs_key] == Points_f.attrs_to_dict(format_metadata)
         if feature_key is None and instance_key is None:
             assert len(format_metadata[attrs_key]) == len(metadata[attrs_key]) == 0
+
+    @pytest.mark.parametrize("attrs_key", [ShapesModel.ATTRS_KEY])
+    @pytest.mark.parametrize("geos_key", [ShapesModel.GEOS_KEY])
+    @pytest.mark.parametrize("type_key", [ShapesModel.TYPE_KEY])
+    @pytest.mark.parametrize("name_key", [ShapesModel.NAME_KEY])
+    @pytest.mark.parametrize("shapes_type", [0])
+    def test_format_shapes(
+        self,
+        attrs_key: str,
+        geos_key: str,
+        type_key: str,
+        name_key: str,
+        shapes_type: int,
+    ) -> None:
+        shapes_dict = {
+            0: "POINT",
+            3: "POLYGON",
+            6: "MULTIPOLYGON",
+        }
+        metadata: dict[str, Any] = {attrs_key: {"version": Shapes_f.version}}
+        format_metadata: dict[str, Any] = {attrs_key: {}}
+        metadata[attrs_key][geos_key] = {}
+        metadata[attrs_key][geos_key][type_key] = shapes_type
+        metadata[attrs_key][geos_key][name_key] = shapes_dict[shapes_type]
+        format_metadata[attrs_key] = Shapes_f.attrs_from_dict(metadata)
+        metadata[attrs_key].pop("version")
+        geometry = GeometryType(metadata[attrs_key][geos_key][type_key])
+        assert metadata[attrs_key] == Shapes_f.attrs_to_dict(geometry)

--- a/tests/_io/test_format.py
+++ b/tests/_io/test_format.py
@@ -3,9 +3,9 @@ from typing import Any, Optional
 import pytest
 
 from spatialdata._core.models import PointsModel
-from spatialdata._io.format import PointsFormat
+from spatialdata._io.format import CurrentPointsFormat
 
-Points_f = PointsFormat()
+Points_f = CurrentPointsFormat()
 
 
 class TestFormat:

--- a/tests/_io/test_format.py
+++ b/tests/_io/test_format.py
@@ -38,7 +38,7 @@ class TestFormat:
     @pytest.mark.parametrize("geos_key", [ShapesModel.GEOS_KEY])
     @pytest.mark.parametrize("type_key", [ShapesModel.TYPE_KEY])
     @pytest.mark.parametrize("name_key", [ShapesModel.NAME_KEY])
-    @pytest.mark.parametrize("shapes_type", [0])
+    @pytest.mark.parametrize("shapes_type", [0, 3, 6])
     def test_format_shapes(
         self,
         attrs_key: str,


### PR DESCRIPTION
addressed some of the points described in #149 

- split format version per element
  - except for images and labels that are grouped together, following ome-zarr format

- removed `@type` and replaced it with `encoding-type`

- added a test for for shapes format