### PR TITLE
Tranformation copy

### DIFF
--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -124,6 +124,8 @@ class RasterSchema(DataArraySchema):
         :class:`spatial_image.SpatialImage` or
         :class:`multiscale_spatial_image.MultiscaleSpatialImage`.
         """
+        if transformations:
+            transformations = transformations.copy()
         if "name" in kwargs:
             raise ValueError("The `name` argument is not (yet) supported for raster data.")
         # if dims is specified inside the data, get the value of dims from the data

--- a/tests/core/operations/test_spatialdata_operations.py
+++ b/tests/core/operations/test_spatialdata_operations.py
@@ -11,6 +11,7 @@ from multiscale_spatial_image import MultiscaleSpatialImage
 from spatial_image import SpatialImage
 from spatialdata import SpatialData
 from spatialdata._core.concatenate import _concatenate_tables, concatenate
+from spatialdata.datasets import blobs
 from spatialdata.models import (
     Image2DModel,
     Labels2DModel,
@@ -18,7 +19,7 @@ from spatialdata.models import (
     ShapesModel,
     TableModel,
 )
-from spatialdata.transformations.operations import set_transformation
+from spatialdata.transformations.operations import get_transformation, set_transformation
 from spatialdata.transformations.transformations import Identity, Scale
 
 from tests.conftest import _get_table
@@ -239,3 +240,18 @@ def test_set_item(full_sdata):
             # trying to overwrite the file used for backing (only for images, labels and points)
             with pytest.raises(ValueError):
                 full_sdata[name] = full_sdata[name]
+
+
+def test_no_shared_transformations():
+    """Test transformation dictionary copy for transformations not to be shared."""
+    sdata = blobs()
+    element_name = "blobs_image"
+    test_space = "test"
+    set_transformation(sdata.images[element_name], Identity(), to_coordinate_system=test_space)
+
+    gen = sdata._gen_elements()
+    for _, name, obj in gen:
+        if name != element_name:
+            assert test_space not in get_transformation(obj, get_all=True)
+        else:
+            assert test_space in get_transformation(obj, get_all=True)


### PR DESCRIPTION
Currently it is the case that a user creates a transformation dictionary which is used while parsing multiple data sources into spatialdata elements. When on top of that setting an additional transformation later for one specific element, all the other elements have the transformation set as well. As suggested by @LucaMarconato, this PR fixes this issue by creating a dictionary copy in the parse function if `transformations` is not `None`. Also, a test has been added.