### PR TITLE
revert omero

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,26 +26,6 @@ repos:
           - id: mypy
             additional_dependencies: [numpy, types-requests]
             exclude: tests/|docs/|temp/
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.4.0
-      hooks:
-          - id: detect-private-key
-          - id: check-ast
-          - id: end-of-file-fixer
-          - id: mixed-line-ending
-            args: [--fix=lf]
-          - id: trailing-whitespace
-          - id: check-case-conflict
-          - id: check-docstring-first
-    - repo: https://github.com/pre-commit/pygrep-hooks
-      rev: v1.10.0
-      hooks:
-          - id: python-no-eval
-          - id: python-use-type-annotations
-          - id: python-check-blanket-noqa
-          - id: rst-backticks
-          - id: rst-directive-colons
-          - id: rst-inline-touching-normal
     - repo: https://github.com/charliermarsh/ruff-pre-commit
       rev: v0.0.250
       hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ select = [
     "BLE", # flake8-blind-except
     "T20",  # flake8-print
     "RET", # flake8-raise
+    "PGH", # pygrep-hooks
 ]
 unfixable = ["B", "UP", "C4", "BLE", "T20", "RET"]
 target-version = "py39"

--- a/src/spatialdata/_io/format.py
+++ b/src/spatialdata/_io/format.py
@@ -73,7 +73,9 @@ class RasterFormatV01(SpatialDataFormatV01):
             assert np.all([j0 == j1 for j0, j1 in zip(json0, json1)])
 
     def channels_to_metadata(
-        self, data: Union[SpatialImage, MultiscaleSpatialImage], channels_metadata: Optional[dict[str, Any]] = None
+        self,
+        data: Union[SpatialImage, MultiscaleSpatialImage],
+        channels_metadata: Optional[dict[str, Any]] = None,
     ) -> dict[str, Union[int, str]]:
         """Convert channels to omero metadata."""
         channels = get_channels(data)

--- a/src/spatialdata/models/_utils.py
+++ b/src/spatialdata/models/_utils.py
@@ -136,7 +136,7 @@ def _(e: SpatialImage) -> tuple[str, ...]:
     # if dims != dims_sizes:
     #     raise ValueError(f"SpatialImage has inconsistent dimensions: {dims}, {dims_sizes}")
     _validate_dims(dims)
-    return dims  # type: ignore
+    return dims  # type: ignore[no-any-return]
 
 
 @get_axis_names.register(MultiscaleSpatialImage)


### PR DESCRIPTION
unfortunately, it looks like omero rewrites the name metadata if present: https://github.com/ome/ome-zarr-py/pull/261

this would require significant rewrite of IO from our side which I wouldn't do now, so using `channel_metadata` for noe.