### PR TITLE
Fix c coords

### DIFF
--- a/src/spatialdata/_core/operations/transform.py
+++ b/src/spatialdata/_core/operations/transform.py
@@ -242,8 +242,9 @@ def _(data: SpatialImage, transformation: BaseTransformation, maintain_positioni
     transformed_dask, raster_translation = _transform_raster(
         data=data.data, axes=axes, transformation=transformation, **kwargs
     )
+    c_coords = data.indexes["c"].values if "c" in data.indexes else None
     # mypy thinks that schema could be ShapesModel, PointsModel, ...
-    transformed_data = schema.parse(transformed_dask, dims=axes)  # type: ignore[call-arg,arg-type]
+    transformed_data = schema.parse(transformed_dask, dims=axes, c_coords=c_coords)  # type: ignore[call-arg,arg-type]
     old_transformations = get_transformation(data, get_all=True)
     assert isinstance(old_transformations, dict)
     set_transformation(transformed_data, old_transformations.copy(), set_all=True)

--- a/src/spatialdata/datasets.py
+++ b/src/spatialdata/datasets.py
@@ -14,6 +14,7 @@ from spatial_image import SpatialImage
 
 from spatialdata import SpatialData
 from spatialdata._core.operations.aggregate import aggregate
+from spatialdata._logging import logger
 from spatialdata._types import ArrayLike
 from spatialdata.models import (
     Image2DModel,
@@ -127,6 +128,11 @@ class BlobsDataset:
         self.transformations = {"global": Identity()}
         self.c_coords = c_coords
         if c_coords is not None:
+            if n_channels != len(c_coords):
+                logger.info(
+                    f"Number of channels ({n_channels}) and c_coords ({len(c_coords)}) do not match; ignoring "
+                    f"n_channels value"
+                )
             n_channels = len(c_coords)
         self.n_channels = n_channels
         if extra_coord_system:

--- a/src/spatialdata/datasets.py
+++ b/src/spatialdata/datasets.py
@@ -33,6 +33,7 @@ def blobs(
     n_shapes: int = 5,
     extra_coord_system: Optional[str] = None,
     n_channels: int = 3,
+    c_coords: Optional[ArrayLike] = None,
 ) -> SpatialData:
     """
     Blobs dataset.
@@ -63,6 +64,7 @@ def blobs(
         n_shapes=n_shapes,
         extra_coord_system=extra_coord_system,
         n_channels=n_channels,
+        c_coords=c_coords,
     ).blobs()
 
 
@@ -100,6 +102,7 @@ class BlobsDataset:
         n_shapes: int = 5,
         extra_coord_system: Optional[str] = None,
         n_channels: int = 3,
+        c_coords: Optional[ArrayLike] = None,
     ) -> None:
         """
         Blobs dataset.
@@ -122,6 +125,9 @@ class BlobsDataset:
         self.n_points = n_points
         self.n_shapes = n_shapes
         self.transformations = {"global": Identity()}
+        self.c_coords = c_coords
+        if c_coords is not None:
+            n_channels = len(c_coords)
         self.n_channels = n_channels
         if extra_coord_system:
             self.transformations[extra_coord_system] = Identity()
@@ -130,7 +136,7 @@ class BlobsDataset:
         self,
     ) -> SpatialData:
         """Blobs dataset."""
-        image = self._image_blobs(self.transformations, self.length, self.n_channels)
+        image = self._image_blobs(self.transformations, self.length, self.n_channels, self.c_coords)
         multiscale_image = self._image_blobs(self.transformations, self.length, self.n_channels, multiscale=True)
         labels = self._labels_blobs(self.transformations, self.length)
         multiscale_labels = self._labels_blobs(self.transformations, self.length, multiscale=True)
@@ -157,6 +163,7 @@ class BlobsDataset:
         transformations: Optional[dict[str, Any]] = None,
         length: int = 512,
         n_channels: int = 3,
+        c_coords: Optional[ArrayLike] = None,
         multiscale: bool = False,
     ) -> Union[SpatialImage, MultiscaleSpatialImage]:
         masks = []
@@ -168,8 +175,10 @@ class BlobsDataset:
         x = np.stack(masks, axis=0)
         dims = ["c", "y", "x"]
         if not multiscale:
-            return Image2DModel.parse(x, transformations=transformations, dims=dims)
-        return Image2DModel.parse(x, transformations=transformations, dims=dims, scale_factors=[2, 2])
+            return Image2DModel.parse(x, transformations=transformations, dims=dims, c_coords=c_coords)
+        return Image2DModel.parse(
+            x, transformations=transformations, dims=dims, c_coords=c_coords, scale_factors=[2, 2]
+        )
 
     def _labels_blobs(
         self, transformations: Optional[dict[str, Any]] = None, length: int = 512, multiscale: bool = False

--- a/tests/transformations/test_transformations.py
+++ b/tests/transformations/test_transformations.py
@@ -3,8 +3,11 @@ from copy import deepcopy
 import numpy as np
 import pytest
 import xarray.testing
+from spatialdata import transform
+from spatialdata.datasets import blobs
 from spatialdata.models import Image2DModel, PointsModel
 from spatialdata.models._utils import ValidAxis_t
+from spatialdata.transformations import get_transformation
 from spatialdata.transformations.ngff._utils import get_default_coordinate_system
 from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
 from spatialdata.transformations.ngff.ngff_transformations import (
@@ -862,3 +865,19 @@ def test_compose_in_xy_and_operate_in_cyx():
             ]
         ),
     )
+
+
+def test_keep_numerical_coordinates_c():
+    c_coords = range(3)
+    sdata = blobs(n_channels=len(c_coords))
+    t = get_transformation(sdata.images["blobs_image"])
+    t_blobs = transform(sdata.images["blobs_image"], t)
+    assert np.array_equal(t_blobs.coords["c"], c_coords)
+
+
+def test_keep_string_coordinates_c():
+    c_coords = ["a", "b", "c"]
+    sdata = blobs(c_coords=c_coords)
+    t = get_transformation(sdata.images["blobs_image"])
+    t_blobs = transform(sdata.images["blobs_image"], t)
+    assert np.array_equal(t_blobs.coords["c"], c_coords)

--- a/tests/transformations/test_transformations.py
+++ b/tests/transformations/test_transformations.py
@@ -877,7 +877,8 @@ def test_keep_numerical_coordinates_c():
 
 def test_keep_string_coordinates_c():
     c_coords = ["a", "b", "c"]
-    sdata = blobs(c_coords=c_coords)
+    # n_channels will be ignored, testing also that this works
+    sdata = blobs(c_coords=c_coords, n_channels=4)
     t = get_transformation(sdata.images["blobs_image"])
     t_blobs = transform(sdata.images["blobs_image"], t)
     assert np.array_equal(t_blobs.coords["c"], c_coords)


### PR DESCRIPTION
Closes #295 

- pass c_coords also to newly transformed SpatialImages
- add c_coords to new blobs dataset for debugging
- add tests for blobs dataset with both numerical and string c_coords

Now spatialdata_plot works as expected.
```python
from spatialdata.datasets import blobs
import spatialdata_plot

sdata = blobs(c_coords=['a', 'b'])
sdata.pl.render_images('blobs_image', channel=['a', 'b'], palette=['red', 'blue']).pl.show()
```