### PR TITLE
Fix/unique names

### DIFF
--- a/spatialdata/_core/_spatialdata.py
+++ b/spatialdata/_core/_spatialdata.py
@@ -375,7 +375,7 @@ class SpatialData:
                     if element_type not in elements:
                         elements[element_type] = {}
                     elements[element_type][element_name] = element
-                    element_paths_in_coordinate_system.append(f"{element_type}/{element_name}")
+                    element_paths_in_coordinate_system.append(element_name)
 
         if filter_table:
             table_mapping_metadata = self.table.uns[TableModel.ATTRS_KEY]

--- a/spatialdata/_core/_spatialdata.py
+++ b/spatialdata/_core/_spatialdata.py
@@ -1136,7 +1136,7 @@ class SpatialData:
                         for element_name in element_names
                     ]
                 )
-                descr += f", with elements: {elements}\n"
+                descr += f", with elements:\n        {elements}"
             if i < len(coordinate_systems) - 1:
                 descr += "\n"
         return descr

--- a/spatialdata/utils.py
+++ b/spatialdata/utils.py
@@ -243,3 +243,17 @@ def iterate_pyramid_levels(image: MultiscaleSpatialImage) -> Generator[DataArray
         assert len(v) == 1
         xdata = next(iter(v))
         yield xdata
+
+
+def atoi(text: str) -> Union[int, str]:
+    return int(text) if text.isdigit() else text
+
+
+# from https://stackoverflow.com/a/5967539/3343783
+def natural_keys(text: str) -> list[Union[int, str]]:
+    """
+    alist.sort(key=natural_keys) sorts in human order
+    http://nedbatchelder.com/blog/200712/human_sorting.html
+    (See Toothy's implementation in the comments)
+    """
+    return [atoi(c) for c in re.split(r"(\d+)", text)]

--- a/tests/_core/test_spatialdata_operations.py
+++ b/tests/_core/test_spatialdata_operations.py
@@ -106,14 +106,12 @@ def test_filter_by_coordinate_system(full_sdata):
 def test_filter_by_coordinate_system_also_table(full_sdata):
     from spatialdata._core.models import TableModel
 
-    full_sdata.table.obs["annotated_shapes"] = np.random.choice(
-        ["shapes/circles", "shapes/poly"], size=full_sdata.table.shape[0]
-    )
+    full_sdata.table.obs["annotated_shapes"] = np.random.choice(["circles", "poly"], size=full_sdata.table.shape[0])
     adata = full_sdata.table
     del adata.uns[TableModel.ATTRS_KEY]
     del full_sdata.table
     full_sdata.table = TableModel.parse(
-        adata, region=["shapes/circles", "shapes/poly"], region_key="annotated_shapes", instance_key="instance_id"
+        adata, region=["circles", "poly"], region_key="annotated_shapes", instance_key="instance_id"
     )
 
     scale = Scale([2.0], axes=("x",))

--- a/tests/_core/test_spatialdata_operations.py
+++ b/tests/_core/test_spatialdata_operations.py
@@ -13,9 +13,42 @@ from spatialdata._core._spatialdata_ops import (
     concatenate,
     set_transformation,
 )
-from spatialdata._core.models import TableModel
+from spatialdata._core.models import (
+    Image2DModel,
+    Labels2DModel,
+    PointsModel,
+    ShapesModel,
+    TableModel,
+)
 from spatialdata._core.transformations import Identity, Scale
 from tests.conftest import _get_table
+
+
+def test_element_names_unique():
+    shapes = ShapesModel.parse(np.array([[0, 0]]), geometry=0, radius=1)
+    points = PointsModel.parse(np.array([[0, 0]]))
+    labels = Labels2DModel.parse(np.array([[0, 0], [0, 0]]), dims=["y", "x"])
+    image = Image2DModel.parse(np.array([[[0, 0], [0, 0]]]), dims=["c", "y", "x"])
+
+    with pytest.raises(ValueError):
+        SpatialData(images={"image": image}, points={"image": points})
+    with pytest.raises(ValueError):
+        SpatialData(images={"image": image}, shapes={"image": shapes})
+    with pytest.raises(ValueError):
+        SpatialData(images={"image": image}, labels={"image": labels})
+
+    sdata = SpatialData(
+        images={"image": image}, points={"points": points}, shapes={"shapes": shapes}, labels={"labels": labels}
+    )
+
+    with pytest.raises(ValueError):
+        sdata.add_image(name="points", image=image)
+    with pytest.raises(ValueError):
+        sdata.add_points(name="image", points=points)
+    with pytest.raises(ValueError):
+        sdata.add_shapes(name="image", shapes=shapes)
+    with pytest.raises(ValueError):
+        sdata.add_labels(name="image", labels=labels)
 
 
 def _assert_elements_left_to_right_seem_identical(sdata0: SpatialData, sdata1: SpatialData):

--- a/tests/_io/test_readwrite.py
+++ b/tests/_io/test_readwrite.py
@@ -168,7 +168,7 @@ class TestReadWrite:
             s3 = SpatialData.read(f2)
             assert len(s3.table) == len(s2.table)
 
-    def test_io_and_lazy_loading_points(points):
+    def test_io_and_lazy_loading_points(self, points):
         elem_name = list(points.points.keys())[0]
         with tempfile.TemporaryDirectory() as td:
             f = os.path.join(td, "data.zarr")
@@ -178,7 +178,7 @@ class TestReadWrite:
             assert all("read-parquet" not in key for key in dask0.dask.layers)
             assert any("read-parquet" in key for key in dask1.dask.layers)
 
-    def test_io_and_lazy_loading_raster(images, labels):
+    def test_io_and_lazy_loading_raster(self, images, labels):
         # addresses bug https://github.com/scverse/spatialdata/issues/117
         sdatas = {"images": images, "labels": labels}
         for k, sdata in sdatas.items():
@@ -192,7 +192,7 @@ class TestReadWrite:
                 assert all("from-zarr" not in key for key in dask0.dask.layers)
                 assert any("from-zarr" in key for key in dask1.dask.layers)
 
-    def test_replace_transformation_on_disk_raster(images, labels):
+    def test_replace_transformation_on_disk_raster(self, images, labels):
         sdatas = {"images": images, "labels": labels}
         for k, sdata in sdatas.items():
             d = sdata.__getattribute__(k)
@@ -214,7 +214,7 @@ class TestReadWrite:
                     t1 = get_transformation(SpatialData.read(f).__getattribute__(k)[elem_name])
                     assert type(t1) == Scale
 
-    def test_replace_transformation_on_disk_non_raster(shapes, points):
+    def test_replace_transformation_on_disk_non_raster(self, shapes, points):
         sdatas = {"shapes": shapes, "points": points}
         for k, sdata in sdatas.items():
             d = sdata.__getattribute__(k)
@@ -230,7 +230,7 @@ class TestReadWrite:
                 t1 = get_transformation(SpatialData.read(f).__getattribute__(k)[elem_name])
                 assert type(t1) == Scale
 
-    def test_overwrite_files_with_backed_data(full_sdata):
+    def test_overwrite_files_with_backed_data(self, full_sdata):
         # addressing https://github.com/scverse/spatialdata/issues/137
         with tempfile.TemporaryDirectory() as tmpdir:
             f = os.path.join(tmpdir, "data.zarr")
@@ -254,7 +254,7 @@ class TestReadWrite:
         #     )
         #     sdata2.write(f, overwrite=True)
 
-    def test_overwrite_onto_non_zarr_file(full_sdata):
+    def test_overwrite_onto_non_zarr_file(self, full_sdata):
         with tempfile.TemporaryDirectory() as tmpdir:
             f0 = os.path.join(tmpdir, "test.txt")
             with open(f0, "w"):
@@ -267,7 +267,7 @@ class TestReadWrite:
             with pytest.raises(ValueError):
                 full_sdata.write(f1)
 
-    def test_incremental_io_with_backed_elements(full_sdata):
+    def test_incremental_io_with_backed_elements(self, full_sdata):
         # addressing https://github.com/scverse/spatialdata/issues/137
         # we test also the non-backed case so that if we switch to the backed version in the future we already have the tests
 

--- a/tests/_io/test_readwrite.py
+++ b/tests/_io/test_readwrite.py
@@ -168,145 +168,142 @@ class TestReadWrite:
             s3 = SpatialData.read(f2)
             assert len(s3.table) == len(s2.table)
 
-
-def test_io_and_lazy_loading_points(points):
-    elem_name = list(points.points.keys())[0]
-    with tempfile.TemporaryDirectory() as td:
-        f = os.path.join(td, "data.zarr")
-        dask0 = points.points[elem_name]
-        points.write(f)
-        dask1 = points.points[elem_name]
-        assert all("read-parquet" not in key for key in dask0.dask.layers)
-        assert any("read-parquet" in key for key in dask1.dask.layers)
-
-
-def test_io_and_lazy_loading_raster(images, labels):
-    # addresses bug https://github.com/scverse/spatialdata/issues/117
-    sdatas = {"images": images, "labels": labels}
-    for k, sdata in sdatas.items():
-        d = sdata.__getattribute__(k)
-        elem_name = list(d.keys())[0]
+    def test_io_and_lazy_loading_points(points):
+        elem_name = list(points.points.keys())[0]
         with tempfile.TemporaryDirectory() as td:
             f = os.path.join(td, "data.zarr")
-            dask0 = d[elem_name].data
-            sdata.write(f)
-            dask1 = d[elem_name].data
-            assert all("from-zarr" not in key for key in dask0.dask.layers)
-            assert any("from-zarr" in key for key in dask1.dask.layers)
+            dask0 = points.points[elem_name]
+            points.write(f)
+            dask1 = points.points[elem_name]
+            assert all("read-parquet" not in key for key in dask0.dask.layers)
+            assert any("read-parquet" in key for key in dask1.dask.layers)
 
-
-def test_replace_transformation_on_disk_raster(images, labels):
-    sdatas = {"images": images, "labels": labels}
-    for k, sdata in sdatas.items():
-        d = sdata.__getattribute__(k)
-        # unlike the non-raster case we are testing all the elements (2d and 3d, multiscale and not)
-        # TODO: we can actually later on merge this test and the one below keepin the logic of this function here
-        for elem_name in d.keys():
-            kwargs = {k: {elem_name: d[elem_name]}}
-            single_sdata = SpatialData(**kwargs)
+    def test_io_and_lazy_loading_raster(images, labels):
+        # addresses bug https://github.com/scverse/spatialdata/issues/117
+        sdatas = {"images": images, "labels": labels}
+        for k, sdata in sdatas.items():
+            d = sdata.__getattribute__(k)
+            elem_name = list(d.keys())[0]
             with tempfile.TemporaryDirectory() as td:
                 f = os.path.join(td, "data.zarr")
-                single_sdata.write(f)
+                dask0 = d[elem_name].data
+                sdata.write(f)
+                dask1 = d[elem_name].data
+                assert all("from-zarr" not in key for key in dask0.dask.layers)
+                assert any("from-zarr" in key for key in dask1.dask.layers)
+
+    def test_replace_transformation_on_disk_raster(images, labels):
+        sdatas = {"images": images, "labels": labels}
+        for k, sdata in sdatas.items():
+            d = sdata.__getattribute__(k)
+            # unlike the non-raster case we are testing all the elements (2d and 3d, multiscale and not)
+            # TODO: we can actually later on merge this test and the one below keepin the logic of this function here
+            for elem_name in d.keys():
+                kwargs = {k: {elem_name: d[elem_name]}}
+                single_sdata = SpatialData(**kwargs)
+                with tempfile.TemporaryDirectory() as td:
+                    f = os.path.join(td, "data.zarr")
+                    single_sdata.write(f)
+                    t0 = get_transformation(SpatialData.read(f).__getattribute__(k)[elem_name])
+                    assert type(t0) == Identity
+                    set_transformation(
+                        single_sdata.__getattribute__(k)[elem_name],
+                        Scale([2.0], axes=("x",)),
+                        write_to_sdata=single_sdata,
+                    )
+                    t1 = get_transformation(SpatialData.read(f).__getattribute__(k)[elem_name])
+                    assert type(t1) == Scale
+
+    def test_replace_transformation_on_disk_non_raster(shapes, points):
+        sdatas = {"shapes": shapes, "points": points}
+        for k, sdata in sdatas.items():
+            d = sdata.__getattribute__(k)
+            elem_name = list(d.keys())[0]
+            with tempfile.TemporaryDirectory() as td:
+                f = os.path.join(td, "data.zarr")
+                sdata.write(f)
                 t0 = get_transformation(SpatialData.read(f).__getattribute__(k)[elem_name])
                 assert type(t0) == Identity
                 set_transformation(
-                    single_sdata.__getattribute__(k)[elem_name], Scale([2.0], axes=("x",)), write_to_sdata=single_sdata
+                    sdata.__getattribute__(k)[elem_name], Scale([2.0], axes=("x",)), write_to_sdata=sdata
                 )
                 t1 = get_transformation(SpatialData.read(f).__getattribute__(k)[elem_name])
                 assert type(t1) == Scale
 
-
-def test_replace_transformation_on_disk_non_raster(shapes, points):
-    sdatas = {"shapes": shapes, "points": points}
-    for k, sdata in sdatas.items():
-        d = sdata.__getattribute__(k)
-        elem_name = list(d.keys())[0]
-        with tempfile.TemporaryDirectory() as td:
-            f = os.path.join(td, "data.zarr")
-            sdata.write(f)
-            t0 = get_transformation(SpatialData.read(f).__getattribute__(k)[elem_name])
-            assert type(t0) == Identity
-            set_transformation(sdata.__getattribute__(k)[elem_name], Scale([2.0], axes=("x",)), write_to_sdata=sdata)
-            t1 = get_transformation(SpatialData.read(f).__getattribute__(k)[elem_name])
-            assert type(t1) == Scale
-
-
-def test_overwrite_files_with_backed_data(full_sdata):
-    # addressing https://github.com/scverse/spatialdata/issues/137
-    with tempfile.TemporaryDirectory() as tmpdir:
-        f = os.path.join(tmpdir, "data.zarr")
-        full_sdata.write(f)
-        with pytest.raises(ValueError):
-            full_sdata.write(f, overwrite=True)
-
-    # support for overwriting backed sdata has been temporarily removed
-    # with tempfile.TemporaryDirectory() as tmpdir:
-    #     f = os.path.join(tmpdir, "data.zarr")
-    #     full_sdata.write(f)
-    #     full_sdata.write(f, overwrite=True)
-    #     print(full_sdata)
-    #
-    #     sdata2 = SpatialData(
-    #         images=full_sdata.images,
-    #         labels=full_sdata.labels,
-    #         points=full_sdata.points,
-    #         shapes=full_sdata.shapes,
-    #         table=full_sdata.table,
-    #     )
-    #     sdata2.write(f, overwrite=True)
-
-
-def test_overwrite_onto_non_zarr_file(full_sdata):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        f0 = os.path.join(tmpdir, "test.txt")
-        with open(f0, "w"):
+    def test_overwrite_files_with_backed_data(full_sdata):
+        # addressing https://github.com/scverse/spatialdata/issues/137
+        with tempfile.TemporaryDirectory() as tmpdir:
+            f = os.path.join(tmpdir, "data.zarr")
+            full_sdata.write(f)
             with pytest.raises(ValueError):
-                full_sdata.write(f0)
+                full_sdata.write(f, overwrite=True)
+
+        # support for overwriting backed sdata has been temporarily removed
+        # with tempfile.TemporaryDirectory() as tmpdir:
+        #     f = os.path.join(tmpdir, "data.zarr")
+        #     full_sdata.write(f)
+        #     full_sdata.write(f, overwrite=True)
+        #     print(full_sdata)
+        #
+        #     sdata2 = SpatialData(
+        #         images=full_sdata.images,
+        #         labels=full_sdata.labels,
+        #         points=full_sdata.points,
+        #         shapes=full_sdata.shapes,
+        #         table=full_sdata.table,
+        #     )
+        #     sdata2.write(f, overwrite=True)
+
+    def test_overwrite_onto_non_zarr_file(full_sdata):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            f0 = os.path.join(tmpdir, "test.txt")
+            with open(f0, "w"):
+                with pytest.raises(ValueError):
+                    full_sdata.write(f0)
+                with pytest.raises(ValueError):
+                    full_sdata.write(f0, overwrite=True)
+            f1 = os.path.join(tmpdir, "test.zarr")
+            os.mkdir(f1)
             with pytest.raises(ValueError):
-                full_sdata.write(f0, overwrite=True)
-        f1 = os.path.join(tmpdir, "test.zarr")
-        os.mkdir(f1)
-        with pytest.raises(ValueError):
-            full_sdata.write(f1)
+                full_sdata.write(f1)
 
+    def test_incremental_io_with_backed_elements(full_sdata):
+        # addressing https://github.com/scverse/spatialdata/issues/137
+        # we test also the non-backed case so that if we switch to the backed version in the future we already have the tests
 
-def test_incremental_io_with_backed_elements(full_sdata):
-    # addressing https://github.com/scverse/spatialdata/issues/137
-    # we test also the non-backed case so that if we switch to the backed version in the future we already have the tests
+        with tempfile.TemporaryDirectory() as tmpdir:
+            f = os.path.join(tmpdir, "data.zarr")
+            full_sdata.write(f)
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        f = os.path.join(tmpdir, "data.zarr")
-        full_sdata.write(f)
+            e = full_sdata.images.values().__iter__().__next__()
+            full_sdata.add_image("new_images", e, overwrite=True)
+            # support for overwriting backed images has been temporarily removed
+            with pytest.raises(ValueError):
+                full_sdata.add_image("new_images", full_sdata.images["new_images"], overwrite=True)
 
-        e = full_sdata.images.values().__iter__().__next__()
-        full_sdata.add_image("new_images", e, overwrite=True)
-        # support for overwriting backed images has been temporarily removed
-        with pytest.raises(ValueError):
-            full_sdata.add_image("new_images", full_sdata.images["new_images"], overwrite=True)
+            e = full_sdata.labels.values().__iter__().__next__()
+            full_sdata.add_labels("new_labels", e, overwrite=True)
+            # support for overwriting backed labels has been temporarily removed
+            with pytest.raises(ValueError):
+                full_sdata.add_labels("new_labels", full_sdata.labels["new_labels"], overwrite=True)
 
-        e = full_sdata.labels.values().__iter__().__next__()
-        full_sdata.add_labels("new_labels", e, overwrite=True)
-        # support for overwriting backed labels has been temporarily removed
-        with pytest.raises(ValueError):
-            full_sdata.add_labels("new_labels", full_sdata.labels["new_labels"], overwrite=True)
+            e = full_sdata.points.values().__iter__().__next__()
+            full_sdata.add_points("new_points", e, overwrite=True)
+            # support for overwriting backed points has been temporarily removed
+            with pytest.raises(ValueError):
+                full_sdata.add_points("new_points", full_sdata.points["new_points"], overwrite=True)
 
-        e = full_sdata.points.values().__iter__().__next__()
-        full_sdata.add_points("new_points", e, overwrite=True)
-        # support for overwriting backed points has been temporarily removed
-        with pytest.raises(ValueError):
-            full_sdata.add_points("new_points", full_sdata.points["new_points"], overwrite=True)
+            e = full_sdata.shapes.values().__iter__().__next__()
+            full_sdata.add_shapes("new_shapes", e, overwrite=True)
+            full_sdata.add_shapes("new_shapes", full_sdata.shapes["new_shapes"], overwrite=True)
 
-        e = full_sdata.shapes.values().__iter__().__next__()
-        full_sdata.add_shapes("new_shapes", e, overwrite=True)
-        full_sdata.add_shapes("new_shapes", full_sdata.shapes["new_shapes"], overwrite=True)
+            print(full_sdata)
 
-        print(full_sdata)
+            f2 = os.path.join(tmpdir, "data2.zarr")
+            sdata2 = SpatialData(table=full_sdata.table.copy())
+            sdata2.write(f2)
+            del full_sdata.table
+            full_sdata.table = sdata2.table
+            full_sdata.write(f2, overwrite=True)
 
-        f2 = os.path.join(tmpdir, "data2.zarr")
-        sdata2 = SpatialData(table=full_sdata.table.copy())
-        sdata2.write(f2)
-        del full_sdata.table
-        full_sdata.table = sdata2.table
-        full_sdata.write(f2, overwrite=True)
-
-        print(full_sdata)
+            print(full_sdata)


### PR DESCRIPTION
Content of this PR: the latest table PR from @giovp assumes unique names. Now I am:
- [x] adding checks when constructing a sdata object, or adding elements to an object, that this is the case
- [x] removing things like `/images/my_image` from various places. In particular:
    - [x] from `__repr__()`
    - [x] in `filter_by_coordinate_system()`

Minor additional things:
- [x] when printing a `sdata` object I use natural ordering instead of normal sorting. In this way `image1` comes before `image10`.
- [x] moved tests for io inside the test class. I haven't modified the tests, I have just added an indent.