### PR TITLE
Support for consolidated remote zarr

### DIFF
--- a/src/spatialdata/_io/io_zarr.py
+++ b/src/spatialdata/_io/io_zarr.py
@@ -1,6 +1,5 @@
 import logging
 from pathlib import Path
-from urlpath import URL
 from typing import Optional, Union
 
 import numpy as np
@@ -13,16 +12,12 @@ from spatialdata._io._utils import ome_zarr_logger
 from spatialdata._io.io_points import _read_points
 from spatialdata._io.io_raster import _read_multiscale
 from spatialdata._io.io_shapes import _read_shapes
-from spatialdata.models import TableModel
-
 from spatialdata._logging import logger
+from spatialdata.models import TableModel
 
 
 def read_zarr(store: Union[str, Path, zarr.Group]) -> SpatialData:
-    if isinstance(store, zarr.Group):
-        f = store
-    else:
-        f = zarr.open(store, mode="r")
+    f = store if isinstance(store, zarr.Group) else zarr.open(store, mode="r")
 
     images = {}
     labels = {}
@@ -31,7 +26,7 @@ def read_zarr(store: Union[str, Path, zarr.Group]) -> SpatialData:
     shapes = {}
 
     # read multiscale images
-    if 'images' in f:
+    if "images" in f:
         images_store = f["images"]
         count = 0
         for k in images_store:
@@ -41,14 +36,13 @@ def read_zarr(store: Union[str, Path, zarr.Group]) -> SpatialData:
             f_elem_store = Path(images_store._store.path) / f_elem.path
             logger.debug(f"Store path for multiscale {f_elem}")
             element = _read_multiscale(f_elem_store, raster_type="image")
-            print(element)
             images[k] = element
             count += 1
         logger.debug(f"Found {count} images in {f}")
 
     # read multiscale labels
     with ome_zarr_logger(logging.ERROR):
-        if 'labels' in f:
+        if "labels" in f:
             labels_store = f["labels"]
             for k in labels_store:
                 if Path(k).name.startswith("."):
@@ -59,7 +53,7 @@ def read_zarr(store: Union[str, Path, zarr.Group]) -> SpatialData:
                 labels[k] = _read_multiscale(f_elem_store, raster_type="labels")
 
     # now read rest of the data
-    if 'points' in f:
+    if "points" in f:
         points_store = f["points"]
         for k in points_store:
             f_elem = points_store[k]
@@ -69,7 +63,7 @@ def read_zarr(store: Union[str, Path, zarr.Group]) -> SpatialData:
             logger.debug(f"Store path for points {f_elem_store}")
             points[k] = _read_points(f_elem_store)
 
-    if 'shapes' in f:
+    if "shapes" in f:
         shapes_store = f["shapes"]
         for k in shapes_store:
             if Path(k).name.startswith("."):
@@ -78,7 +72,7 @@ def read_zarr(store: Union[str, Path, zarr.Group]) -> SpatialData:
             f_elem_store = Path(shapes_store._store.path) / f_elem.path
             shapes[k] = _read_shapes(f_elem_store)
 
-    if 'table' in f:
+    if "table" in f:
         table_store = f["table"]
         for k in table_store:
             if Path(k).name.startswith("."):

--- a/src/spatialdata/_io/io_zarr.py
+++ b/src/spatialdata/_io/io_zarr.py
@@ -33,19 +33,26 @@ def read_zarr(store: Union[str, Path, zarr.Group]) -> SpatialData:
     # read multiscale images
     if 'images' in f:
         images_store = f["images"]
+        count = 0
         for k in images_store:
+            if Path(k).name.startswith("."):
+                continue
             f_elem = images_store[k]
             f_elem_store = Path(images_store._store.path) / f_elem.path
             logger.debug(f"Store path for multiscale {f_elem}")
             element = _read_multiscale(f_elem_store, raster_type="image")
             print(element)
             images[k] = element
+            count += 1
+        logger.debug(f"Found {count} images in {f}")
 
     # read multiscale labels
     with ome_zarr_logger(logging.ERROR):
         if 'labels' in f:
             labels_store = f["labels"]
             for k in labels_store:
+                if Path(k).name.startswith("."):
+                    continue
                 f_elem = labels_store[k]
                 f_elem_store = Path(labels_store._store.path) / f_elem.path
                 logger.debug(f"Store path for multiscale {f_elem}")
@@ -56,6 +63,8 @@ def read_zarr(store: Union[str, Path, zarr.Group]) -> SpatialData:
         points_store = f["points"]
         for k in points_store:
             f_elem = points_store[k]
+            if Path(k).name.startswith("."):
+                continue
             f_elem_store = Path(points_store._store.path) / f_elem.path
             logger.debug(f"Store path for points {f_elem_store}")
             points[k] = _read_points(f_elem_store)
@@ -63,6 +72,8 @@ def read_zarr(store: Union[str, Path, zarr.Group]) -> SpatialData:
     if 'shapes' in f:
         shapes_store = f["shapes"]
         for k in shapes_store:
+            if Path(k).name.startswith("."):
+                continue
             f_elem = shapes_store[k]
             f_elem_store = Path(shapes_store._store.path) / f_elem.path
             shapes[k] = _read_shapes(f_elem_store)
@@ -70,6 +81,8 @@ def read_zarr(store: Union[str, Path, zarr.Group]) -> SpatialData:
     if 'table' in f:
         table_store = f["table"]
         for k in table_store:
+            if Path(k).name.startswith("."):
+                continue
             f_elem = table_store[k]
             f_elem_store = Path(table_store._store.path) / f_elem.path
             table = read_anndata_zarr(f_elem_store)


### PR DESCRIPTION
Closes #275

- Uses `._store.path` and Path to get to subelements.
- Ignores hidden files