### PR TITLE
added filter_table param to bounding box query

### DIFF
--- a/spatialdata/_core/_spatial_query.py
+++ b/spatialdata/_core/_spatial_query.py
@@ -22,6 +22,13 @@ from spatialdata._core.core_utils import (
     get_dims,
     get_spatial_axes,
 )
+from spatialdata._core.models import (
+    Labels2DModel,
+    Labels3DModel,
+    ShapesModel,
+    TableModel,
+    get_schema,
+)
 from spatialdata._core.transformations import (
     Affine,
     BaseTransformation,
@@ -85,10 +92,10 @@ def get_bounding_box_corners(min_coordinate: ArrayLike, max_coordinate: ArrayLik
 
 def _get_bounding_box_corners_in_intrinsic_coordinates(
     element: SpatialElement,
+    axes: tuple[str, ...],
     min_coordinate: ArrayLike,
     max_coordinate: ArrayLike,
     target_coordinate_system: str,
-    axes: tuple[str, ...],
 ) -> tuple[ArrayLike, tuple[str, ...]]:
     """Get all corners of a bounding box in the intrinsic coordinates of an element.
 
@@ -96,6 +103,8 @@ def _get_bounding_box_corners_in_intrinsic_coordinates(
     ----------
     element
         The SpatialElement to get the intrinsic coordinate system from.
+    axes
+        The axes of the coordinate system the bounding box is defined in.
     min_coordinate
         The upper left hand corner of the bounding box (i.e., minimum coordinates
         along all dimensions).
@@ -104,8 +113,6 @@ def _get_bounding_box_corners_in_intrinsic_coordinates(
         along all dimensions
     target_coordinate_system
         The coordinate system the bounding box is defined in.
-    axes
-        The axes of the coordinate system the bounding box is defined in.
 
     Returns ------- All the corners of the bounding box in the intrinsic coordinate system of the element. The shape
     is (2, 4) when axes has 2 spatial dimensions, and (2, 8) when axes has 3 spatial dimensions.
@@ -143,14 +150,6 @@ class BaseSpatialRequest:
     """Base class for spatial queries."""
 
     target_coordinate_system: str
-    axes: tuple[ValidAxis_t, ...]
-
-    def __post_init__(self) -> None:
-        # validate the axes
-        spatial_axes = get_spatial_axes(self.axes)
-        non_spatial_axes = set(self.axes) - set(spatial_axes)
-        if len(non_spatial_axes) > 0:
-            raise ValueError(f"Non-spatial axes specified: {non_spatial_axes}")
 
     @abstractmethod
     def to_dict(self) -> dict[str, Any]:
@@ -175,9 +174,14 @@ class BoundingBoxRequest(BaseSpatialRequest):
 
     min_coordinate: np.ndarray  # type: ignore[type-arg]
     max_coordinate: np.ndarray  # type: ignore[type-arg]
+    axes: tuple[ValidAxis_t, ...]
 
     def __post_init__(self) -> None:
-        super().__post_init__()
+        # validate the axes
+        spatial_axes = get_spatial_axes(self.axes)
+        non_spatial_axes = set(self.axes) - set(spatial_axes)
+        if len(non_spatial_axes) > 0:
+            raise ValueError(f"Non-spatial axes specified: {non_spatial_axes}")
 
         # validate the axes
         if len(self.axes) != len(self.min_coordinate) or len(self.axes) != len(self.max_coordinate):
@@ -197,7 +201,7 @@ class BoundingBoxRequest(BaseSpatialRequest):
 
 
 def _bounding_box_mask_points(
-    points: DaskDataFrame, min_coordinate: ArrayLike, max_coordinate: ArrayLike, axes: tuple[str, ...]
+    points: DaskDataFrame, axes: tuple[str, ...], min_coordinate: ArrayLike, max_coordinate: ArrayLike
 ) -> da.Array:
     """Compute a mask that is true for the points inside of an axis-aligned bounding box..
 
@@ -205,14 +209,14 @@ def _bounding_box_mask_points(
     ----------
     points
         The points element to perform the query on.
+    axes
+        The axes for the min/max coordinates.
     min_coordinate
         The upper left hand corner of the bounding box (i.e., minimum coordinates
         along all dimensions).
     max_coordinate
         The lower right hand corner of the bounding box (i.e., the maximum coordinates
         along all dimensions
-    axes
-        The axes for the min/max coordinates.
 
     Returns
     -------
@@ -249,6 +253,7 @@ def bounding_box_query(
     min_coordinate: ArrayLike,
     max_coordinate: ArrayLike,
     target_coordinate_system: str,
+    **kwargs: Any,
 ) -> Optional[Union[SpatialElement, SpatialData]]:
     raise NotImplementedError()
 
@@ -260,6 +265,7 @@ def _(
     min_coordinate: ArrayLike,
     max_coordinate: ArrayLike,
     target_coordinate_system: str,
+    filter_table: bool = True,
 ) -> SpatialData:
     from spatialdata import SpatialData
 
@@ -275,7 +281,34 @@ def _(
             target_coordinate_system=target_coordinate_system,
         )
         new_elements[element_type] = queried_elements
-    return SpatialData(**new_elements, table=sdata.table)
+
+    if filter_table:
+        to_keep = np.array([False] * len(sdata.table))
+        region_key = sdata.table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]
+        instance_key = sdata.table.uns[TableModel.ATTRS_KEY][TableModel.INSTANCE_KEY]
+        for _, elements in new_elements.items():
+            for name, element in elements.items():
+                if get_schema(element) == Labels2DModel or get_schema(element) == Labels3DModel:
+                    if isinstance(element, SpatialImage):
+                        # get unique labels value (including 0 if present)
+                        instances = da.unique(element.data).compute()
+                    else:
+                        assert isinstance(element, MultiscaleSpatialImage)
+                        v = element["scale0"].values()
+                        assert len(v) == 1
+                        xdata = next(iter(v))
+                        instances = da.unique(xdata.data).compute()
+                elif get_schema(element) == ShapesModel:
+                    instances = element.index.to_numpy()
+                else:
+                    continue
+                indices = (sdata.table.obs[region_key] == name) & (sdata.table.obs[instance_key].isin(instances))
+                to_keep = to_keep | indices
+        table = sdata.table[to_keep, :].copy()
+        table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY] = table.obs[region_key].unique().tolist()
+    else:
+        table = sdata.table
+    return SpatialData(**new_elements, table=table)
 
 
 @bounding_box_query.register(SpatialImage)
@@ -288,23 +321,8 @@ def _(
     target_coordinate_system: str,
 ) -> Optional[Union[SpatialImage, MultiscaleSpatialImage]]:
     """
-
-    Parameters
-    ----------
-    image
-    axes
-    min_coordinate
-    max_coordinate
-    target_coordinate_system
-
-    Returns
-    -------
-
-    Notes
-    _____
     See https://github.com/scverse/spatialdata/pull/151 for a detailed overview of the logic of this code,
     and for the cases the comments refer to.
-
     """
     # for triggering validation
     _ = BoundingBoxRequest(
@@ -480,10 +498,10 @@ def _(
     # get the four corners of the bounding box (2D case), or the 8 corners of the "3D bounding box" (3D case)
     (intrinsic_bounding_box_corners, intrinsic_axes) = _get_bounding_box_corners_in_intrinsic_coordinates(
         element=points,
+        axes=axes,
         min_coordinate=min_coordinate,
         max_coordinate=max_coordinate,
         target_coordinate_system=target_coordinate_system,
-        axes=axes,
     )
     min_coordinate_intrinsic = intrinsic_bounding_box_corners.min(axis=0)
     max_coordinate_intrinsic = intrinsic_bounding_box_corners.max(axis=0)
@@ -491,9 +509,9 @@ def _(
     # get the points in the intrinsic coordinate bounding box
     in_intrinsic_bounding_box = _bounding_box_mask_points(
         points=points,
+        axes=intrinsic_axes,
         min_coordinate=min_coordinate_intrinsic,
         max_coordinate=max_coordinate_intrinsic,
-        axes=intrinsic_axes,
     )
     points_in_intrinsic_bounding_box = points.loc[in_intrinsic_bounding_box]
 
@@ -519,9 +537,9 @@ def _(
     # get a mask for the points in the bounding box
     bounding_box_mask = _bounding_box_mask_points(
         points=points_query_coordinate_system,
+        axes=axes,
         min_coordinate=min_coordinate,
         max_coordinate=max_coordinate,
-        axes=axes,
     )
     if bounding_box_mask.sum() == 0:
         return None
@@ -547,10 +565,10 @@ def _(
     # get the four corners of the bounding box
     (intrinsic_bounding_box_corners, intrinsic_axes) = _get_bounding_box_corners_in_intrinsic_coordinates(
         element=polygons,
+        axes=axes,
         min_coordinate=min_coordinate,
         max_coordinate=max_coordinate,
         target_coordinate_system=target_coordinate_system,
-        axes=axes,
     )
 
     bounding_box_non_axes_aligned = Polygon(intrinsic_bounding_box_corners)

--- a/spatialdata/_core/_spatialdata.py
+++ b/spatialdata/_core/_spatialdata.py
@@ -1133,7 +1133,7 @@ class QueryManager:
         target_coordinate_system
             The coordinate system the bounding box is defined in.
         filter_table
-            If True, the table is filtered to only contain rows that are annotating individual regions contained in the bounding box.
+            If True, the table is filtered to only contain rows that are annotating regions contained within the bounding box.
         Returns
         -------
         The SpatialData object containing the requested data.

--- a/spatialdata/_core/_spatialdata.py
+++ b/spatialdata/_core/_spatialdata.py
@@ -1150,11 +1150,12 @@ class QueryManager:
             filter_table=filter_table,
         )
 
-    def __call__(self, request: BaseSpatialRequest) -> SpatialData:
+    def __call__(self, request: BaseSpatialRequest, **kwargs) -> SpatialData:  # type: ignore[no-untyped-def]
         from spatialdata._core._spatial_query import BoundingBoxRequest
 
         if isinstance(request, BoundingBoxRequest):
-            # TODO: filter table is on by default, shall we put filter_table inside the request?
-            return self.bounding_box(**request.to_dict(), filter_table=True)
+            # TODO: request doesn't contain filter_table. If the user doesn't specify this in kwargs, it will be set
+            #  to it's default value. This could be a bit unintuitive and we may want to change make things more explicit.
+            return self.bounding_box(**request.to_dict(), **kwargs)
         else:
             raise TypeError("unknown request type")

--- a/spatialdata/_core/_spatialdata.py
+++ b/spatialdata/_core/_spatialdata.py
@@ -1118,14 +1118,22 @@ class QueryManager:
         min_coordinate: ArrayLike,
         max_coordinate: ArrayLike,
         target_coordinate_system: str,
+        filter_table: bool = True,
     ) -> SpatialData:
         """Perform a bounding box query on the SpatialData object.
 
         Parameters
         ----------
-        request
-            The bounding box request.
-
+        axes
+            The axes the bounding box is defined in.
+        min_coordinate
+            The minimum coordinates of the bounding box.
+        max_coordinate
+            The maximum coordinates of the bounding box.
+        target_coordinate_system
+            The coordinate system the bounding box is defined in.
+        filter_table
+            If True, the table is filtered to only contain rows that are annotating individual regions contained in the bounding box.
         Returns
         -------
         The SpatialData object containing the requested data.
@@ -1139,12 +1147,14 @@ class QueryManager:
             min_coordinate=min_coordinate,
             max_coordinate=max_coordinate,
             target_coordinate_system=target_coordinate_system,
+            filter_table=filter_table,
         )
 
     def __call__(self, request: BaseSpatialRequest) -> SpatialData:
         from spatialdata._core._spatial_query import BoundingBoxRequest
 
         if isinstance(request, BoundingBoxRequest):
-            return self.bounding_box(**request.to_dict())
+            # TODO: filter table is on by default, shall we put filter_table inside the request?
+            return self.bounding_box(**request.to_dict(), filter_table=True)
         else:
             raise TypeError("unknown request type")

--- a/spatialdata/_core/_spatialdata_ops.py
+++ b/spatialdata/_core/_spatialdata_ops.py
@@ -405,3 +405,11 @@ def concatenate(
         table=merged_table,
     )
     return sdata
+
+
+def _filter_table_in_coordinate_systems(table: AnnData, coordinate_systems: list[str]) -> AnnData:
+    table_mapping_metadata = table.uns[TableModel.ATTRS_KEY]
+    region_key = table_mapping_metadata[TableModel.REGION_KEY_KEY]
+    new_table = table[table.obs[region_key].isin(coordinate_systems)].copy()
+    new_table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY] = new_table.obs[region_key].unique().tolist()
+    return new_table

--- a/tests/_core/test_models.py
+++ b/tests/_core/test_models.py
@@ -52,10 +52,8 @@ from tests.conftest import (
 
 RNG = default_rng()
 
-# should be set to False for pre-commit and CI; useful to set to True for are fixing/debugging tests
-SHORT_TESTS = True
 
-
+@pytest.mark.ci_only
 class TestModels:
     def _parse_transformation_from_multiple_places(self, model: Any, element: Any, **kwargs) -> None:
         # This function seems convoluted but the idea is simple: sometimes the parser creates a whole new object,
@@ -64,8 +62,6 @@ class TestModels:
         # passing it also explicitly in the parser.
         # This function does that for all the models (it's called by the various tests of the models) and it first
         # creates clean copies of the element, and then puts the transformation inside it with various methods
-        if SHORT_TESTS:
-            return
         if any([isinstance(element, t) for t in (SpatialImage, DataArray, AnnData, GeoDataFrame, DaskDataFrame)]):
             element_erased = deepcopy(element)
             # we are not respecting the function signature (the transform should be not None); it's fine for testing
@@ -118,8 +114,6 @@ class TestModels:
             raise ValueError(f"Unknown type {type(element)}")
 
     def _passes_validation_after_io(self, model: Any, element: Any, element_type: str) -> None:
-        if SHORT_TESTS:
-            return
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "test.zarr")
             d = {"element": element}

--- a/tests/_core/test_models.py
+++ b/tests/_core/test_models.py
@@ -53,7 +53,7 @@ from tests.conftest import (
 RNG = default_rng()
 
 # should be set to False for pre-commit and CI; useful to set to True for are fixing/debugging tests
-SHORT_TESTS = False
+SHORT_TESTS = True
 
 
 class TestModels:

--- a/tests/_core/test_spatial_query.py
+++ b/tests/_core/test_spatial_query.py
@@ -341,7 +341,7 @@ def test_bounding_box_spatial_data(full_sdata):
     )
     result = bounding_box_query(full_sdata, **request.to_dict(), filter_table=True)
     # filter table is True by default when calling query(request)
-    result2 = full_sdata.query(request)
+    result2 = full_sdata.query(request, filter_table=True)
     from tests._core.test_spatialdata_operations import (
         _assert_spatialdata_objects_seem_identical,
     )

--- a/tests/_core/test_spatial_query.py
+++ b/tests/_core/test_spatial_query.py
@@ -4,6 +4,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pytest
+from anndata import AnnData
 from multiscale_spatial_image import MultiscaleSpatialImage
 from shapely import linearrings, polygons
 from spatial_image import SpatialImage
@@ -15,6 +16,8 @@ from spatialdata import (
     Labels3DModel,
     PointsModel,
     ShapesModel,
+    SpatialData,
+    TableModel,
 )
 from spatialdata._core._spatial_query import (
     BaseSpatialRequest,
@@ -336,7 +339,8 @@ def test_bounding_box_spatial_data(full_sdata):
         min_coordinate=np.array([2, 1]),
         max_coordinate=np.array([40, 60]),
     )
-    result = bounding_box_query(full_sdata, **request.to_dict())
+    result = bounding_box_query(full_sdata, **request.to_dict(), filter_table=True)
+    # filter table is True by default when calling query(request)
     result2 = full_sdata.query(request)
     from tests._core.test_spatialdata_operations import (
         _assert_spatialdata_objects_seem_identical,
@@ -348,3 +352,33 @@ def test_bounding_box_spatial_data(full_sdata):
         d = get_transformation(element, get_all=True)
         new_d = {k.replace("global", "cropped"): v for k, v in d.items()}
         set_transformation(element, new_d, set_all=True)
+
+
+def test_bounding_box_filter_table():
+    ##
+    coords0 = np.array([[10, 10], [20, 20]])
+    coords1 = np.array([[30, 30]])
+    circles0 = ShapesModel.parse(coords0, geometry=0, radius=1)
+    circles1 = ShapesModel.parse(coords1, geometry=0, radius=1)
+    table = AnnData(shape=(3, 0))
+    table.obs["region"] = ["circles0", "circles0", "circles1"]
+    table.obs["instance"] = [0, 1, 0]
+    table = TableModel.parse(table, region=["circles0", "circles1"], region_key="region", instance_key="instance")
+    sdata = SpatialData(shapes={"circles0": circles0, "circles1": circles1}, table=table)
+    queried0 = sdata.query.bounding_box(
+        axes=("y", "x"),
+        min_coordinate=np.array([15, 15]),
+        max_coordinate=np.array([25, 25]),
+        filter_table=True,
+        target_coordinate_system="global",
+    )
+    queried1 = sdata.query.bounding_box(
+        axes=("y", "x"),
+        min_coordinate=np.array([15, 15]),
+        max_coordinate=np.array([25, 25]),
+        filter_table=False,
+        target_coordinate_system="global",
+    )
+    assert len(queried0.table) == 1
+    assert len(queried1.table) == 3
+    ##

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import tempfile
 
 import dask.dataframe as dd
 import dask_image.ndinterp
+import pytest
 import xarray
 import xarray.testing
 from multiscale_spatial_image import MultiscaleSpatialImage
@@ -38,6 +39,7 @@ def _pad_raster(data: DataArray, axes: tuple[str, ...]) -> DataArray:
     return transformed
 
 
+@pytest.mark.ci_only
 def test_unpad_raster(images, labels) -> None:
     for raster in itertools.chain(images.images.values(), labels.labels.values()):
         schema = get_schema(raster)


### PR DESCRIPTION
Small PR closing https://github.com/scverse/spatialdata/issues/167 as asked by @EliHei2:

when performing a bounding box query on a spatialdata object, it is now possible to filter the table to contain only the rows that are annotating any of the elements in the resulting queried object.