### PR TITLE
unpin typing extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "shapely>=2.0.1",
     "rich",
     "pyarrow",
-    "typing_extensions>=4.0.0,<4.6.0",
+    "typing_extensions>=4.8.0",
     "dask-image",
     "networkx",
     "xarray-spatial>=0.3.5",
@@ -193,4 +193,3 @@ convention = "numpy"
 
 # pyupgrade typing rewrite TODO: remove at some point from per-file ignore
 # "UP006", "UP007"
-    


### PR DESCRIPTION
spatialdata pins typing extensions for some reasons that I don't remember, but it often conflicts with other packages in the same env. Would like to merge this asap 