### PR TITLE
fixed bugs in points models

### DIFF
--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -487,7 +487,10 @@ class PointsModel:
         annotation
             Annotation dataframe. Only if `data` is :class:`numpy.ndarray`.
         coordinates
-            Mapping of axes names to column names in `data`. Only if `data` is :class:`pandas.DataFrame`.
+            Mapping of axes names (keys) to column names (valus) in `data`. Only if `data` is
+            :class:`pandas.DataFrame`. Example: {'x': 'my_x_column', 'y': 'my_y_column'}.
+            If not provided and `data` is :class:`pandas.DataFrame`, and `x`, `y` and optinally `z` are column names,
+            then they will be used as coordinates.
         feature_key
             Feature key in `annotation` or `data`.
         instance_key
@@ -528,7 +531,9 @@ class PointsModel:
                 table[feature_key] = feature_categ
             if instance_key is not None:
                 table[instance_key] = annotation[instance_key]
-            for c in set(annotation.columns) - {feature_key, instance_key}:
+            if Z not in axes and Z in annotation.columns:
+                logger.info(f"Column `{Z}` in `annotation` will be ignored since the data is 2D.")
+            for c in set(annotation.columns) - {feature_key, instance_key, X, Y, Z}:
                 table[c] = dd.from_pandas(annotation[c], **kwargs)  # type: ignore[attr-defined]
             return cls._add_metadata_and_validate(
                 table, feature_key=feature_key, instance_key=instance_key, transformations=transformations
@@ -541,7 +546,7 @@ class PointsModel:
     def _(
         cls,
         data: pd.DataFrame,
-        coordinates: Mapping[str, str],
+        coordinates: Mapping[str, str] | None = None,
         feature_key: str | None = None,
         instance_key: str | None = None,
         transformations: MappingToCoordinateSystem_t | None = None,
@@ -549,6 +554,14 @@ class PointsModel:
     ) -> DaskDataFrame:
         if "npartitions" not in kwargs and "chunksize" not in kwargs:
             kwargs["npartitions"] = cls.NPARTITIONS
+        if coordinates is None:
+            if X in data.columns and Y in data.columns:
+                coordinates = {X: X, Y: Y, Z: Z} if Z in data.columns else {X: X, Y: Y}
+            else:
+                raise ValueError(
+                    f"Coordinates must be provided as a mapping of axes names (keys) to column names (values) in "
+                    f"dataframe. Example: `{'x': 'my_x_column', 'y': 'my_y_column'}`."
+                )
         ndim = len(coordinates)
         axes = [X, Y, Z][:ndim]
         if isinstance(data, pd.DataFrame):
@@ -568,7 +581,13 @@ class PointsModel:
                 table[feature_key] = data[feature_key].astype(str).astype("category")
         if instance_key is not None:
             table[instance_key] = data[instance_key]
-        for c in set(data.columns) - {feature_key, instance_key, *coordinates.values()}:
+        for c in [X, Y, Z]:
+            if c in coordinates and c != coordinates[c] and c in data.columns:
+                logger.info(
+                    f'The column "{coordinates[c]} has now been renamed to "{c}"; the column "{c}" was already '
+                    f"present in the dataframe, and will be dropped."
+                )
+        for c in set(data.columns) - {feature_key, instance_key, *coordinates.values(), X, Y, Z}:
             table[c] = data[c]
         return cls._add_metadata_and_validate(
             table, feature_key=feature_key, instance_key=instance_key, transformations=transformations

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -584,7 +584,7 @@ class PointsModel:
         for c in [X, Y, Z]:
             if c in coordinates and c != coordinates[c] and c in data.columns:
                 logger.info(
-                    f'The column "{coordinates[c]} has now been renamed to "{c}"; the column "{c}" was already '
+                    f'The column "{coordinates[c]}" has now been renamed to "{c}"; the column "{c}" was already '
                     f"present in the dataframe, and will be dropped."
                 )
         for c in set(data.columns) - {feature_key, instance_key, *coordinates.values(), X, Y, Z}:

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -587,6 +587,8 @@ class PointsModel:
                     f'The column "{coordinates[c]}" has now been renamed to "{c}"; the column "{c}" was already '
                     f"present in the dataframe, and will be dropped."
                 )
+        if Z not in axes and Z in data.columns:
+            logger.info(f"Column `{Z}` in `data` will be ignored since the data is 2D.")
         for c in set(data.columns) - {feature_key, instance_key, *coordinates.values(), X, Y, Z}:
             table[c] = data[c]
         return cls._add_metadata_and_validate(


### PR DESCRIPTION
Fixed bugs and added tests:
* fixed bug (appearing with MERSCOPE data and [described also here](https://github.com/scverse/spatialdata-io/pull/33#issuecomment-1635973682)). In the case in which a dataframe is passed to `PointsModel.parse()` and the dataframe contains both `x` and `another_x`, and `coordinates[`x`] = 'another_x`, then the final parsed dataframe would contain the original column `x` and not `another_x` as expected. Added tests.
* fixed bug where if `coordinates.keys()` are `x` and `y`, but the dataframe contains a `z` column, the `z` column is added to the metadata and the `get_axis_names()` would return `x`, `y`, `z` instead of `x`, `y`. Now the `z` column is not added. Added tests.
* fixed bug same as above, but the parser gets a `np.ndarray` instead. I.e. if the parser receives a 2D array but the `annotation` dataframe contains `z`, now `z` is not added. Added tests.
* `PointsModels.parse()` for dataframes now takes the paramter `coordinates` as optional. In such a case, if `x`, `y`, or `x`, `y`, `z`, are in the dataframe, it is assumed, respectively that `coordinates` is `{'x': 'x', 'y': 'y'}` and `{'x': 'x', 'y': 'y, 'z', 'z''}`. This improves the ergonomics of the parser and closes https://github.com/scverse/spatialdata/issues/228. Added tests.