### PR TITLE
fix bug with get_values and labels

### DIFF
--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -181,3 +181,10 @@ def test_get_values_df(sdata_query_aggregation):
             sdata=sdata_query_aggregation,
             element_name="values_circles",
         )
+
+
+def test_get_values_labels_bug(sdata_blobs):
+    # https://github.com/scverse/spatialdata-plot/issues/165
+    from spatialdata import get_values
+
+    get_values("channel_0_sum", sdata=sdata_blobs, element_name="blobs_labels")


### PR DESCRIPTION
This PR is minor and unlocks other PRs, I'll merge it straight away.

### 1. Fix bug with `get_values()` for labels

`get_values()` was failing when the internal function `_filter_table_by_elements()` was called with `match_rows=True`, because the aggregated table from blobs doesn't contain the background in the table (for how we implemented the aggregate function), while the labels has it.

To fix, I simply discard the background index when matching a labels element to the table.

### 2. Minor: fix an assert
Fix an assert that was wrongly written and refactored into the function `_get_element()`