### PR TITLE
update table model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "shapely>=2.0.1",
     "rich",
     "pyarrow",
-    "tqdm",
     "typing_extensions>=4.0.0",
     "dask-image",
     "networkx"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "xarray",
     "zarr",
 #    "ome_zarr",
-    "ome_zarr@git+https://github.com/LucaMarconato/ome-zarr-py@bug_fix_io",
+    "ome_zarr@git+https://github.com/ome/ome-zarr-py.git",
     "spatial_image>=0.3.0",
     "multiscale_spatial_image>=0.11.2",
     "xarray-schema",

--- a/spatialdata/_core/_spatialdata.py
+++ b/spatialdata/_core/_spatialdata.py
@@ -901,9 +901,6 @@ class QueryManager:
     def __init__(self, sdata: SpatialData):
         self._sdata = sdata
 
-    # def bounding_box(self, request: BoundingBoxRequest) -> SpatialData:
-    # type: ignore[type-arg]
-
     def bounding_box(
         self,
         axes: tuple[str, ...],

--- a/spatialdata/_core/_spatialdata.py
+++ b/spatialdata/_core/_spatialdata.py
@@ -359,8 +359,9 @@ class SpatialData:
 
         if filter_table:
             table_mapping_metadata = self.table.uns[TableModel.ATTRS_KEY]
-            region_key = table_mapping_metadata["region_key"]
+            region_key = table_mapping_metadata[TableModel.REGION_KEY_KEY]
             table = self.table[self.table.obs[region_key].isin(element_paths_in_coordinate_system)].copy()
+            table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY] = table.obs[region_key].unique().tolist()
         else:
             table = self.table
 

--- a/spatialdata/_core/_spatialdata_ops.py
+++ b/spatialdata/_core/_spatialdata_ops.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import anndata
 import networkx as nx
 import numpy as np
 from anndata import AnnData
 
-from spatialdata._core._spatialdata import SpatialData
+if TYPE_CHECKING:
+    from spatialdata._core._spatialdata import SpatialData
+
 from spatialdata._core.core_utils import (
     DEFAULT_COORDINATE_SYSTEM,
     SpatialElement,

--- a/spatialdata/_core/_spatialdata_ops.py
+++ b/spatialdata/_core/_spatialdata_ops.py
@@ -363,6 +363,7 @@ def concatenate(
     -------
     The concatenated :class:`spatialdata.SpatialData` object.
     """
+    from spatialdata import SpatialData
 
     assert type(sdatas) == list, "sdatas must be a list"
     assert len(sdatas) > 0, "sdatas must be a non-empty list"

--- a/spatialdata/_core/_spatialdata_ops.py
+++ b/spatialdata/_core/_spatialdata_ops.py
@@ -289,13 +289,25 @@ def get_transformation_between_coordinate_systems(
 
 def _concatenate_tables(
     tables: list[AnnData],
-    region_key: str = "region_merged",
-    instance_key: str = "instance_merged",
+    region_key: str | None = None,
+    instance_key: str | None = None,
     **kwargs: Any,
 ) -> AnnData:
     region_keys = [table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY] for table in tables]
     instance_keys = [table.uns[TableModel.ATTRS_KEY][TableModel.INSTANCE_KEY] for table in tables]
     regions = [table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY] for table in tables]
+
+    if len(set(region_keys)) == 1:
+        region_key = list(region_keys)[0]
+    else:
+        if region_key is None:
+            raise ValueError("`region_key` must be specified if tables have different region keys")
+
+    if len(set(instance_keys)) == 1:
+        instance_key = list(instance_keys)[0]
+    else:
+        if instance_key is None:
+            raise ValueError("`instance_key` must be specified if tables have different instance keys")
 
     tables_l = []
     regions_l = []
@@ -326,8 +338,8 @@ def _concatenate_tables(
 
 def concatenate(
     sdatas: list[SpatialData],
-    region_key: str = "region_merged",
-    instance_key: str = "instance_merged",
+    region_key: str | None = None,
+    instance_key: str | None = None,
     **kwargs: Any,
 ) -> SpatialData:
     """
@@ -339,6 +351,7 @@ def concatenate(
         The spatial data objects to concatenate.
     region_key
         The key to use for the region column in the concatenated object.
+        If all region_keys are the same, the `region_key` is used.
     instance_key
         The key to use for the instance column in the concatenated object.
     kwargs

--- a/spatialdata/_core/_spatialdata_ops.py
+++ b/spatialdata/_core/_spatialdata_ops.py
@@ -362,27 +362,25 @@ def concatenate(
     """
     from spatialdata import SpatialData
 
+    merged_images = {**{k: v for sdata in sdatas for k, v in sdata.images.items()}}
+    if len(merged_images) != np.sum([len(sdata.images) for sdata in sdatas]):
+        raise KeyError("Images must have unique names across the SpatialData objects to concatenate")
+    merged_labels = {**{k: v for sdata in sdatas for k, v in sdata.labels.items()}}
+    if len(merged_labels) != np.sum([len(sdata.labels) for sdata in sdatas]):
+        raise KeyError("Labels must have unique names across the SpatialData objects to concatenate")
+    merged_points = {**{k: v for sdata in sdatas for k, v in sdata.points.items()}}
+    if len(merged_points) != np.sum([len(sdata.points) for sdata in sdatas]):
+        raise KeyError("Points must have unique names across the SpatialData objects to concatenate")
+    merged_shapes = {**{k: v for sdata in sdatas for k, v in sdata.shapes.items()}}
+    if len(merged_shapes) != np.sum([len(sdata.shapes) for sdata in sdatas]):
+        raise KeyError("Shapes must have unique names across the SpatialData objects to concatenate")
+
     assert type(sdatas) == list, "sdatas must be a list"
     assert len(sdatas) > 0, "sdatas must be a non-empty list"
-    if len(sdatas) == 1:
-        return sdatas[0]
 
     merged_table = _concatenate_tables(
         [sdata.table for sdata in sdatas if sdata.table is not None], region_key, instance_key, **kwargs
     )
-
-    merged_images = {**{k: v for sdata in sdatas for k, v in sdata.images.items()}}
-    if len(merged_images) != np.sum([len(sdata.images) for sdata in sdatas]):
-        raise RuntimeError("Images must have unique names across the SpatialData objects to concatenate")
-    merged_labels = {**{k: v for sdata in sdatas for k, v in sdata.labels.items()}}
-    if len(merged_labels) != np.sum([len(sdata.labels) for sdata in sdatas]):
-        raise RuntimeError("Labels must have unique names across the SpatialData objects to concatenate")
-    merged_points = {**{k: v for sdata in sdatas for k, v in sdata.points.items()}}
-    if len(merged_points) != np.sum([len(sdata.points) for sdata in sdatas]):
-        raise RuntimeError("Points must have unique names across the SpatialData objects to concatenate")
-    merged_shapes = {**{k: v for sdata in sdatas for k, v in sdata.shapes.items()}}
-    if len(merged_shapes) != np.sum([len(sdata.shapes) for sdata in sdatas]):
-        raise RuntimeError("Shapes must have unique names across the SpatialData objects to concatenate")
 
     sdata = SpatialData(
         images=merged_images,

--- a/spatialdata/_core/_spatialdata_ops.py
+++ b/spatialdata/_core/_spatialdata_ops.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-import anndata
 import networkx as nx
 import numpy as np
 from anndata import AnnData
@@ -297,7 +296,7 @@ def _concatenate_tables(
 ) -> AnnData:
     region_keys = [table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY] for table in tables]
     instance_keys = [table.uns[TableModel.ATTRS_KEY][TableModel.INSTANCE_KEY] for table in tables]
-    regions = [table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY] for table in tables]
+    [table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY] for table in tables]
 
     if len(set(region_keys)) == 1:
         region_key = list(region_keys)[0]

--- a/spatialdata/_core/models.py
+++ b/spatialdata/_core/models.py
@@ -669,9 +669,12 @@ class TableModel:
 
         if region_key is None:
             raise ValueError(f"`{cls.REGION_KEY_KEY}` must be provided.")
+        if isinstance(region, np.ndarray):
+            region = region.tolist()
         if region is None:
             raise ValueError(f"`{cls.REGION_KEY}` must be provided.")
         region_ = region if isinstance(region, list) else [region]
+        print(region_)
         if TYPE_CHECKING:
             assert isinstance(region_, list)
         if not adata.obs[region_key].isin(region_).all():
@@ -688,7 +691,7 @@ class TableModel:
 
 
 # TODO: consider removing if we settle with geodataframe
-def _sparse_matrix_from_assignment(
+def _sparse_matrix_from_assignment(  # pragma: no cover
     n_obs: int, var_names: Union[list[str], ArrayLike], assignment: pd.Series
 ) -> csr_matrix:
     """Create a sparse matrix from an assignment array."""

--- a/spatialdata/_core/models.py
+++ b/spatialdata/_core/models.py
@@ -674,7 +674,6 @@ class TableModel:
         if region is None:
             raise ValueError(f"`{cls.REGION_KEY}` must be provided.")
         region_ = region if isinstance(region, list) else [region]
-        print(region_)
         if TYPE_CHECKING:
             assert isinstance(region_, list)
         if not adata.obs[region_key].isin(region_).all():

--- a/spatialdata/_core/models.py
+++ b/spatialdata/_core/models.py
@@ -356,7 +356,7 @@ class ShapesModel:
         offsets
             In the case of (Multi)`Polygons` shapes, the offsets of the polygons must be provided.
         radius
-            Array of size of the `Circles`. It must be provided if the shapes are `Circles`.
+            Size of the `Circles`. It must be provided if the shapes are `Circles`.
         index
             Index of the shapes, must be of type `str`. If None, it's generated automatically.
         transform
@@ -377,7 +377,7 @@ class ShapesModel:
         data: np.ndarray,  # type: ignore[type-arg]
         geometry: Literal[0, 3, 6],  # [GeometryType.POINT, GeometryType.POLYGON, GeometryType.MULTIPOLYGON]
         offsets: Optional[tuple[ArrayLike, ...]] = None,
-        radius: Optional[ArrayLike] = None,
+        radius: Optional[Union[float, ArrayLike]] = None,
         index: Optional[ArrayLike] = None,
         transformations: Optional[MappingToCoordinateSystem_t] = None,
     ) -> GeoDataFrame:
@@ -400,7 +400,7 @@ class ShapesModel:
     def _(
         cls,
         data: Union[str, Path],
-        radius: Optional[ArrayLike] = None,
+        radius: Optional[Union[float, ArrayLike]] = None,
         index: Optional[ArrayLike] = None,
         transformations: Optional[Any] = None,
         **kwargs: Any,

--- a/spatialdata/_core/models.py
+++ b/spatialdata/_core/models.py
@@ -678,7 +678,9 @@ class TableModel:
         if not adata.obs[region_key].isin(region_).all():
             raise ValueError(f"`adata.obs[{region_key}]` values do not match with `{cls.REGION_KEY}` values.")
         if not is_categorical_dtype(adata.obs[region_key]):
-            warnings.warn(f"Converting `{cls.REGION_KEY_KEY}: {region_key}` to categorical dtype.", UserWarning)
+            warnings.warn(
+                f"Converting `{cls.REGION_KEY_KEY}: {region_key}` to categorical dtype.", UserWarning, stacklevel=2
+            )
             adata.obs[region_key] = pd.Categorical(adata.obs[region_key])
         if instance_key is None:
             raise ValueError("`instance_key` must be provided.")

--- a/spatialdata/_core/models.py
+++ b/spatialdata/_core/models.py
@@ -432,7 +432,7 @@ class ShapesModel:
     ) -> GeoDataFrame:
         if "geometry" not in data.columns:
             raise ValueError("`geometry` column not found in `GeoDataFrame`.")
-        if isinstance(data["geometry"][0], Point):
+        if isinstance(data["geometry"].iloc[0], Point):
             if cls.RADIUS_KEY not in data.columns:
                 raise ValueError(f"Column `{cls.RADIUS_KEY}` not found.")
         _parse_transformations(data, transformations)

--- a/tests/_core/test_models.py
+++ b/tests/_core/test_models.py
@@ -286,17 +286,14 @@ class TestModels:
     ) -> None:
         region_key = "reg"
         obs = pd.DataFrame(RNG.integers(0, 100, size=(10, 3)), columns=["A", "B", "C"])
-        obs["A"] = obs["A"].astype(str)  # instance_key
         obs[region_key] = region
         adata = AnnData(RNG.normal(size=(10, 2)), obs=obs)
-        if not isinstance(region, str):
-            table = model.parse(adata, region=region, region_key=region_key, instance_key="A")
-            assert region_key in table.obs
-            assert is_categorical_dtype(table.obs[region_key])
-            assert table.obs[region_key].cat.categories.tolist() == np.unique(region).tolist()
-            assert table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY] == region_key
-        else:
-            table = model.parse(adata, region=region, instance_key="A")
+        table = model.parse(adata, region=region, region_key=region_key, instance_key="A")
+        assert region_key in table.obs
+        assert is_categorical_dtype(table.obs[region_key])
+        assert table.obs[region_key].cat.categories.tolist() == np.unique(region).tolist()
+        assert table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY] == region_key
+        assert table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY] == region
         assert TableModel.ATTRS_KEY in table.uns
         assert TableModel.REGION_KEY in table.uns[TableModel.ATTRS_KEY]
         assert TableModel.REGION_KEY_KEY in table.uns[TableModel.ATTRS_KEY]
@@ -308,7 +305,7 @@ def test_get_schema():
     labels = _get_labels()
     points = _get_points()
     shapes = _get_shapes()
-    table = _get_table(region="sample1")
+    table = _get_table()
     for k, v in images.items():
         schema = get_schema(v)
         if "2d" in k:

--- a/tests/_core/test_spatialdata_operations.py
+++ b/tests/_core/test_spatialdata_operations.py
@@ -115,13 +115,13 @@ def test_concatenate_tables():
     d["region"] = sorted(d["region"])
     assert d == {
         "region": ["shapes/circles", "shapes/poly"],
-        "region_key": "region_merged",
-        "instance_key": "instance_merged",
+        "region_key": "region",
+        "instance_key": "instance_id",
     }
 
     table3 = _get_table(region="shapes/circles", region_key="annotated_shapes_other", instance_key="instance_id")
     with pytest.raises(ValueError, match="Categorical categories must be unique"):
-        _concatenate_tables([table0, table3])
+        _concatenate_tables([table0, table3], region_key="region")
 
     table4 = _get_table(
         region=["shapes/circles1", "shapes/poly1"], region_key="annotated_shape0", instance_key="instance_id"
@@ -132,8 +132,11 @@ def test_concatenate_tables():
     table6 = _get_table(
         region=["shapes/circles3", "shapes/poly3"], region_key="annotated_shape1", instance_key="instance_id"
     )
-
-    assert len(_concatenate_tables([table4, table5, table6])) == len(table4) + len(table5) + len(table6)
+    with pytest.raises(ValueError, match="`region_key` must be specified if tables have different region keys"):
+        assert len(_concatenate_tables([table4, table5, table6])) == len(table4) + len(table5) + len(table6)
+    assert len(_concatenate_tables([table4, table5, table6], region_key="region")) == len(table4) + len(table5) + len(
+        table6
+    )
 
 
 def test_concatenate_sdatas(full_sdata):

--- a/tests/_core/test_spatialdata_operations.py
+++ b/tests/_core/test_spatialdata_operations.py
@@ -120,7 +120,7 @@ def test_concatenate_tables():
     }
 
     table3 = _get_table(region="shapes/circles", region_key="annotated_shapes_other", instance_key="instance_id")
-    with pytest.raises(ValueError, match="Categorical categories must be unique"):
+    with pytest.raises(ValueError):
         _concatenate_tables([table0, table3], region_key="region")
 
     table4 = _get_table(

--- a/tests/_core/test_spatialdata_operations.py
+++ b/tests/_core/test_spatialdata_operations.py
@@ -13,7 +13,6 @@ from spatialdata._core._spatialdata_ops import (
     concatenate,
     set_transformation,
 )
-from spatialdata._core.models import TableModel
 from spatialdata._core.transformations import Identity, Scale
 from tests.conftest import _get_table
 
@@ -99,51 +98,51 @@ def test_concatenate_tables():
     """
     The concatenation uses AnnData.concatenate(), here we test the contatenation result on region, region_key, instance_key
     """
-    table0 = _get_table(region="shapes/circles", instance_key="instance_id")
-    table1 = _get_table(region="shapes/poly", instance_key="instance_id")
-    table2 = _get_table(region="shapes/poly", instance_key="instance_id")
-    assert _concatenate_tables([]) is None
-    assert len(_concatenate_tables([table0])) == len(table0)
-    assert len(_concatenate_tables([table0, table1, table2])) == len(table0) + len(table1) + len(table2)
-
-    ##
-    table0.obs["annotated_element_merged"] = np.arange(len(table0))
-    c0 = _concatenate_tables([table0, table1])
-    assert len(c0) == len(table0) + len(table1)
-
-    d = c0.uns[TableModel.ATTRS_KEY]
-    d["region"] = sorted(d["region"])
-    assert d == {
-        "region": ["shapes/circles", "shapes/poly"],
-        "region_key": "annotated_element_merged_1",
-        "instance_key": "instance_id",
-    }
-
-    ##
-    table3 = _get_table(region="shapes/circles", region_key="annotated_shapes_other", instance_key="instance_id")
-    table3.uns[TableModel.ATTRS_KEY]["region_key"] = "annotated_shapes_other"
-    with pytest.raises(AssertionError):
-        _concatenate_tables([table0, table3])
-    table3.uns[TableModel.ATTRS_KEY]["region_key"] = None
-    table3.uns[TableModel.ATTRS_KEY]["instance_key"] = ["shapes/circles", "shapes/poly"]
-    with pytest.raises(AssertionError):
-        _concatenate_tables([table0, table3])
-
-    ##
-    table4 = _get_table(
-        region=["shapes/circles", "shapes/poly"], region_key="annotated_shape0", instance_key="instance_id"
-    )
-    table5 = _get_table(
-        region=["shapes/circles", "shapes/poly"], region_key="annotated_shape0", instance_key="instance_id"
-    )
-    table6 = _get_table(
-        region=["shapes/circles", "shapes/poly"], region_key="annotated_shape1", instance_key="instance_id"
+    sdata0 = SpatialData(table=_get_table(region="shapes/circles", instance_key="instance_id"))
+    sdata1 = SpatialData(table=_get_table(region="shapes/poly", instance_key="instance_id"))
+    sdata2 = SpatialData(table=_get_table(region="shapes/poly2", instance_key="instance_id"))
+    with pytest.raises(ValueError):
+        _concatenate_tables([])
+    assert len(_concatenate_tables([sdata0])) == len(sdata0.table)
+    assert len(_concatenate_tables([sdata0, sdata1, sdata2])) == len(sdata0.table) + len(sdata1.table) + len(
+        sdata2.table
     )
 
-    assert len(_concatenate_tables([table4, table5])) == len(table4) + len(table5)
+    # sdata0.obs["annotated_element_merged"] = np.arange(len(sdata0))
+    # c0 = _concatenate_tables([sdata0, sdata1])
+    # assert len(c0) == len(sdata0) + len(sdata1)
 
-    with pytest.raises(RuntimeError):
-        _concatenate_tables([table4, table6])
+    # d = c0.uns[TableModel.ATTRS_KEY]
+    # d["region"] = sorted(d["region"])
+    # assert d == {
+    #     "region": ["shapes/circles", "shapes/poly"],
+    #     "region_key": "annotated_element_merged_1",
+    #     "instance_key": "instance_id",
+    # }
+
+    # table3 = _get_table(region="shapes/circles", region_key="annotated_shapes_other", instance_key="instance_id")
+    # table3.uns[TableModel.ATTRS_KEY]["region_key"] = "annotated_shapes_other"
+    # with pytest.raises(AssertionError):
+    #     _concatenate_tables([sdata0, table3])
+    # table3.uns[TableModel.ATTRS_KEY]["region_key"] = None
+    # table3.uns[TableModel.ATTRS_KEY]["instance_key"] = ["shapes/circles", "shapes/poly"]
+    # with pytest.raises(AssertionError):
+    #     _concatenate_tables([sdata0, table3])
+
+    # table4 = _get_table(
+    #     region=["shapes/circles", "shapes/poly"], region_key="annotated_shape0", instance_key="instance_id"
+    # )
+    # table5 = _get_table(
+    #     region=["shapes/circles", "shapes/poly"], region_key="annotated_shape0", instance_key="instance_id"
+    # )
+    # table6 = _get_table(
+    #     region=["shapes/circles", "shapes/poly"], region_key="annotated_shape1", instance_key="instance_id"
+    # )
+
+    # assert len(_concatenate_tables([table4, table5])) == len(table4) + len(table5)
+
+    # with pytest.raises(RuntimeError):
+    #     _concatenate_tables([table4, table6])
 
 
 def test_concatenate_sdatas(full_sdata):

--- a/tests/_core/test_spatialdata_operations.py
+++ b/tests/_core/test_spatialdata_operations.py
@@ -133,20 +133,20 @@ def test_concatenate_tables():
         region=["shapes/circles3", "shapes/poly3"], region_key="annotated_shape1", instance_key="instance_id"
     )
     with pytest.raises(ValueError, match="`region_key` must be specified if tables have different region keys"):
-        assert len(_concatenate_tables([table4, table5, table6])) == len(table4) + len(table5) + len(table6)
+        _concatenate_tables([table4, table5, table6])
     assert len(_concatenate_tables([table4, table5, table6], region_key="region")) == len(table4) + len(table5) + len(
         table6
     )
 
 
 def test_concatenate_sdatas(full_sdata):
-    with pytest.raises(RuntimeError):
+    with pytest.raises(KeyError):
         concatenate([full_sdata, SpatialData(images={"image2d": full_sdata.images["image2d"]})])
-    with pytest.raises(RuntimeError):
+    with pytest.raises(KeyError):
         concatenate([full_sdata, SpatialData(labels={"labels2d": full_sdata.labels["labels2d"]})])
-    with pytest.raises(RuntimeError):
+    with pytest.raises(KeyError):
         concatenate([full_sdata, SpatialData(points={"points_0": full_sdata.points["points_0"]})])
-    with pytest.raises(RuntimeError):
+    with pytest.raises(KeyError):
         concatenate([full_sdata, SpatialData(shapes={"circles": full_sdata.shapes["circles"]})])
 
     assert concatenate([full_sdata, SpatialData()]).table is not None

--- a/tests/_core/test_spatialdata_operations.py
+++ b/tests/_core/test_spatialdata_operations.py
@@ -99,9 +99,9 @@ def test_concatenate_tables():
     """
     The concatenation uses AnnData.concatenate(), here we test the contatenation result on region, region_key, instance_key
     """
-    table0 = _get_table(region="shapes/circles", region_key=None, instance_key="instance_id")
-    table1 = _get_table(region="shapes/poly", region_key=None, instance_key="instance_id")
-    table2 = _get_table(region="shapes/poly", region_key=None, instance_key="instance_id")
+    table0 = _get_table(region="shapes/circles", instance_key="instance_id")
+    table1 = _get_table(region="shapes/poly", instance_key="instance_id")
+    table2 = _get_table(region="shapes/poly", instance_key="instance_id")
     assert _concatenate_tables([]) is None
     assert len(_concatenate_tables([table0])) == len(table0)
     assert len(_concatenate_tables([table0, table1, table2])) == len(table0) + len(table1) + len(table2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,18 +90,18 @@ def full_sdata() -> SpatialData:
 #     return SpatialData(points={"empty": geo_df})
 
 
-@pytest.fixture()
-def empty_table() -> SpatialData:
-    adata = AnnData(shape=(0, 0))
-    adata = TableModel.parse(adata=adata)
-    return SpatialData(table=adata)
+# @pytest.fixture()
+# def empty_table() -> SpatialData:
+#     adata = AnnData(shape=(0, 0), obs=pd.DataFrame(columns="region"), var=pd.DataFrame())
+#     adata = TableModel.parse(adata=adata)
+#     return SpatialData(table=adata)
 
 
 @pytest.fixture(
     # params=["labels"]
     params=["full", "empty"]
     + ["images", "labels", "points", "table_single_annotation", "table_multiple_annotations"]
-    + ["empty_" + x for x in ["table"]]
+    # + ["empty_" + x for x in ["table"]] # TODO: empty table not supported yet
 )
 def sdata(request) -> SpatialData:
     if request.param == "full":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -252,23 +252,14 @@ def _get_points() -> dict[str, DaskDataFrame]:
 
 
 def _get_table(
-    region: Optional[Union[str, list[str]]],
-    region_key: Optional[str] = None,
-    instance_key: Optional[str] = None,
+    region: Union[str, list[str]] = "sample1",
+    region_key: str = "region",
+    instance_key: str = "instance_id",
 ) -> AnnData:
-    if region is not None:
-        region_key = region_key or "annotated_region"
-        instance_key = instance_key or "instance_id"
     adata = AnnData(RNG.normal(size=(100, 10)), obs=pd.DataFrame(RNG.normal(size=(100, 3)), columns=["a", "b", "c"]))
-    if instance_key is not None:
-        adata.obs[instance_key] = np.arange(adata.n_obs)
+    adata.obs[instance_key] = np.arange(adata.n_obs)
     if isinstance(region, str):
-        return TableModel.parse(adata=adata, region=region, instance_key=instance_key)
+        adata.obs[region_key] = region
     elif isinstance(region, list):
         adata.obs[region_key] = RNG.choice(region, size=adata.n_obs)
-        adata.obs[instance_key] = RNG.integers(0, 10, size=(100,))
-        return TableModel.parse(adata=adata, region=region, region_key=region_key, instance_key=instance_key)
-    elif region is None:
-        return TableModel.parse(adata=adata)
-    else:
-        raise ValueError(f"region must be a string or list of strings, not {type(region)}")
+    return TableModel.parse(adata=adata, region=region, region_key=region_key, instance_key=instance_key)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -226,6 +226,7 @@ def _get_shapes() -> dict[str, GeoDataFrame]:
     points["radius"] = np.random.normal(size=(len(points), 1))
 
     out["poly"] = ShapesModel.parse(poly)
+    out["poly"].index = ["a", "b", "c", "d", "e"]
     out["multipoly"] = ShapesModel.parse(multipoly)
     out["circles"] = ShapesModel.parse(points)
 


### PR DESCRIPTION
as discussed in #158 

- [x] introduce mandatory `region` `region_key` and `instance_key`
- [x] rewrite concatenate following implementation
- [x] support string index io for shapes
- [x] change type of radius to `Union[float, ArrayLike]`

changes
- [x] the empty table case is not supported anymore, we can revert to this behaviour later but for now don't see priority

things leaving out of this PR as discussed in #158 
-  validation of type of categorical in for instances and instances in labels (should be done in spatialdata)
reason:
- not high priority and postponing to later work to consolidate spatialdata validation (e.g. we need a way to consolidate relationships between elements).
