### PR TITLE
fix docs banner background

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,3 @@
-<img src="static/img/spatialdata_horizontal.png" alt="spatialdata banner">
-
-```{eval-rst}
-.. image:: _static/img/spatialdata_horizontal.png
-  :width: 400
-  :alt: Alternative text
-```
-
 # SpatialData: an open and universal framework for processing spatial omics data.
 
 ```{eval-rst}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,21 +1,22 @@
 ```{eval-rst}
 .. image:: _static/img/spatialdata_horizontal.png
+  :width: 600
   :class: dark-light p-2
   :alt: SpatialData banner
 ```
 
-# SpatialData: an open and universal framework for processing spatial omics data.
-
-```{eval-rst}
-.. note::
-   This library is currently under active development. We may make changes to the API between versions as the community provides feedback. To ensure reproducibility, please make note of the version you are developing against.
-```
+# An open and universal framework for processing spatial omics data.
 
 SpatialData is a data framework that comprises a FAIR storage format and a collection of python libraries for performant access, alignment, and processing of uni- and multi-modal spatial omics datasets. This page provides documentation on how to install, use, and extend the core `spatialdata` library. See the links below to learn more about other packages in the SpatialData ecosystem.
 
 -   [spatialdata-io][]: load data from common spatial omics technologies into `spatialdata`.
 -   [spatialdata-plot][]: Static plotting library for `spatialdata`.
 -   [napari-spatialdata][]: napari plugin for interactive exploration and annotation of `spatialdata`.
+
+```{eval-rst}
+.. note::
+   This library is currently under active development. We may make changes to the API between versions as the community provides feedback. To ensure reproducibility, please make note of the version you are developing against.
+```
 
 ```{eval-rst}
 .. card:: Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,8 @@
-![SpatialData banner](_static/img/spatialdata_horizontal.png)
+```{eval-rst}
+.. image:: _static/img/spatialdata_horizontal.png
+  :width: 400
+  :alt: Alternative text
+```
 
 # SpatialData: an open and universal framework for processing spatial omics data.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,9 @@
+```{eval-rst}
+.. image:: _static/img/spatialdata_horizontal.png
+  :class: dark-light p-2
+  :alt: SpatialData banner
+```
+
 # SpatialData: an open and universal framework for processing spatial omics data.
 
 ```{eval-rst}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,5 @@
+<img src="static/img/spatialdata_horizontal.png" alt="spatialdata banner">
+
 ```{eval-rst}
 .. image:: _static/img/spatialdata_horizontal.png
   :width: 400

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,5 @@
 ```{eval-rst}
 .. image:: _static/img/spatialdata_horizontal.png
-  :width: 600
   :class: dark-light p-2
   :alt: SpatialData banner
 ```


### PR DESCRIPTION
~~for some reason the transparency in dark mode isn't working properly , so I am reverting the banner.~~

it looks like sphinx pydata theme applies a filter: https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/light-dark.html#images-and-content-that-work-in-both-themes

using the `light-dark` class should prevent this.