### PR TITLE
Fix channel names in transform for MultiscaleSpatialImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning][].
 -   Added `get_element_instances()` (replaces `_get_unique_label_values_as_index()`) #582
 -   Added `get_element_annotators()`, retrieving the tables that annotate a particular SpatialElement #595
 
+### Fixed
+
+-   Preserve channel names of multi-scale images in `transform` (#379)
+
 ## [0.1.2] - 2024-03-30
 
 ### Minor

--- a/tests/transformations/test_transformations.py
+++ b/tests/transformations/test_transformations.py
@@ -997,9 +997,10 @@ def test_keep_numerical_coordinates_c(image_name):
     assert np.array_equal(get_channels(t_blobs), c_coords)
 
 
-def test_keep_string_coordinates_c():
+@pytest.mark.parametrize("image_name", ["blobs_image", "blobs_multiscale_image"])
+def test_keep_string_coordinates_c(image_name):
     c_coords = ["a", "b", "c"]
     # n_channels will be ignored, testing also that this works
     sdata = blobs(c_coords=c_coords, n_channels=4)
-    t_blobs = transform(sdata.images["blobs_image"], to_coordinate_system=DEFAULT_COORDINATE_SYSTEM)
-    assert np.array_equal(t_blobs.coords["c"], c_coords)
+    t_blobs = transform(sdata.images[image_name], to_coordinate_system=DEFAULT_COORDINATE_SYSTEM)
+    assert np.array_equal(get_channels(t_blobs), c_coords)

--- a/tests/transformations/test_transformations.py
+++ b/tests/transformations/test_transformations.py
@@ -4,10 +4,12 @@ from copy import deepcopy
 import numpy as np
 import pytest
 import xarray.testing
+from xarray import DataArray
+
 from spatialdata import transform
 from spatialdata.datasets import blobs
 from spatialdata.models import Image2DModel, PointsModel
-from spatialdata.models._utils import DEFAULT_COORDINATE_SYSTEM, ValidAxis_t
+from spatialdata.models._utils import DEFAULT_COORDINATE_SYSTEM, ValidAxis_t, get_channels
 from spatialdata.transformations.ngff._utils import get_default_coordinate_system
 from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
 from spatialdata.transformations.ngff.ngff_transformations import (
@@ -32,7 +34,6 @@ from spatialdata.transformations.transformations import (
     _decompose_transformation,
     _get_affine_for_element,
 )
-from xarray import DataArray
 
 
 def test_identity():
@@ -988,11 +989,12 @@ def test_compose_in_xy_and_operate_in_cyx():
     )
 
 
-def test_keep_numerical_coordinates_c():
+@pytest.mark.parametrize("image_name", ["blobs_image", "blobs_multiscale_image"])
+def test_keep_numerical_coordinates_c(image_name):
     c_coords = range(3)
     sdata = blobs(n_channels=len(c_coords))
-    t_blobs = transform(sdata.images["blobs_image"], to_coordinate_system=DEFAULT_COORDINATE_SYSTEM)
-    assert np.array_equal(t_blobs.coords["c"], c_coords)
+    t_blobs = transform(sdata.images[image_name], to_coordinate_system=DEFAULT_COORDINATE_SYSTEM)
+    assert np.array_equal(get_channels(t_blobs), c_coords)
 
 
 def test_keep_string_coordinates_c():

--- a/tests/transformations/test_transformations.py
+++ b/tests/transformations/test_transformations.py
@@ -4,8 +4,6 @@ from copy import deepcopy
 import numpy as np
 import pytest
 import xarray.testing
-from xarray import DataArray
-
 from spatialdata import transform
 from spatialdata.datasets import blobs
 from spatialdata.models import Image2DModel, PointsModel
@@ -34,6 +32,7 @@ from spatialdata.transformations.transformations import (
     _decompose_transformation,
     _get_affine_for_element,
 )
+from xarray import DataArray
 
 
 def test_identity():


### PR DESCRIPTION
When transforming a MultiscaleSpatialImage, a KeyError is raised. See https://github.com/scverse/spatialdata/issues/378

So far, I've modified the test case to cover both SpatialImage and MultiscaleSpatialImage and reproduce the problem. I have no proposed fix yet.