### PR TITLE
refactor data loader

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
         python: "3.10"
 sphinx:
     configuration: docs/conf.py
-    fail_on_warning: false
+    fail_on_warning: true
 python:
     install:
         - method: pip

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ If you found a bug, please use the [issue tracker][issue-tracker].
 [L Marconato*, G Palla*, KA Yamauchi*, I Virshup*, E Heidari, T Treis, M Toth, R Shrestha, H Vöhringer, W Huber, M Gerstung, J Moore, FJ Theis, O Stegle, bioRxiv, 2023](https://www.biorxiv.org/content/10.1101/2023.05.05.539647v1). \* = equal contribution
 
 ## Sponsor
+
 The spatialdata project is supported by the EMBL International PhD Programme and the Chan Zuckerberg Initiative.
 
-[//]: # (numfocus-fiscal-sponsor-attribution)
+[//]: # "numfocus-fiscal-sponsor-attribution"
 
 The scverse project uses a [consensus based governance model](https://scverse.org/about/roles/) and is fiscally sponsored by [NumFOCUS](https://numfocus.org/). Consider making a [tax-deductible donation](https://numfocus.org/donate-to-scverse) to help the project pay for developer time, professional services, travel, workshops, and a variety of other needs.
 

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -12,11 +12,8 @@ Attributes table
 ~~~~~~~~~~~~~~~~~~
 
 .. autosummary::
-
 {% for item in attributes %}
-
     ~{{ fullname }}.{{ item }}
-
 {%- endfor %}
 {% endif %}
 {% endblock %}
@@ -27,13 +24,10 @@ Methods table
 ~~~~~~~~~~~~~
 
 .. autosummary::
-
 {% for item in methods %}
-
     {%- if item != '__init__' %}
     ~{{ fullname }}.{{ item }}
     {%- endif -%}
-
 {%- endfor %}
 {% endif %}
 {% endblock %}
@@ -46,7 +40,6 @@ Attributes
 {% for item in attributes %}
 
 .. autoattribute:: {{ [objname, item] | join(".") }}
-
 {%- endfor %}
 
 {% endif %}
@@ -61,7 +54,6 @@ Methods
 {%- if item != '__init__' %}
 
 .. automethod:: {{ [objname, item] | join(".") }}
-
 {%- endif -%}
 {%- endfor %}
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -33,7 +33,7 @@ Operations on `SpatialData` objects.
     aggregate
 ```
 
-### Utilities
+### Operations Utilities
 
 ```{eval-rst}
 .. autosummary::
@@ -61,7 +61,7 @@ The elements (building-blocks) that consitute `SpatialData`.
     TableModel
 ```
 
-### Utilities
+### Models Utilities
 
 ```{eval-rst}
 .. currentmodule:: spatialdata.models
@@ -96,7 +96,7 @@ The transformations that can be defined between elements and coordinate systems 
     Sequence
 ```
 
-### Utilities
+### Transformations Utilities
 
 ```{eval-rst}
 .. currentmodule:: spatialdata.transformations
@@ -123,7 +123,7 @@ The transformations that can be defined between elements and coordinate systems 
     ImageTilesDataset
 ```
 
-## Input/output
+## Input/Output
 
 ```{eval-rst}
 .. currentmodule:: spatialdata

--- a/docs/api.md
+++ b/docs/api.md
@@ -111,7 +111,6 @@ The transformations that can be defined between elements and coordinate systems 
 
 ```{eval-rst}
 .. currentmodule:: spatialdata.dataloader
-
 .. autosummary::
     :toctree: generated
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -108,7 +108,7 @@ The transformations that can be defined between elements and coordinate systems 
 ## DataLoader
 
 ```{eval-rst}
-.. currentmodule:: spatialdata.dataloader
+.. currentmodule:: spatialdata.dataloader.datasets
 
 .. autosummary::
     :toctree: generated

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,7 +29,6 @@ Operations on `SpatialData` objects.
     match_table_to_element
     concatenate
     rasterize
-    transform
     aggregate
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,7 +9,6 @@
 The `SpatialData` class.
 
 ```{eval-rst}
-.. currentmodule:: spatialdata
 .. autosummary::
     :toctree: generated
 
@@ -49,6 +48,7 @@ The elements (building-blocks) that consitute `SpatialData`.
 
 ```{eval-rst}
 .. currentmodule:: spatialdata.models
+
 .. autosummary::
     :toctree: generated
 
@@ -65,6 +65,7 @@ The elements (building-blocks) that consitute `SpatialData`.
 
 ```{eval-rst}
 .. currentmodule:: spatialdata.models
+
 .. autosummary::
     :toctree: generated
 
@@ -82,6 +83,7 @@ The transformations that can be defined between elements and coordinate systems 
 
 ```{eval-rst}
 .. currentmodule:: spatialdata.transformations
+
 .. autosummary::
     :toctree: generated
 
@@ -97,8 +99,9 @@ The transformations that can be defined between elements and coordinate systems 
 ### Utilities
 
 ```{eval-rst}
-.. autosummary::
 .. currentmodule:: spatialdata.transformations
+
+.. autosummary::
     :toctree: generated
 
     get_transformation
@@ -113,6 +116,7 @@ The transformations that can be defined between elements and coordinate systems 
 
 ```{eval-rst}
 .. currentmodule:: spatialdata.dataloader
+
 .. autosummary::
     :toctree: generated
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,6 +9,7 @@
 The `SpatialData` class.
 
 ```{eval-rst}
+.. currentmodule:: spatialdata
 .. autosummary::
     :toctree: generated
 
@@ -63,6 +64,7 @@ The elements (building-blocks) that consitute `SpatialData`.
 ### Utilities
 
 ```{eval-rst}
+.. currentmodule:: spatialdata.models
 .. autosummary::
     :toctree: generated
 
@@ -80,7 +82,6 @@ The transformations that can be defined between elements and coordinate systems 
 
 ```{eval-rst}
 .. currentmodule:: spatialdata.transformations
-
 .. autosummary::
     :toctree: generated
 
@@ -97,6 +98,7 @@ The transformations that can be defined between elements and coordinate systems 
 
 ```{eval-rst}
 .. autosummary::
+.. currentmodule:: spatialdata.transformations
     :toctree: generated
 
     get_transformation

--- a/docs/api.md
+++ b/docs/api.md
@@ -110,7 +110,7 @@ The transformations that can be defined between elements and coordinate systems 
 ## DataLoader
 
 ```{eval-rst}
-.. currentmodule:: spatialdata.dataloader.datasets
+.. currentmodule:: spatialdata.dataloader
 
 .. autosummary::
     :toctree: generated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dev = [
 docs = [
     "sphinx>=4.5",
     "sphinx-book-theme>=1.0.0",
-    "sphinx_rtd_theme",
     "myst-nb",
     "sphinxcontrib-bibtex>=1.0.0",
     "sphinx-autodoc-typehints",

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -27,7 +27,7 @@ __all__ = [
     "save_transformations",
 ]
 
-from spatialdata import models, transformations
+from spatialdata import dataloader, models, transformations
 from spatialdata._core.concatenate import concatenate
 from spatialdata._core.operations.aggregate import aggregate
 from spatialdata._core.operations.rasterize import rasterize

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -27,7 +27,7 @@ __all__ = [
     "save_transformations",
 ]
 
-from spatialdata import dataloader, models, transformations
+from spatialdata import models, transformations
 from spatialdata._core.concatenate import concatenate
 from spatialdata._core.operations.aggregate import aggregate
 from spatialdata._core.operations.rasterize import rasterize

--- a/src/spatialdata/_core/concatenate.py
+++ b/src/spatialdata/_core/concatenate.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 from copy import copy  # Should probably go up at the top
 from itertools import chain
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy as np
 from anndata import AnnData
 
-if TYPE_CHECKING:
-    from spatialdata._core.spatialdata import SpatialData
-
+from spatialdata._core.spatialdata import SpatialData
 from spatialdata.models import TableModel
 
 __all__ = [
@@ -94,8 +92,6 @@ def concatenate(
     -------
     The concatenated :class:`spatialdata.SpatialData` object.
     """
-    from spatialdata import SpatialData
-
     merged_images = {**{k: v for sdata in sdatas for k, v in sdata.images.items()}}
     if len(merged_images) != np.sum([len(sdata.images) for sdata in sdatas]):
         raise KeyError("Images must have unique names across the SpatialData objects to concatenate")

--- a/src/spatialdata/_core/data_extent.py
+++ b/src/spatialdata/_core/data_extent.py
@@ -129,6 +129,8 @@ def get_extent(
 
     Returns
     -------
+    The bounding box description.
+
     min_coordinate
         The minimum coordinate of the bounding box.
     max_coordinate
@@ -136,7 +138,11 @@ def get_extent(
     axes
         The names of the dimensions of the bounding box.
     exact
-        If `True`, the extent is computed exactly. If `False`, an approximation faster to compute is given.
+        Whether the extent is computed exactly or not.
+
+            - If `True`, the extent is computed exactly.
+            - If `False`, an approximation faster to compute is given.
+
         The approximation is guaranteed to contain all the data, see notes for details.
     has_images
         If `True`, images are included in the computation of the extent.

--- a/src/spatialdata/_core/data_extent.py
+++ b/src/spatialdata/_core/data_extent.py
@@ -259,7 +259,12 @@ def _get_extent_of_shapes(e: GeoDataFrame) -> BoundingBoxDescription:
 @get_extent.register
 def _(e: GeoDataFrame, coordinate_system: str = "global", exact: bool = True) -> BoundingBoxDescription:
     """
-    Compute the extent (bounding box) of a set of shapes.
+    Get the extent (bounding box) of a SpatialData object: the extent of the union of the extents of all its elements.
+
+    Parameters
+    ----------
+    e
+        The SpatialData object.
 
     Returns
     -------

--- a/src/spatialdata/_core/data_extent.py
+++ b/src/spatialdata/_core/data_extent.py
@@ -136,36 +136,37 @@ def get_extent(
     axes
         The names of the dimensions of the bounding box.
     exact
-        If True, the extent is computed exactly. If False, an approximation faster to compute is given. The
-        approximation is guaranteed to contain all the data, see notes for details.
+        If `True`, the extent is computed exactly. If `False`, an approximation faster to compute is given.
+        The approximation is guaranteed to contain all the data, see notes for details.
     has_images
-        If True, images are included in the computation of the extent.
+        If `True`, images are included in the computation of the extent.
     has_labels
-        If True, labels are included in the computation of the extent.
+        If `True`, labels are included in the computation of the extent.
     has_points
-        If True, points are included in the computation of the extent.
+        If `True`, points are included in the computation of the extent.
     has_shapes
-        If True, shapes are included in the computation of the extent.
+        If `True`, shapes are included in the computation of the extent.
     elements
-        If not None, only the elements with the given names are included in the computation of the extent.
+        If not `None`, only the elements with the given names are included in the computation of the extent.
 
     Notes
     -----
-    The extent of a SpatialData object is the extent of the union of the extents of all its elements. The extent of a
-    SpatialElement is the extent of the element in the coordinate system specified by the argument `coordinate_system`.
+    The extent of a `SpatialData` object is the extent of the union of the extents of all its elements.
+    The extent of a `SpatialElement` is the extent of the element in the coordinate system
+    specified by the argument `coordinate_system`.
 
-    If `exact` is False, first the extent of the SpatialElement before any transformation is computed. Then, the extent
-    is transformed to the target coordinate system. This is faster than computing the extent after the transformation,
-    since the transformation is applied to extent of the untransformed data, as opposed to transforming the data and
-    then computing the extent.
+    If `exact` is `False`, first the extent of the `SpatialElement` before any transformation is computed.
+    Then, the extent is transformed to the target coordinate system. This is faster than computing the extent
+    after the transformation, since the transformation is applied to extent of the untransformed data,
+    as opposed to transforming the data and then computing the extent.
 
-    The exact and approximate extent are the same if the transformation doesn't contain any rotation or shear, or in the
-    case in which the transformation is affine but all the corners of the extent of the untransformed data
+    The exact and approximate extent are the same if the transformation does not contain any rotation or shear, or in
+    the case in which the transformation is affine but all the corners of the extent of the untransformed data
     (bounding box corners) are part of the dataset itself. Note that this is always the case for raster data.
 
-    An extreme case is a dataset composed of the two points (0, 0) and (1, 1), rotated anticlockwise by 45 degrees. The
-    exact extent is the bounding box [minx, miny, maxx, maxy] = [0, 0, 0, 1.414], while the approximate extent is the
-    box [minx, miny, maxx, maxy] = [-0.707, 0, 0.707, 1.414].
+    An extreme case is a dataset composed of the two points `(0, 0)` and `(1, 1)`, rotated anticlockwise by 45 degrees.
+    The exact extent is the bounding box `[minx, miny, maxx, maxy] = [0, 0, 0, 1.414]`, while the approximate extent is
+    the box `[minx, miny, maxx, maxy] = [-0.707, 0, 0.707, 1.414]`.
     """
     raise ValueError("The object type is not supported.")
 
@@ -184,7 +185,9 @@ def _(
     elements: Union[list[str], None] = None,  # noqa: UP007
 ) -> BoundingBoxDescription:
     """
-    Get the extent (bounding box) of a SpatialData object: the extent of the union of the extents of all its elements.
+    Get the extent (bounding box) of a SpatialData object.
+
+    The resulting extent is the union of the extents of all its elements.
 
     Parameters
     ----------
@@ -259,7 +262,9 @@ def _get_extent_of_shapes(e: GeoDataFrame) -> BoundingBoxDescription:
 @get_extent.register
 def _(e: GeoDataFrame, coordinate_system: str = "global", exact: bool = True) -> BoundingBoxDescription:
     """
-    Get the extent (bounding box) of a SpatialData object: the extent of the union of the extents of all its elements.
+    Get the extent (bounding box) of a SpatialData object.
+
+    The resulting extent is the union of the extents of all its elements.
 
     Parameters
     ----------

--- a/src/spatialdata/_core/data_extent.py
+++ b/src/spatialdata/_core/data_extent.py
@@ -115,9 +115,9 @@ def get_extent(
     has_labels: bool = True,
     has_points: bool = True,
     has_shapes: bool = True,
-    # python 3.9 tests fail if we don't use Union here, see
-    # https://github.com/scverse/spatialdata/pull/318#issuecomment-1755714287
-    elements: Union[list[str], None] = None,  # noqa: UP007
+    elements: Union[  # noqa: UP007 # https://github.com/scverse/spatialdata/pull/318#issuecomment-1755714287
+        list[str], None
+    ] = None,
 ) -> BoundingBoxDescription:
     """
     Get the extent (bounding box) of a SpatialData object or a SpatialElement.
@@ -134,7 +134,7 @@ def get_extent(
     max_coordinate
         The maximum coordinate of the bounding box.
     axes
-        The names of the dimensions of the bounding box
+        The names of the dimensions of the bounding box.
     exact
         If True, the extent is computed exactly. If False, an approximation faster to compute is given. The
         approximation is guaranteed to contain all the data, see notes for details.

--- a/src/spatialdata/_core/operations/aggregate.py
+++ b/src/spatialdata/_core/operations/aggregate.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import anndata as ad
 import dask as da
@@ -20,6 +20,7 @@ from xrspatial import zonal_stats
 from spatialdata._core.operations.transform import transform
 from spatialdata._core.query._utils import circles_to_polygons
 from spatialdata._core.query.relational_query import get_values
+from spatialdata._core.spatialdata import SpatialData
 from spatialdata._types import ArrayLike
 from spatialdata.models import (
     Image2DModel,
@@ -31,9 +32,6 @@ from spatialdata.models import (
     get_model,
 )
 from spatialdata.transformations import BaseTransformation, Identity, get_transformation
-
-if TYPE_CHECKING:
-    from spatialdata import SpatialData
 
 __all__ = ["aggregate"]
 
@@ -236,7 +234,6 @@ def _create_sdata_from_table_and_shapes(
     instance_key: str,
     deepcopy: bool,
 ) -> SpatialData:
-    from spatialdata import SpatialData
     from spatialdata._utils import _deepcopy_geodataframe
 
     table.obs[instance_key] = table.obs_names.copy()

--- a/src/spatialdata/_core/operations/rasterize.py
+++ b/src/spatialdata/_core/operations/rasterize.py
@@ -207,8 +207,6 @@ def _(
     target_height: Optional[float] = None,
     target_depth: Optional[float] = None,
 ) -> SpatialData:
-    from spatialdata import SpatialData
-
     min_coordinate = _parse_list_into_array(min_coordinate)
     max_coordinate = _parse_list_into_array(max_coordinate)
 

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import dask.array as da
 import numpy as np
@@ -11,6 +11,7 @@ from dask.dataframe.core import DataFrame as DaskDataFrame
 from multiscale_spatial_image import MultiscaleSpatialImage
 from spatial_image import SpatialImage
 
+from spatialdata._core.spatialdata import SpatialData
 from spatialdata._utils import _inplace_fix_subset_categorical_obs
 from spatialdata.models import (
     Labels2DModel,
@@ -21,9 +22,6 @@ from spatialdata.models import (
     TableModel,
     get_model,
 )
-
-if TYPE_CHECKING:
-    from spatialdata import SpatialData
 
 
 def _filter_table_by_coordinate_system(table: AnnData | None, coordinate_system: str | list[str]) -> AnnData | None:

--- a/src/spatialdata/_core/query/spatial_query.py
+++ b/src/spatialdata/_core/query/spatial_query.py
@@ -305,7 +305,6 @@ def _(
     target_coordinate_system: str,
     filter_table: bool = True,
 ) -> SpatialData:
-    from spatialdata import SpatialData
     from spatialdata._core.query.relational_query import _filter_table_by_elements
 
     min_coordinate = _parse_list_into_array(min_coordinate)

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -18,27 +18,17 @@ from ome_zarr.types import JSONDict
 from pyarrow.parquet import read_table
 from spatial_image import SpatialImage
 
-from spatialdata._io import (
-    write_image,
-    write_labels,
-    write_points,
-    write_shapes,
-    write_table,
-)
-from spatialdata._io._utils import get_backing_files
 from spatialdata._logging import logger
 from spatialdata._types import ArrayLike
-from spatialdata._utils import _natural_keys
-from spatialdata.models import (
+from spatialdata.models._utils import SpatialElement, get_axes_names
+from spatialdata.models.models import (
     Image2DModel,
     Image3DModel,
     Labels2DModel,
     Labels3DModel,
     PointsModel,
     ShapesModel,
-    SpatialElement,
     TableModel,
-    get_axes_names,
     get_model,
 )
 
@@ -653,6 +643,9 @@ class SpatialData:
         -----
         If the SpatialData object is backed by a Zarr storage, the image will be written to the Zarr storage.
         """
+        from spatialdata._io._utils import get_backing_files
+        from spatialdata._io.io_raster import write_image
+
         if self.is_backed():
             files = get_backing_files(image)
             assert self.path is not None
@@ -736,6 +729,9 @@ class SpatialData:
         -----
         If the SpatialData object is backed by a Zarr storage, the image will be written to the Zarr storage.
         """
+        from spatialdata._io._utils import get_backing_files
+        from spatialdata._io.io_raster import write_labels
+
         if self.is_backed():
             files = get_backing_files(labels)
             assert self.path is not None
@@ -820,6 +816,9 @@ class SpatialData:
         -----
         If the SpatialData object is backed by a Zarr storage, the image will be written to the Zarr storage.
         """
+        from spatialdata._io._utils import get_backing_files
+        from spatialdata._io.io_points import write_points
+
         if self.is_backed():
             files = get_backing_files(points)
             assert self.path is not None
@@ -902,6 +901,8 @@ class SpatialData:
         -----
         If the SpatialData object is backed by a Zarr storage, the image will be written to the Zarr storage.
         """
+        from spatialdata._io.io_shapes import write_shapes
+
         self._add_shapes_in_memory(name=name, shapes=shapes, overwrite=overwrite)
         if self.is_backed():
             elem_group = self._init_add_element(name=name, element_type="shapes", overwrite=overwrite)
@@ -918,6 +919,8 @@ class SpatialData:
         storage_options: JSONDict | list[JSONDict] | None = None,
         overwrite: bool = False,
     ) -> None:
+        from spatialdata._io import write_image, write_labels, write_points, write_shapes, write_table
+
         """Write the SpatialData object to Zarr."""
         if isinstance(file_path, str):
             file_path = Path(file_path)
@@ -1113,6 +1116,8 @@ class SpatialData:
         The table needs to pass validation (see :class:`~spatialdata.TableModel`).
         If the SpatialData object is backed by a Zarr storage, the table will be written to the Zarr storage.
         """
+        from spatialdata._io.io_table import write_table
+
         TableModel().validate(table)
         if self.table is not None:
             raise ValueError("The table already exists. Use del sdata.table to remove it first.")
@@ -1199,6 +1204,7 @@ class SpatialData:
         -------
             The string representation of the SpatialData object.
         """
+        from spatialdata._utils import _natural_keys
 
         def rreplace(s: str, old: str, new: str, occurrence: int) -> str:
             li = s.rsplit(old, occurrence)

--- a/src/spatialdata/_io/_utils.py
+++ b/src/spatialdata/_io/_utils.py
@@ -8,7 +8,7 @@ import tempfile
 from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 from functools import singledispatch
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import zarr
 from dask.dataframe.core import DataFrame as DaskDataFrame
@@ -18,6 +18,7 @@ from ome_zarr.writer import _get_valid_axes
 from spatial_image import SpatialImage
 from xarray import DataArray
 
+from spatialdata._core.spatialdata import SpatialData
 from spatialdata._utils import iterate_pyramid_levels
 from spatialdata.models._utils import (
     MappingToCoordinateSystem_t,
@@ -29,9 +30,6 @@ from spatialdata.transformations.transformations import (
     BaseTransformation,
     _get_current_output_axes,
 )
-
-if TYPE_CHECKING:
-    from spatialdata import SpatialData
 
 
 # suppress logger debug from ome_zarr with context manager
@@ -196,8 +194,6 @@ def _are_directories_identical(
 
 
 def _compare_sdata_on_disk(a: SpatialData, b: SpatialData) -> bool:
-    from spatialdata import SpatialData
-
     if not isinstance(a, SpatialData) or not isinstance(b, SpatialData):
         return False
     # TODO: if the sdata object is backed on disk, don't create a new zarr file

--- a/src/spatialdata/_io/io_zarr.py
+++ b/src/spatialdata/_io/io_zarr.py
@@ -7,7 +7,7 @@ import zarr
 from anndata import AnnData
 from anndata import read_zarr as read_anndata_zarr
 
-from spatialdata import SpatialData
+from spatialdata._core.spatialdata import SpatialData
 from spatialdata._io._utils import ome_zarr_logger
 from spatialdata._io.io_points import _read_points
 from spatialdata._io.io_raster import _read_multiscale

--- a/src/spatialdata/_utils.py
+++ b/src/spatialdata/_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections.abc import Generator
 from copy import deepcopy
-from typing import TYPE_CHECKING, Union
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -25,9 +25,6 @@ from spatialdata.transformations import (
 
 # I was using "from numbers import Number" but this led to mypy errors, so I switched to the following:
 Number = Union[int, float]
-
-if TYPE_CHECKING:
-    pass
 
 
 def _parse_list_into_array(array: list[Number] | ArrayLike) -> ArrayLike:

--- a/src/spatialdata/dataloader/__init__.py
+++ b/src/spatialdata/dataloader/__init__.py
@@ -1,6 +1,1 @@
-import contextlib
-
-with contextlib.suppress(ImportError):
-    from spatialdata.dataloader.datasets import ImageTilesDataset
-
-__all__ = ["ImageTilesDataset"]
+from spatialdata.dataloader.datasets import ImageTilesDataset

--- a/src/spatialdata/dataloader/__init__.py
+++ b/src/spatialdata/dataloader/__init__.py
@@ -1,1 +1,4 @@
-from spatialdata.dataloader.datasets import ImageTilesDataset
+try:
+    from spatialdata.dataloader.datasets import ImageTilesDataset
+except ImportError:
+    ImageTilesDataset = None  # type: ignore[assignment, misc]

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from itertools import chain
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import numpy as np
 import pandas as pd
@@ -192,7 +192,7 @@ class ImageTilesDataset(Dataset):
         assert np.all([i in self.tiles_coords for i in dims_])
         self.dims = list(dims_)
 
-    def _get_return_table(self, return_table: str | list[str] | None) -> Optional[Callable[[int], Any]] | None:
+    def _get_return_table(self, return_table: str | list[str] | None) -> Callable[[int], Any] | None:
         """Get function to return values from the table of the dataset."""
         if return_table is not None:
             return_table = [return_table] if isinstance(return_table, str) else return_table

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -83,7 +83,7 @@ class ImageTilesDataset(Dataset):
             of the image each tile is querying. This is not related he size in pixel of each returned tile.
         raster
             If True, the images are rasterized using :func:`spatialdata.rasterize`.
-            If False, they are rasterized using :func:`spatialdata.bounding_box_query`.
+            If False, they are queried using :func:`spatialdata.bounding_box_query`.
         return_annot
             If not None, a value from the table is returned together with the image tile.
             Only columns in :attr:`anndata.AnnData.obs` and :attr:`anndata.AnnData.X`

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -11,7 +11,6 @@ from spatial_image import SpatialImage
 from torch.utils.data import Dataset
 
 from spatialdata._core.operations.rasterize import rasterize
-from spatialdata._types import ArrayLike
 from spatialdata._utils import _affine_matrix_multiplication
 from spatialdata.models import (
     Image2DModel,
@@ -23,9 +22,7 @@ from spatialdata.models import (
     get_axes_names,
     get_model,
 )
-from spatialdata.models._utils import SpatialElement
 from spatialdata.transformations import get_transformation
-from spatialdata.transformations.operations import get_transformation
 from spatialdata.transformations.transformations import BaseTransformation
 
 if TYPE_CHECKING:
@@ -42,12 +39,9 @@ class ImageTilesDataset(Dataset):
         self,
         sdata: SpatialData,
         regions_to_images: dict[str, str],
-        tiel_scale: float = 1.0,
+        regions_to_coordinate_systems: dict[str, str],
+        tile_scale: float = 1.0,
         tile_dim_in_units: float | None = None,
-        tile_dim_in_pixels: int | None = None,
-        coordinate_systems: str | list[str] = None,
-        # unused at the moment, see
-        transform: Optional[Callable[[SpatialData], Any]] = None,
     ):
         """
         :class:`torch.utils.data.Dataset` for loading tiles from a :class:`spatialdata.SpatialData` object.
@@ -59,6 +53,9 @@ class ImageTilesDataset(Dataset):
         regions_to_images
             A mapping betwen region and images. The regions are used to compute the tile centers, while the images are
             used to get the pixel values.
+        regions_to_coordinate_systems
+            A mapping between regions and coordinate systems. The coordinate systems are used to transform both
+            regions coordinates for tiles as well as images.
         tile_scale
             The scale of the tiles. This is used only if the `regions` are `shapes`.
             It is a scaling factor applied to either the radius (spots) or length (polygons) of the `shapes`
@@ -74,31 +71,23 @@ class ImageTilesDataset(Dataset):
         tile_dim_in_pixels
             The dimension of the requested tile in pixels. This specifies the size of the output tiles that we will get,
              independently of which extent of the image the tile is covering.
-        target_coordinate_system
-            The coordinate system in which the tile_dim_in_units is specified.
         """
         # TODO: we can extend this code to support:
         #  - automatic dermination of the tile_dim_in_pixels to match the image resolution (prevent down/upscaling)
         #  - use the bounding box query instead of the raster function if the user wants
-        coordinate_systems = [coordinate_systems] if isinstance(coordinate_systems, str) else coordinate_systems
-        self._validate(sdata, regions_to_images, coordinate_systems)
-
-        self.tile_dim_in_units = tile_dim_in_units
-        self.tile_dim_in_pixels = tile_dim_in_pixels
-
-        self.n_spots_dict = self._compute_n_spots_dict()
-        self.n_spots = sum(self.n_spots_dict.values())
+        self._validate(sdata, regions_to_images, regions_to_coordinate_systems)
+        self._preprocess(tile_scale, tile_dim_in_units)
 
     def _validate(
         self,
         sdata: SpatialData,
         regions_to_images: dict[str, str],
-        coordinate_systems: list[str],
+        regions_to_coordinate_systems: dict[str, str],
     ) -> None:
         """Validate input parameters."""
-        self._region_key = sdata.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]
-        self._instance_key = sdata.uns[TableModel.ATTRS_KEY][TableModel.INSTANCE_KEY]
-        available_regions = sdata.obs[region_key].unique()
+        self._region_key = sdata.table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]
+        self._instance_key = sdata.table.uns[TableModel.ATTRS_KEY][TableModel.INSTANCE_KEY]
+        available_regions = sdata.table.obs[self._region_key].unique()
         cs_region_image = []  # list of tuples (coordinate_system, region, image)
 
         for region_key, image_key in regions_to_images.items():
@@ -121,78 +110,54 @@ class ImageTilesDataset(Dataset):
             region_trans = get_transformation(region_elem)
             image_trans = get_transformation(image_elem)
 
-            for cs in coordinate_systems:
-                if cs in region_trans and cs in image_trans:
-                    cs_region_image.append(tuple(cs, region_key, image_key))
+            try:
+                cs = regions_to_coordinate_systems[region_key]
+                region_trans = get_transformation(region_elem, cs)
+                image_trans = get_transformation(image_elem, cs)
+                if isinstance(region_trans, BaseTransformation) and isinstance(image_trans, BaseTransformation):
+                    cs_region_image.append((cs, region_key, image_key))
+            except KeyError as e:
+                raise KeyError(f"region {region_key} not found in `regions_to_coordinate_systems`") from e
 
         self.regions = list(available_regions.keys())  # all regions for the dataloader
         self.sdata = sdata
         self._cs_region_image = tuple(cs_region_image)  # tuple(coordinate_system, region_key, image_key)
 
-    def _preprocess(self, tile_scale, tile_dim_in_units) -> None:
+    def _preprocess(
+        self,
+        tile_scale: float = 1.0,
+        tile_dim_in_units: float | None = None,
+    ) -> None:
         """Preprocess the dataset."""
         index_df = []
+        tile_coords_df = []
 
         for cs, region, image in self._cs_region_image:
+            # get dims and transformations for the region element
+            dims = get_axes_names(region)
+            t = get_transformation(region, cs)
+            assert isinstance(t, BaseTransformation)
+
+            # get coordinates of centroids and extent for tiles
+            tile_coords = _get_tile_coords(self.sdata[region], t, dims, tile_scale, tile_dim_in_units)
+            tile_coords_df.append(tile_coords)
+
             # get instances from region
-            inst = self.sdata.table.obs[self.sdata.table.obs[self._region_key] == region][self._instance_key]
-            # get extent for bounding box
-            extent = self._get_extent(self.sdata[region], tile_scale, tile_dim_in_units)
-            if len(extent) == 1:
-                extent = np.repeat(extent, len(inst))
-            if len(extent) != len(inst):
-                raise ValueError(
-                    f"the number of elements in the region {region} ({len(extent)}) does not match the number of "
-                    f"instances ({len(inst)})."
-                )
+            inst = self.sdata.table.obs[self.sdata.table.obs[self._region_key] == region][self._instance_key].values
+            # get index dictionary, with `instance_id`, `cs`, `region`, and `image`
             df = pd.DataFrame({self.INSTANCE_KEY: inst})
             df[self.CS_KEY] = cs
             df[self.REGION_KEY] = region
             df[self.IMAGE_KEY] = image
             index_df.append(df)
 
-        self.index = pd.concat(index_df).reset_index(inplace=True, drop=True)
-
-    def _get_extent(
-        self,
-        elem: SpatialElement,
-        tile_scale: float | None = None,
-        tile_dim_in_units: float | None = None,
-    ) -> ArrayLike:
-        """Get the extent of the region."""
-        if tile_dim_in_units is None:
-            if elem.iloc[0][0].geom_type == "Point":
-                return elem[ShapesModel.RADIUS_KEY].values * tile_scale
-            if elem.iloc[0][0].geom_type == "Polygon":
-                return elem[ShapesModel.GEOMETRY_KEY].length * tile_scale
-            raise ValueError("Only point and polygon shapes are supported.")
-        return tile_dim_in_units
-
-    def _get_unique_instances(self) -> dict[str, Any]:
-        n_spots_dict = {}
-        region_key = self.sdata.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]
-        for region_key in self.regions_to_images:
-            element = self.sdata[region_key]
-            # we could allow also points
-            if isinstance(element, GeoDataFrame):
-                n_spots_dict[region_key] = len(element)
-            elif isinstance(element, (SpatialImage, MultiscaleSpatialImage)):
-                raise NotImplementedError("labels not supported yet")
-            else:
-                raise ValueError("element must be a geodataframe or a spatial image")
-        return n_spots_dict
-
-    def _get_region_info_for_index(self, index: int) -> tuple[str, int]:
-        # TODO: this implmenetation can be improved
-        i = 0
-        for region_key, n_spots in self.n_spots_dict.items():
-            if index < i + n_spots:
-                return region_key, index - i
-            i += n_spots
-        raise ValueError(f"index {index} is out of range")
+        # concatenate and assign to self
+        self.dataset_index = pd.concat(index_df).reset_index(inplace=True, drop=True)
+        self.tiles_coords = pd.concat(tile_coords_df).reset_index(inplace=True, drop=True)
+        assert len(self.tiles_coords) == len(self.dataset_index)
 
     def __len__(self) -> int:
-        return self.n_spots
+        return len(self.dataset_index)
 
     def __getitem__(self, idx: int) -> Any | SpatialData:
         from spatialdata import SpatialData
@@ -278,24 +243,89 @@ class ImageTilesDataset(Dataset):
 
     @property
     def regions(self) -> list[str]:
+        """List of regions in the dataset."""
         return self._regions
 
     @regions.setter
-    def regions(self, regions: list[str]) -> None:
+    def regions(self, regions: list[str]) -> None:  # D102
         self._regions = regions
 
     @property
     def sdata(self) -> SpatialData:
+        """SpatialData object."""
         return self._sdata
 
     @sdata.setter
-    def sdata(self, sdata: SpatialData) -> None:
+    def sdata(self, sdata: SpatialData) -> None:  # D102
         self._sdata = sdata
 
     @property
     def coordinate_systems(self) -> list[str]:
+        """List of coordinate systems in the dataset."""
         return self._coordinate_systems
 
     @coordinate_systems.setter
-    def coordinate_systems(self, coordinate_systems: list[str]) -> None:
+    def coordinate_systems(self, coordinate_systems: list[str]) -> None:  # D102
         self._coordinate_systems = coordinate_systems
+
+    @property
+    def tiles_coords(self) -> pd.DataFrame:
+        """DataFrame with the index of tiles."""
+        return self._tiles_coords
+
+    @tiles_coords.setter
+    def tiles_coords(self, tiles: pd.DataFrame) -> None:
+        self._tiles_coords = tiles
+
+    @property
+    def dataset_index(self) -> pd.DataFrame:
+        """DataFrame with the metadata of the tiles.
+
+        It contains the following columns:
+
+            - INSTANCE: the name of the instance in the region.
+            - CS: the coordinate system of the region-image pair.
+            - REGION: the name of the region.
+            - IMAGE: the name of the image.
+        """
+        return self._dataset_index
+
+    @dataset_index.setter
+    def dataset_index(self, dataset_index: pd.DataFrame) -> None:
+        self._dataset_index = dataset_index
+
+
+def _get_tile_coords(
+    elem: GeoDataFrame,
+    transformation: BaseTransformation,
+    dims: tuple[str, ...],
+    tile_scale: float | None = None,
+    tile_dim_in_units: float | None = None,
+) -> pd.DataFrame:
+    """Get the (transformed) centroid of the region and the extent."""
+    # get centroids and transform them
+    centroids = elem.centroid.get_coordinates()
+    aff = transformation.to_affine_matrix(input_axes=dims, output_axes=dims)
+    centroids = np.squeeze(_affine_matrix_multiplication(aff, centroids), 0)
+    centroids = pd.DataFrame(centroids, columns=dims)
+
+    # get extent, first by checking shape defaults, then by using the `tile_dim_in_units`
+    if tile_dim_in_units is None:
+        if elem.iloc[0][0].geom_type == "Point":
+            extent = elem[ShapesModel.RADIUS_KEY].values * tile_scale
+        if elem.iloc[0][0].geom_type == "Polygon":
+            extent = elem[ShapesModel.GEOMETRY_KEY].length * tile_scale
+        raise ValueError("Only point and polygon shapes are supported.")
+    if tile_dim_in_units is not None:
+        if isinstance(tile_dim_in_units, float):
+            extent = np.repeat(tile_dim_in_units, len(centroids))
+        if len(extent) != len(centroids):
+            raise ValueError(
+                f"the number of elements in the region ({len(extent)}) does not match"
+                f" the number of instances ({len(centroids)})."
+            )
+
+    # transform extent
+    aff = transformation.to_affine_matrix(input_axes=tuple(dims[0]), output_axes=tuple(dims[0]))
+    centroids["extent"] = np.squeeze(_affine_matrix_multiplication(aff, extent), 0)
+    return centroids

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -13,7 +13,7 @@ from geopandas import GeoDataFrame
 from multiscale_spatial_image import MultiscaleSpatialImage
 from scipy.sparse import issparse
 from torch.utils.data import Dataset
-from spatialdata._core.query.relational_query import match_table_to_element
+
 from spatialdata._core.spatialdata import SpatialData
 from spatialdata._utils import _affine_matrix_multiplication
 from spatialdata.models import (
@@ -107,7 +107,12 @@ class ImageTilesDataset(Dataset):
         self._preprocess(tile_scale, tile_dim_in_units)
 
         self._crop_image: Callable[..., Any] = (
-            partial(rasterize_fn, **dict(rasterize_kwargs)) if rasterize else bounding_box_query  # type: ignore[assignment]
+            partial(
+                rasterize_fn,
+                **dict(rasterize_kwargs),
+            )
+            if rasterize
+            else bounding_box_query  # type: ignore[assignment]
         )
         self._return = self._get_return(return_annotations)
         self.transform = transform

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -375,9 +375,9 @@ def _get_tile_coords(
 
     # get extent, first by checking shape defaults, then by using the `tile_dim_in_units`
     if tile_dim_in_units is None:
-        if elem.iloc[0][0].geom_type == "Point":
+        if elem.iloc[0, 0].geom_type == "Point":
             extent = elem[ShapesModel.RADIUS_KEY].values * tile_scale
-        elif elem.iloc[0][0].geom_type in ["Polygon", "MultiPolygon"]:
+        elif elem.iloc[0, 0].geom_type in ["Polygon", "MultiPolygon"]:
             extent = elem[ShapesModel.GEOMETRY_KEY].length * tile_scale
         else:
             raise ValueError("Only point and polygon shapes are supported.")

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -377,7 +377,7 @@ def _get_tile_coords(
 
     # transform extent
     aff = transformation.to_affine_matrix(input_axes=tuple(dims[0]), output_axes=tuple(dims[0]))
-    extent = _affine_matrix_multiplication(aff, extent[:, np.newaxis])
+    extent = _affine_matrix_multiplication(aff, np.array(extent)[:, np.newaxis])
 
     # get min and max coordinates
     min_coordinates = np.array(centroids) - extent / 2

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from functools import partial
 from itertools import chain
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Callable
+from typing import Any, Callable
 
 import numpy as np
 import pandas as pd
@@ -14,6 +14,7 @@ from multiscale_spatial_image import MultiscaleSpatialImage
 from scipy.sparse import issparse
 from torch.utils.data import Dataset
 
+from spatialdata import SpatialData
 from spatialdata._utils import _affine_matrix_multiplication
 from spatialdata.models import (
     Image2DModel,
@@ -29,9 +30,6 @@ from spatialdata.transformations import get_transformation
 from spatialdata.transformations.transformations import BaseTransformation
 
 __all__ = ["ImageTilesDataset"]
-
-if TYPE_CHECKING:
-    from spatialdata import SpatialData
 
 
 class ImageTilesDataset(Dataset):
@@ -217,8 +215,6 @@ class ImageTilesDataset(Dataset):
         return_annot: str | list[str] | None,
     ) -> Callable[[int, Any], tuple[Any, Any] | SpatialData]:
         """Get function to return values from the table of the dataset."""
-        from spatialdata import SpatialData
-
         if return_annot is not None:
             # table is always returned as array shape (1, len(return_annot))
             # where return_table can be a single column or a list of columns

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -33,7 +33,7 @@ __all__ = ["ImageTilesDataset"]
 
 
 class ImageTilesDataset(Dataset):
-    INSTANCE_KEY = "instance"
+    INSTANCE_KEY = "instance_id"
     CS_KEY = "cs"
     REGION_KEY = "region"
     IMAGE_KEY = "image"
@@ -79,9 +79,9 @@ class ImageTilesDataset(Dataset):
 
             If `tile_dim_in_units` is passed, `tile_scale` is ignored.
         tile_dim_in_units
-            The dimension of the requested tile in the units of the target coordinate system. This specifies the extent
-            of the image each tile is querying. This is not related he size in pixel of each returned tile.
-        raster
+            The dimension of the requested tile in the units of the target coordinate system.
+            This specifies the extent of the tile. This is not related the size in pixel of each returned tile.
+        rasterize
             If True, the images are rasterized using :func:`spatialdata.rasterize`.
             If False, they are queried using :func:`spatialdata.bounding_box_query`.
         return_annot
@@ -97,13 +97,13 @@ class ImageTilesDataset(Dataset):
         :class:`torch.utils.data.Dataset` for loading tiles from a :class:`spatialdata.SpatialData`.
         """
         from spatialdata import bounding_box_query
-        from spatialdata._core.operations.rasterize import rasterize
+        from spatialdata._core.operations.rasterize import rasterize as rasterize_fn
 
         self._validate(sdata, regions_to_images, regions_to_coordinate_systems)
         self._preprocess(tile_scale, tile_dim_in_units)
 
         self._crop_image: Callable[..., Any] = (
-            partial(rasterize, **dict(raster_kwargs)) if raster else bounding_box_query  # type: ignore[assignment]
+            partial(rasterize_fn, **dict(raster_kwargs)) if raster else bounding_box_query  # type: ignore[assignment]
         )
         self._return = self._get_return(return_annot)
         self.transform = transform

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -57,14 +57,14 @@ class ImageTilesDataset(Dataset):
         are set, the dataset may return a tuple containing:
 
             - the tile image, centered in the target coordinate system of the region.
-            - a vector or scala value from the table.
+            - a vector or scalar value from the table.
 
         Parameters
         ----------
         sdata
             The :class`spatialdata.SpatialData` object.
         regions_to_images
-            A mapping betwen region and images. The regions are used to compute the tile centers, while the images are
+            A mapping between region and images. The regions are used to compute the tile centers, while the images are
             used to get the pixel values.
         regions_to_coordinate_systems
             A mapping between regions and coordinate systems. The coordinate systems are used to transform both

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import Any, Callable, Optional
 
 import numpy as np
 import pandas as pd

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -90,10 +90,10 @@ class ImageTilesDataset(Dataset):
             can be returned. If None, it will return a `SpatialData` object with only the tuple
             containing the image and the table value.
         transform
-            A callable that takes as input the tuple (image, table_value) and returns a new tuple (when 
-            `return_annotations` is not None); a callable that takes as input the `SpatialData` object and 
-            returns a tuple when `return_annotations` is `None`. 
-            This parameter can be used to apply data transformations (for instance a normalization operation) to the 
+            A callable that takes as input the tuple (image, table_value) and returns a new tuple (when
+            `return_annotations` is not None); a callable that takes as input the `SpatialData` object and
+            returns a tuple when `return_annotations` is `None`.
+            This parameter can be used to apply data transformations (for instance a normalization operation) to the
             image and the table value.
         rasterize_kwargs
             Keyword arguments passed to :func:`spatialdata.rasterize` if `rasterize` is True.

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -14,7 +14,7 @@ from multiscale_spatial_image import MultiscaleSpatialImage
 from scipy.sparse import issparse
 from torch.utils.data import Dataset
 
-from spatialdata import SpatialData
+from spatialdata._core.spatialdata import SpatialData
 from spatialdata._utils import _affine_matrix_multiplication
 from spatialdata.models import (
     Image2DModel,

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -87,11 +87,14 @@ class ImageTilesDataset(Dataset):
         return_annotations
             If not None, a value from the table is returned together with the image tile.
             Only columns in :attr:`anndata.AnnData.obs` and :attr:`anndata.AnnData.X`
-            can be returned. If None, it will return a spatialdata object with only the tuple
+            can be returned. If None, it will return a `SpatialData` object with only the tuple
             containing the image and the table value.
         transform
-            A callable that takes as input the tuple (image, table_value) and returns a new tuple.
-            This can be used to apply transformations to the image and the table value.
+            A callable that takes as input the tuple (image, table_value) and returns a new tuple (when 
+            `return_annotations` is not None); a callable that takes as input the `SpatialData` object and 
+            returns a tuple when `return_annotations` is `None`. 
+            This parameter can be used to apply data transformations (for instance a normalization operation) to the 
+            image and the table value.
         rasterize_kwargs
             Keyword arguments passed to :func:`spatialdata.rasterize` if `rasterize` is True.
             This argument can be used for instance to choose the pixel dimension of the image tile.

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -193,8 +193,10 @@ class ImageTilesDataset(Dataset):
         self.dims = list(dims_)
 
     def _get_return_table(self, return_table: str | list[str] | None) -> Optional[Callable[[int], Any]] | None:
+        """Get function to return values from the table of the dataset."""
         if return_table is not None:
             return_table = [return_table] if isinstance(return_table, str) else return_table
+            # return callable that always return array of shape (1, len(return_table))
             if return_table in self.dataset_table.obs:
                 return lambda x: self.dataset_table.obs[return_table].iloc[x].values.reshape(1, -1)
             if return_table in self.dataset_table.var_names:

--- a/src/spatialdata/datasets.py
+++ b/src/spatialdata/datasets.py
@@ -12,8 +12,8 @@ from shapely.geometry import MultiPolygon, Point, Polygon
 from skimage.segmentation import slic
 from spatial_image import SpatialImage
 
-from spatialdata import SpatialData
 from spatialdata._core.operations.aggregate import aggregate
+from spatialdata._core.spatialdata import SpatialData
 from spatialdata._types import ArrayLike
 from spatialdata.models import (
     Image2DModel,

--- a/src/spatialdata/models/_utils.py
+++ b/src/spatialdata/models/_utils.py
@@ -17,7 +17,6 @@ from spatialdata.transformations.transformations import BaseTransformation
 SpatialElement = Union[SpatialImage, MultiscaleSpatialImage, GeoDataFrame, DaskDataFrame]
 TRANSFORM_KEY = "transform"
 DEFAULT_COORDINATE_SYSTEM = "global"
-# ValidAxis_t = Literal["c", "x", "y", "z"]
 ValidAxis_t = str
 MappingToCoordinateSystem_t = dict[str, BaseTransformation]
 C = "c"

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -18,7 +18,7 @@ from geopandas import GeoDataFrame, GeoSeries
 from multiscale_spatial_image import to_multiscale
 from multiscale_spatial_image.multiscale_spatial_image import MultiscaleSpatialImage
 from multiscale_spatial_image.to_multiscale.to_multiscale import Methods
-from pandas.api.types import is_categorical_dtype
+from pandas import CategoricalDtype
 from shapely._geometry import GeometryType
 from shapely.geometry import MultiPolygon, Point, Polygon
 from shapely.geometry.collection import GeometryCollection
@@ -470,7 +470,7 @@ class PointsModel:
             raise ValueError(f":attr:`dask.dataframe.core.DataFrame.attrs` does not contain `{cls.TRANSFORM_KEY}`.")
         if cls.ATTRS_KEY in data.attrs and "feature_key" in data.attrs[cls.ATTRS_KEY]:
             feature_key = data.attrs[cls.ATTRS_KEY][cls.FEATURE_KEY]
-            if not is_categorical_dtype(data[feature_key]):
+            if not isinstance(data[feature_key], CategoricalDtype):
                 logger.info(f"Feature key `{feature_key}`could be of type `pd.Categorical`. Consider casting it.")
 
     @singledispatchmethod
@@ -624,7 +624,7 @@ class PointsModel:
             #  Here we are explicitly importing the categories
             #  but it is a convenient way to ensure that the categories are known.
             # It also just changes the state of the series, so it is not a big deal.
-            if is_categorical_dtype(data[c]) and not data[c].cat.known:
+            if isinstance(data[c], CategoricalDtype) and not data[c].cat.known:
                 try:
                     data[c] = data[c].cat.set_categories(data[c].head(1).cat.categories)
                 except ValueError:
@@ -729,7 +729,7 @@ class TableModel:
         region_: list[str] = region if isinstance(region, list) else [region]
         if not adata.obs[region_key].isin(region_).all():
             raise ValueError(f"`adata.obs[{region_key}]` values do not match with `{cls.REGION_KEY}` values.")
-        if not is_categorical_dtype(adata.obs[region_key]):
+        if not isinstance(adata.obs[region_key], CategoricalDtype):
             warnings.warn(
                 f"Converting `{cls.REGION_KEY_KEY}: {region_key}` to categorical dtype.", UserWarning, stacklevel=2
             )

--- a/src/spatialdata/transformations/operations.py
+++ b/src/spatialdata/transformations/operations.py
@@ -16,7 +16,7 @@ from spatialdata.transformations._utils import (
 )
 
 if TYPE_CHECKING:
-    from spatialdata import SpatialData
+    from spatialdata._core.spatialdata import SpatialData
     from spatialdata.models import SpatialElement
     from spatialdata.transformations import Affine, BaseTransformation
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ from multiscale_spatial_image import MultiscaleSpatialImage
 from numpy.random import default_rng
 from shapely.geometry import MultiPolygon, Point, Polygon
 from spatial_image import SpatialImage
-from spatialdata import SpatialData
+from spatialdata._core.spatialdata import SpatialData
 from spatialdata.models import (
     Image2DModel,
     Image3DModel,

--- a/tests/core/operations/test_aggregations.py
+++ b/tests/core/operations/test_aggregations.py
@@ -9,8 +9,9 @@ from anndata import AnnData
 from anndata.tests.helpers import assert_equal
 from geopandas import GeoDataFrame
 from numpy.random import default_rng
-from spatialdata import SpatialData, aggregate
+from spatialdata import aggregate
 from spatialdata._core.query._utils import circles_to_polygons
+from spatialdata._core.spatialdata import SpatialData
 from spatialdata._utils import _deepcopy_geodataframe
 from spatialdata.models import Image2DModel, Labels2DModel, PointsModel, TableModel
 from spatialdata.transformations import Affine, Identity, set_transformation

--- a/tests/core/operations/test_spatialdata_operations.py
+++ b/tests/core/operations/test_spatialdata_operations.py
@@ -9,8 +9,8 @@ from dask.delayed import Delayed
 from geopandas import GeoDataFrame
 from multiscale_spatial_image import MultiscaleSpatialImage
 from spatial_image import SpatialImage
-from spatialdata import SpatialData
 from spatialdata._core.concatenate import _concatenate_tables, concatenate
+from spatialdata._core.spatialdata import SpatialData
 from spatialdata.datasets import blobs
 from spatialdata.models import (
     Image2DModel,

--- a/tests/core/operations/test_transform.py
+++ b/tests/core/operations/test_transform.py
@@ -8,7 +8,8 @@ import scipy.misc
 from geopandas.testing import geom_almost_equals
 from multiscale_spatial_image import MultiscaleSpatialImage
 from spatial_image import SpatialImage
-from spatialdata import SpatialData, transform
+from spatialdata import transform
+from spatialdata._core.spatialdata import SpatialData
 from spatialdata._utils import unpad_raster
 from spatialdata.models import Image2DModel, PointsModel, ShapesModel, get_axes_names
 from spatialdata.transformations.operations import (

--- a/tests/core/query/test_spatial_query.py
+++ b/tests/core/query/test_spatial_query.py
@@ -5,13 +5,13 @@ import pytest
 from anndata import AnnData
 from multiscale_spatial_image import MultiscaleSpatialImage
 from spatial_image import SpatialImage
-from spatialdata import SpatialData
 from spatialdata._core.query.spatial_query import (
     BaseSpatialRequest,
     BoundingBoxRequest,
     bounding_box_query,
     polygon_query,
 )
+from spatialdata._core.spatialdata import SpatialData
 from spatialdata.models import (
     Image2DModel,
     Image3DModel,

--- a/tests/dataloader/test_datasets.py
+++ b/tests/dataloader/test_datasets.py
@@ -37,10 +37,10 @@ class TestImageTilesDataset:
         sdata = self._annotate_shapes(sdata_blobs, regions_element)
         ds = ImageTilesDataset(
             sdata=sdata,
-            raster=raster,
+            rasterize=raster,
             regions_to_images={regions_element: "blobs_image"},
             regions_to_coordinate_systems={regions_element: "global"},
-            raster_kwargs=raster_kwargs,
+            rasterize_kwargs=raster_kwargs,
         )
 
         sdata_tile = ds[0]
@@ -79,7 +79,7 @@ class TestImageTilesDataset:
             sdata=sdata,
             regions_to_images={regions_element: "blobs_image"},
             regions_to_coordinate_systems={regions_element: "global"},
-            return_annot=return_annot,
+            return_annotations=return_annot,
         )
 
         tile, annot = ds[0]

--- a/tests/dataloader/test_datasets.py
+++ b/tests/dataloader/test_datasets.py
@@ -29,20 +29,72 @@ class TestImageTilesDataset:
                 regions_to_coordinate_systems={regions_element: "global"},
             )
 
-    @pytest.mark.parametrize(
-        "regions_element",
-        ["blobs_circles", "blobs_polygons", "blobs_multipolygons"],
-    )
-    def test_default(self, sdata_blobs, image_element, regions_element):
+    @pytest.mark.parametrize("regions_element", ["blobs_circles", "blobs_polygons", "blobs_multipolygons"])
+    @pytest.mark.parametrize("raster", [True, False])
+    def test_default(self, sdata_blobs, regions_element, raster):
+        raster_kwargs = {"target_unit_to_pixels": 2} if raster else {}
+
+        sdata = self._annotate_shapes(sdata_blobs, regions_element)
+        ds = ImageTilesDataset(
+            sdata=sdata,
+            raster=raster,
+            regions_to_images={regions_element: "blobs_image"},
+            regions_to_coordinate_systems={regions_element: "global"},
+            raster_kwargs=raster_kwargs,
+        )
+
+        sdata_tile = ds[0].__next__()
+        tile = sdata_tile.images.values().__iter__().__next__()
+
+        if regions_element == "blobs_circles":
+            if raster:
+                assert tile.shape == (3, 50, 50)
+            else:
+                assert tile.shape == (3, 25, 25)
+        elif regions_element == "blobs_polygons":
+            if raster:
+                assert tile.shape == (3, 164, 164)
+            else:
+                assert tile.shape == (3, 82, 82)
+        elif regions_element == "blobs_multipolygons":
+            if raster:
+                assert tile.shape == (3, 329, 329)
+            else:
+                assert tile.shape == (3, 164, 164)
+        else:
+            raise ValueError(f"Unexpected regions_element: {regions_element}")
+        # extent has units in pixel so should be the same as tile shape
+        if raster:
+            assert round(ds.tiles_coords.extent.unique()[0] * 2) == tile.shape[1]
+        else:
+            assert int(ds.tiles_coords.extent.unique()[0]) == tile.shape[1]
+        assert np.all(sdata_tile.table.obs.columns == ds.sdata.table.obs.columns)
+        assert list(sdata_tile.images.keys())[0] == "blobs_image"
+
+    @pytest.mark.parametrize("regions_element", ["blobs_circles", "blobs_polygons", "blobs_multipolygons"])
+    @pytest.mark.parametrize("return_annot", ["region", ["region", "instance_id"]])
+    def test_return_annot(self, sdata_blobs, regions_element, return_annot):
         sdata = self._annotate_shapes(sdata_blobs, regions_element)
         ds = ImageTilesDataset(
             sdata=sdata,
             regions_to_images={regions_element: "blobs_image"},
             regions_to_coordinate_systems={regions_element: "global"},
+            return_annot=return_annot,
         )
 
-        tile = ds[0].images.values().__iter__().__next__()
-        assert tile.shape == (3, 32, 32)
+        tile, annot = ds[0].__next__()
+        if regions_element == "blobs_circles":
+            assert tile.shape == (3, 25, 25)
+        elif regions_element == "blobs_polygons":
+            assert tile.shape == (3, 82, 82)
+        elif regions_element == "blobs_multipolygons":
+            assert tile.shape == (3, 164, 164)
+        else:
+            raise ValueError(f"Unexpected regions_element: {regions_element}")
+        # extent has units in pixel so should be the same as tile shape
+        assert int(ds.tiles_coords.extent.unique()[0]) == tile.shape[1]
+        return_annot = [return_annot] if isinstance(return_annot, str) else return_annot
+        assert annot.shape[1] == len(return_annot)
 
     # TODO: consider adding this logic to blobs, to generate blobs with arbitrary table annotation
     def _annotate_shapes(self, sdata: SpatialData, shape: str) -> SpatialData:
@@ -54,35 +106,3 @@ class TestImageTilesDataset:
         del sdata.table
         sdata.table = new_table
         return sdata
-
-
-def test_tiles_table(sdata_blobs):
-    new_table = AnnData(
-        X=np.random.default_rng().random((3, 10)),
-        obs=pd.DataFrame({"region": "blobs_circles", "instance_id": np.array([0, 1, 2])}),
-    )
-    new_table = TableModel.parse(new_table, region="blobs_circles", region_key="region", instance_key="instance_id")
-    del sdata_blobs.table
-    sdata_blobs.table = new_table
-    ds = ImageTilesDataset(
-        sdata=sdata_blobs,
-        regions_to_images={"blobs_circles": "blobs_image"},
-        tile_dim_in_units=10,
-        tile_dim_in_pixels=32,
-        target_coordinate_system="global",
-    )
-    assert len(ds) == 3
-    assert len(ds[0].table) == 1
-    assert np.all(ds[0].table.X == new_table[0].X)
-
-
-def test_tiles_multiple_elements(sdata_blobs):
-    ds = ImageTilesDataset(
-        sdata=sdata_blobs,
-        regions_to_images={"blobs_circles": "blobs_image", "blobs_polygons": "blobs_multiscale_image"},
-        tile_dim_in_units=10,
-        tile_dim_in_pixels=32,
-        target_coordinate_system="global",
-    )
-    assert len(ds) == 6
-    _ = ds[0]

--- a/tests/dataloader/test_datasets.py
+++ b/tests/dataloader/test_datasets.py
@@ -8,26 +8,27 @@ from spatialdata.dataloader import ImageTilesDataset
 from spatialdata.models import TableModel
 
 
-@pytest.mark.parametrize("image_element", ["blobs_image", "blobs_multiscale_image"])
-@pytest.mark.parametrize(
-    "regions_element",
-    ["blobs_labels", "blobs_multiscale_labels", "blobs_circles", "blobs_polygons", "blobs_multipolygons"],
-)
-def test_tiles_dataset(sdata_blobs, image_element, regions_element):
-    if regions_element in ["blobs_labels", "blobs_multipolygons", "blobs_multiscale_labels"]:
-        cm = pytest.raises(NotImplementedError)
-    else:
-        cm = contextlib.nullcontext()
-    with cm:
-        ds = ImageTilesDataset(
-            sdata=sdata_blobs,
-            regions_to_images={regions_element: image_element},
-            tile_dim_in_units=10,
-            tile_dim_in_pixels=32,
-            target_coordinate_system="global",
-        )
-        tile = ds[0].images.values().__iter__().__next__()
-        assert tile.shape == (3, 32, 32)
+class TestImageTilesDataset:
+    @pytest.mark.parametrize("image_element", ["blobs_image", "blobs_multiscale_image"])
+    @pytest.mark.parametrize(
+        "regions_element",
+        ["blobs_labels", "blobs_multiscale_labels", "blobs_circles", "blobs_polygons", "blobs_multipolygons"],
+    )
+    def test_tiles_dataset(self, sdata_blobs, image_element, regions_element):
+        if regions_element in ["blobs_labels", "blobs_multipolygons", "blobs_multiscale_labels"]:
+            cm = pytest.raises(NotImplementedError)
+        else:
+            cm = contextlib.nullcontext()
+        with cm:
+            ds = ImageTilesDataset(
+                sdata=sdata_blobs,
+                regions_to_images={regions_element: image_element},
+                tile_dim_in_units=10,
+                tile_dim_in_pixels=32,
+                target_coordinate_system="global",
+            )
+            tile = ds[0].images.values().__iter__().__next__()
+            assert tile.shape == (3, 32, 32)
 
 
 def test_tiles_table(sdata_blobs):

--- a/tests/dataloader/test_datasets.py
+++ b/tests/dataloader/test_datasets.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from anndata import AnnData
+from spatialdata import SpatialData
 from spatialdata.dataloader import ImageTilesDataset
 from spatialdata.models import TableModel
 
@@ -14,21 +15,45 @@ class TestImageTilesDataset:
         "regions_element",
         ["blobs_labels", "blobs_multiscale_labels", "blobs_circles", "blobs_polygons", "blobs_multipolygons"],
     )
-    def test_tiles_dataset(self, sdata_blobs, image_element, regions_element):
-        if regions_element in ["blobs_labels", "blobs_multipolygons", "blobs_multiscale_labels"]:
+    def test_validation(self, sdata_blobs, image_element, regions_element):
+        if regions_element in ["blobs_labels", "blobs_multiscale_labels"] or image_element == "blobs_multiscale_image":
             cm = pytest.raises(NotImplementedError)
+        elif regions_element in ["blobs_circles", "blobs_polygons", "blobs_multipolygons"]:
+            cm = pytest.raises(ValueError)
         else:
             cm = contextlib.nullcontext()
         with cm:
-            ds = ImageTilesDataset(
+            _ = ImageTilesDataset(
                 sdata=sdata_blobs,
                 regions_to_images={regions_element: image_element},
-                tile_dim_in_units=10,
-                tile_dim_in_pixels=32,
-                target_coordinate_system="global",
+                regions_to_coordinate_systems={regions_element: "global"},
             )
-            tile = ds[0].images.values().__iter__().__next__()
-            assert tile.shape == (3, 32, 32)
+
+    @pytest.mark.parametrize(
+        "regions_element",
+        ["blobs_circles", "blobs_polygons", "blobs_multipolygons"],
+    )
+    def test_default(self, sdata_blobs, image_element, regions_element):
+        sdata = self._annotate_shapes(sdata_blobs, regions_element)
+        ds = ImageTilesDataset(
+            sdata=sdata,
+            regions_to_images={regions_element: "blobs_image"},
+            regions_to_coordinate_systems={regions_element: "global"},
+        )
+
+        tile = ds[0].images.values().__iter__().__next__()
+        assert tile.shape == (3, 32, 32)
+
+    # TODO: consider adding this logic to blobs, to generate blobs with arbitrary table annotation
+    def _annotate_shapes(self, sdata: SpatialData, shape: str) -> SpatialData:
+        new_table = AnnData(
+            X=np.random.default_rng().random((len(sdata[shape]), 10)),
+            obs=pd.DataFrame({"region": shape, "instance_id": sdata[shape].index.values}),
+        )
+        new_table = TableModel.parse(new_table, region=shape, region_key="region", instance_key="instance_id")
+        del sdata.table
+        sdata.table = new_table
+        return sdata
 
 
 def test_tiles_table(sdata_blobs):

--- a/tests/dataloader/test_datasets.py
+++ b/tests/dataloader/test_datasets.py
@@ -60,7 +60,7 @@ class TestImageTilesDataset:
             if raster:
                 assert tile.shape == (3, 329, 329)
             else:
-                assert tile.shape == (3, 165, 164)
+                assert tile.shape == (3, 164, 164)
         else:
             raise ValueError(f"Unexpected regions_element: {regions_element}")
         # extent has units in pixel so should be the same as tile shape

--- a/tests/dataloader/test_datasets.py
+++ b/tests/dataloader/test_datasets.py
@@ -60,7 +60,7 @@ class TestImageTilesDataset:
             if raster:
                 assert tile.shape == (3, 329, 329)
             else:
-                assert tile.shape == (3, 164, 164)
+                assert tile.shape == (3, 165, 164)
         else:
             raise ValueError(f"Unexpected regions_element: {regions_element}")
         # extent has units in pixel so should be the same as tile shape

--- a/tests/dataloader/test_datasets.py
+++ b/tests/dataloader/test_datasets.py
@@ -43,7 +43,7 @@ class TestImageTilesDataset:
             raster_kwargs=raster_kwargs,
         )
 
-        sdata_tile = ds[0].__next__()
+        sdata_tile = ds[0]
         tile = sdata_tile.images.values().__iter__().__next__()
 
         if regions_element == "blobs_circles":
@@ -82,7 +82,7 @@ class TestImageTilesDataset:
             return_annot=return_annot,
         )
 
-        tile, annot = ds[0].__next__()
+        tile, annot = ds[0]
         if regions_element == "blobs_circles":
             assert tile.shape == (3, 25, 25)
         elif regions_element == "blobs_polygons":

--- a/tests/dataloader/test_datasets.py
+++ b/tests/dataloader/test_datasets.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from anndata import AnnData
-from spatialdata import SpatialData
+from spatialdata._core.spatialdata import SpatialData
 from spatialdata.dataloader import ImageTilesDataset
 from spatialdata.models import TableModel
 

--- a/tests/dataloader/test_datasets.py
+++ b/tests/dataloader/test_datasets.py
@@ -60,14 +60,18 @@ class TestImageTilesDataset:
             if raster:
                 assert tile.shape == (3, 329, 329)
             else:
-                assert tile.shape == (3, 164, 164)
+                assert tile.shape == (3, 165, 164)
         else:
             raise ValueError(f"Unexpected regions_element: {regions_element}")
+
         # extent has units in pixel so should be the same as tile shape
         if raster:
             assert round(ds.tiles_coords.extent.unique()[0] * 2) == tile.shape[1]
         else:
-            assert int(ds.tiles_coords.extent.unique()[0]) == tile.shape[1]
+            if regions_element != "blobs_multipolygons":
+                assert int(ds.tiles_coords.extent.unique()[0]) == tile.shape[1]
+            else:
+                assert int(ds.tiles_coords.extent.unique()[0]) + 1 == tile.shape[1]
         assert np.all(sdata_tile.table.obs.columns == ds.sdata.table.obs.columns)
         assert list(sdata_tile.images.keys())[0] == "blobs_image"
 
@@ -88,11 +92,14 @@ class TestImageTilesDataset:
         elif regions_element == "blobs_polygons":
             assert tile.shape == (3, 82, 82)
         elif regions_element == "blobs_multipolygons":
-            assert tile.shape == (3, 164, 164)
+            assert tile.shape == (3, 165, 164)
         else:
             raise ValueError(f"Unexpected regions_element: {regions_element}")
         # extent has units in pixel so should be the same as tile shape
-        assert int(ds.tiles_coords.extent.unique()[0]) == tile.shape[1]
+        if regions_element != "blobs_multipolygons":
+            assert int(ds.tiles_coords.extent.unique()[0]) == tile.shape[1]
+        else:
+            assert round(ds.tiles_coords.extent.unique()[0]) + 1 == tile.shape[1]
         return_annot = [return_annot] if isinstance(return_annot, str) else return_annot
         assert annot.shape[1] == len(return_annot)
 

--- a/tests/io/test_readwrite.py
+++ b/tests/io/test_readwrite.py
@@ -12,7 +12,7 @@ from multiscale_spatial_image.multiscale_spatial_image import MultiscaleSpatialI
 from numpy.random import default_rng
 from shapely.geometry import Point
 from spatial_image import SpatialImage
-from spatialdata import SpatialData
+from spatialdata._core.spatialdata import SpatialData
 from spatialdata._io._utils import _are_directories_identical
 from spatialdata.models import TableModel
 from spatialdata.transformations.operations import (

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -20,7 +20,7 @@ from numpy.random import default_rng
 from pandas.api.types import is_categorical_dtype
 from shapely.io import to_ragged_array
 from spatial_image import SpatialImage, to_spatial_image
-from spatialdata import SpatialData
+from spatialdata._core.spatialdata import SpatialData
 from spatialdata._types import ArrayLike
 from spatialdata.models import (
     Image2DModel,


### PR DESCRIPTION
This PR is a refactoring of the dataloader. It introduces the following improvements:
- [x] it is possible to create a dataloader from collections of images/regions in the spatialdata object (before, it was a single image-region pair)
- [x] It performs more thorough validation and preprocess as much as possible.
- [x] it simplifies the `__getitem__` method to minimize the amount of computation that is done at that stage, and leverage pre-computed (transformed) coordinates of the tiles at init stage
- [x] it allows the user to both use the rasterize and the bounding_box query API, By default, the latter is used.
- [x] it allows to generate tiles from circles, polygons or multipolygons. For polygons and multipolygons, the length of the polygon is used to get the extent of the tile.
- [x] It returns either a spatialdata object with the image tile and the associated table, or a pair of image/annotation (either from adata.obs or adata.X).

**Considerations for future work**
While I tried to also make it usable for the labels as regions, I realized early on that for that we might want a drastically different type of pipeline in that case. Specifically, we might not want to iterate over centroids but over chunks. 

