### PR TITLE
Fixes on dataloaders

### DIFF
--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -354,7 +354,7 @@ class ImageTilesDataset(Dataset):
         image = self.sdata[row["image"]]
         tile = self._crop_image(
             image,
-            axes=self.dims,
+            axes=tuple(self.dims),
             min_coordinate=t_coords[[f"min{i}" for i in self.dims]].values,
             max_coordinate=t_coords[[f"max{i}" for i in self.dims]].values,
             target_coordinate_system=row["cs"],

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -408,9 +408,6 @@ def _get_tile_coords(
     circles: GeoDataFrame,
     cs: str,
     rasterize: bool,
-    # elem: GeoDataFrame,
-    # transformation: BaseTransformation,
-    # dims: tuple[str, ...],
     tile_scale: float | None = None,
     tile_dim_in_units: float | None = None,
 ) -> pd.DataFrame:

--- a/tests/dataloader/test_datasets.py
+++ b/tests/dataloader/test_datasets.py
@@ -132,13 +132,7 @@ class TestImageTilesDataset:
         )
         if return_annot is None:
             sdata_tile = ds[0]
-            if rasterize:
-                # rasterize transforms teh multiscale image into a single scale image
-                tile = sdata_tile["blobs_multiscale_image"]
-            else:
-                tile = next(iter(sdata_tile["blobs_multiscale_image"]["scale0"].ds.values()))
+            tile = sdata_tile["blobs_multiscale_image"]
         else:
             tile, annot = ds[0]
-            if not rasterize:
-                tile = next(iter(tile["scale0"].ds.values()))
         assert tile.shape == (3, 10, 10)

--- a/tests/dataloader/test_datasets.py
+++ b/tests/dataloader/test_datasets.py
@@ -1,12 +1,7 @@
-import contextlib
-
 import numpy as np
-import pandas as pd
 import pytest
-from anndata import AnnData
-from spatialdata._core.spatialdata import SpatialData
 from spatialdata.dataloader import ImageTilesDataset
-from spatialdata.models import TableModel
+from spatialdata.datasets import blobs_annotating_element
 
 
 class TestImageTilesDataset:
@@ -15,101 +10,109 @@ class TestImageTilesDataset:
         "regions_element",
         ["blobs_labels", "blobs_multiscale_labels", "blobs_circles", "blobs_polygons", "blobs_multipolygons"],
     )
-    def test_validation(self, sdata_blobs, image_element, regions_element):
-        if regions_element in ["blobs_labels", "blobs_multiscale_labels"] or image_element == "blobs_multiscale_image":
-            cm = pytest.raises(NotImplementedError)
-        elif regions_element in ["blobs_circles", "blobs_polygons", "blobs_multipolygons"]:
-            cm = pytest.raises(ValueError)
+    @pytest.mark.parametrize("table", [True, False])
+    def test_validation(self, sdata_blobs, image_element: str, regions_element: str, table: bool):
+        if table:
+            sdata = blobs_annotating_element(regions_element)
         else:
-            cm = contextlib.nullcontext()
-        with cm:
-            _ = ImageTilesDataset(
-                sdata=sdata_blobs,
-                regions_to_images={regions_element: image_element},
-                regions_to_coordinate_systems={regions_element: "global"},
-            )
+            sdata = sdata_blobs
+            del sdata_blobs.tables["table"]
+        _ = ImageTilesDataset(
+            sdata=sdata,
+            regions_to_images={regions_element: image_element},
+            regions_to_coordinate_systems={regions_element: "global"},
+            table_name="table" if table else None,
+            return_annotations="instance_id" if table else None,
+        )
 
-    @pytest.mark.parametrize("regions_element", ["blobs_circles", "blobs_polygons", "blobs_multipolygons"])
-    @pytest.mark.parametrize("raster", [True, False])
-    def test_default(self, sdata_blobs, regions_element, raster):
-        raster_kwargs = {"target_unit_to_pixels": 2} if raster else {}
+    @pytest.mark.parametrize(
+        "regions_element",
+        ["blobs_circles", "blobs_polygons", "blobs_multipolygons", "blobs_labels", "blobs_multiscale_labels"],
+    )
+    @pytest.mark.parametrize("rasterize", [True, False])
+    def test_default(self, sdata_blobs, regions_element, rasterize):
+        rasterize_kwargs = {"target_unit_to_pixels": 2} if rasterize else {}
 
-        sdata = self._annotate_shapes(sdata_blobs, regions_element)
+        sdata = blobs_annotating_element(regions_element)
         ds = ImageTilesDataset(
             sdata=sdata,
-            rasterize=raster,
+            rasterize=rasterize,
             regions_to_images={regions_element: "blobs_image"},
             regions_to_coordinate_systems={regions_element: "global"},
-            rasterize_kwargs=raster_kwargs,
+            rasterize_kwargs=rasterize_kwargs,
+            table_name="table",
         )
 
         sdata_tile = ds[0]
         tile = sdata_tile.images.values().__iter__().__next__()
 
         if regions_element == "blobs_circles":
-            if raster:
-                assert tile.shape == (3, 50, 50)
+            if rasterize:
+                assert tile.shape == (3, 20, 20)
             else:
-                assert tile.shape == (3, 25, 25)
+                assert tile.shape == (3, 10, 10)
         elif regions_element == "blobs_polygons":
-            if raster:
-                assert tile.shape == (3, 164, 164)
+            if rasterize:
+                assert tile.shape == (3, 6, 6)
             else:
-                assert tile.shape == (3, 82, 82)
+                assert tile.shape == (3, 3, 3)
         elif regions_element == "blobs_multipolygons":
-            if raster:
-                assert tile.shape == (3, 329, 329)
+            if rasterize:
+                assert tile.shape == (3, 9, 9)
             else:
-                assert tile.shape == (3, 165, 164)
+                assert tile.shape == (3, 5, 4)
+        elif regions_element == "blobs_labels" or regions_element == "blobs_multiscale_labels":
+            if rasterize:
+                assert tile.shape == (3, 16, 16)
+            else:
+                assert tile.shape == (3, 8, 8)
         else:
             raise ValueError(f"Unexpected regions_element: {regions_element}")
 
         # extent has units in pixel so should be the same as tile shape
-        if raster:
+        if rasterize:
             assert round(ds.tiles_coords.extent.unique()[0] * 2) == tile.shape[1]
         else:
-            if regions_element != "blobs_multipolygons":
-                assert int(ds.tiles_coords.extent.unique()[0]) == tile.shape[1]
-            else:
-                assert int(ds.tiles_coords.extent.unique()[0]) + 1 == tile.shape[1]
-        assert np.all(sdata_tile.table.obs.columns == ds.sdata.table.obs.columns)
+            # here we have a tolerance of 1 pixel because the size of the tile depends on the values of the centroids
+            # and of the extenta and here we keep the test simple.
+            # For example, if the centroid is 0.5 and the extent is 0.1, the tile will be 1 pixel since the extent will
+            # span 0.4 to 0.6; but if the centroid is 0.95 now the tile will be 2 pixels
+            assert np.ceil(ds.tiles_coords.extent.unique()[0]) in [tile.shape[1], tile.shape[1] + 1]
+        assert np.all(sdata_tile["table"].obs.columns == ds.sdata["table"].obs.columns)
         assert list(sdata_tile.images.keys())[0] == "blobs_image"
 
-    @pytest.mark.parametrize("regions_element", ["blobs_circles", "blobs_polygons", "blobs_multipolygons"])
-    @pytest.mark.parametrize("return_annot", ["region", ["region", "instance_id"]])
+    @pytest.mark.parametrize(
+        "regions_element",
+        ["blobs_circles", "blobs_polygons", "blobs_multipolygons", "blobs_labels", "blobs_multiscale_labels"],
+    )
+    @pytest.mark.parametrize("return_annot", [None, "region", ["region", "instance_id"]])
     def test_return_annot(self, sdata_blobs, regions_element, return_annot):
-        sdata = self._annotate_shapes(sdata_blobs, regions_element)
+        sdata = blobs_annotating_element(regions_element)
         ds = ImageTilesDataset(
             sdata=sdata,
             regions_to_images={regions_element: "blobs_image"},
             regions_to_coordinate_systems={regions_element: "global"},
             return_annotations=return_annot,
+            table_name="table",
         )
-
-        tile, annot = ds[0]
+        if return_annot is None:
+            sdata_tile = ds[0]
+            tile = sdata_tile["blobs_image"]
+        else:
+            tile, annot = ds[0]
         if regions_element == "blobs_circles":
-            assert tile.shape == (3, 25, 25)
+            assert tile.shape == (3, 10, 10)
         elif regions_element == "blobs_polygons":
-            assert tile.shape == (3, 82, 82)
+            assert tile.shape == (3, 3, 3)
         elif regions_element == "blobs_multipolygons":
-            assert tile.shape == (3, 165, 164)
+            assert tile.shape == (3, 5, 4)
+        elif regions_element == "blobs_labels" or regions_element == "blobs_multiscale_labels":
+            assert tile.shape == (3, 8, 8)
         else:
             raise ValueError(f"Unexpected regions_element: {regions_element}")
         # extent has units in pixel so should be the same as tile shape
-        if regions_element != "blobs_multipolygons":
-            assert int(ds.tiles_coords.extent.unique()[0]) == tile.shape[1]
-        else:
-            assert round(ds.tiles_coords.extent.unique()[0]) + 1 == tile.shape[1]
-        return_annot = [return_annot] if isinstance(return_annot, str) else return_annot
-        assert annot.shape[1] == len(return_annot)
-
-    # TODO: consider adding this logic to blobs, to generate blobs with arbitrary table annotation
-    def _annotate_shapes(self, sdata: SpatialData, shape: str) -> SpatialData:
-        new_table = AnnData(
-            X=np.random.default_rng(0).random((len(sdata[shape]), 10)),
-            obs=pd.DataFrame({"region": shape, "instance_id": sdata[shape].index.values}),
-        )
-        new_table = TableModel.parse(new_table, region=shape, region_key="region", instance_key="instance_id")
-        del sdata.table
-        sdata.table = new_table
-        return sdata
+        # see comment in the test above explaining why we have a tolerance of 1 pixel
+        assert np.ceil(ds.tiles_coords.extent.unique()[0]) in [tile.shape[1], tile.shape[1] + 1]
+        if return_annot is not None:
+            return_annot = [return_annot] if isinstance(return_annot, str) else return_annot
+            assert annot.shape[1] == len(return_annot)


### PR DESCRIPTION
This PR improves the `ImageTilesDataset` class in the following ways.
- General minor cleanup, validation of the arguments and improvement of the docstring.
- Now the regions to derive the tiles from can also be labels and multiscale lables; before only polygons, multipolygons and circles were supported. Points are not supported.
- Now the dataset works also with multiscale images, both if `rasterize` is `True` or `False`. The output is always a single scale image.
- The implementation is now simplified thanks to the use of `to_circles()` API; in particular in `_get_tile_coords()` there is no need anymore to perform affine matrix multiplications manually.
- I removed the logic around `polygon.length`. Before if the regions were polygons or multipolygons, the perimeter of these polygon would have been used as the tile width/height. This contrasted with the usage of the diameter for circles. Now any region element is transformed to circles element using `to_circles()` and the tile sizes are the diameters of these circles.