### PR TITLE
Test against pre-release dependencies

### DIFF
--- a/.github/workflows/test_and_deploy.yaml
+++ b/.github/workflows/test_and_deploy.yaml
@@ -23,6 +23,10 @@ jobs:
                 include:
                     - os: macos-latest
                       python: "3.9"
+                    - os: ubuntu-latest
+                      python: "3.10"
+                      pip-flags: "--pre"
+                      name: "Python 3.10 (pre-release)"
 
         env:
             OS: ${{ matrix.os }}
@@ -52,7 +56,7 @@ jobs:
                   pip install pytest-cov
             - name: Install dependencies
               run: |
-                  pip install -e ".[dev,test,torch]"
+                  pip install ${{ matrix.pip-flags }} -e ".[dev,test,torch]"
             - name: Test
               env:
                   MPLBACKEND: agg

--- a/.github/workflows/test_and_deploy.yaml
+++ b/.github/workflows/test_and_deploy.yaml
@@ -23,7 +23,7 @@ jobs:
                 include:
                     - os: macos-latest
                       python: "3.9"
-                    - os: ubuntu-latest
+                    - os: macos-latest
                       python: "3.10"
                       pip-flags: "--pre"
                       name: "Python 3.10 (pre-release)"


### PR DESCRIPTION
So that things like https://github.com/scverse/anndata/issues/1170#issuecomment-1752057015 are found during the release candidate period

Implementation based off of the scverse cookie cutter: https://github.com/scverse/cookiecutter-scverse/blob/main/%7B%7Bcookiecutter.project_name%7D%7D/.github/workflows/test.yaml