### PR TITLE
Enforce instance key to be dtype int

### DIFF
--- a/src/spatialdata/datasets.py
+++ b/src/spatialdata/datasets.py
@@ -240,7 +240,7 @@ class BlobsDataset:
         arr = rng.integers(padding, length - padding, size=(n_points, 2)).astype(np.int64)
         # randomly assign some values from v to the points
         points_assignment0 = rng.integers(0, 10, size=arr.shape[0]).astype(np.int64)
-        genes = rng.choice(["a", "b"], size=arr.shape[0])
+        genes = rng.choice(["gene_a", "gene_b"], size=arr.shape[0])
         annotation = pd.DataFrame(
             {
                 "genes": genes,

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -867,6 +867,15 @@ class TableModel:
             except IntCastingNaNError as exc:
                 raise ValueError("Values within table.obs[] must be able to be coerced to int dtype.") from exc
 
+        grouped = adata.obs.groupby(region_key)
+        grouped_size = grouped.size()
+        grouped_nunique = grouped.nunique()
+        not_unique = grouped_size[grouped_size != grouped_nunique[instance_key]].index.tolist()
+        if not_unique:
+            raise ValueError(
+                f"Instance key column for region(s) `{', '.join(not_unique)}` does not contain only unique integers"
+            )
+
         attr = {"region": region, "region_key": region_key, "instance_key": instance_key}
         adata.uns[cls.ATTRS_KEY] = attr
         return adata

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -19,6 +19,7 @@ from multiscale_spatial_image import to_multiscale
 from multiscale_spatial_image.multiscale_spatial_image import MultiscaleSpatialImage
 from multiscale_spatial_image.to_multiscale.to_multiscale import Methods
 from pandas import CategoricalDtype
+from pandas.errors import IntCastingNaNError
 from shapely._geometry import GeometryType
 from shapely.geometry import MultiPolygon, Point, Polygon
 from shapely.geometry.collection import GeometryCollection
@@ -863,8 +864,8 @@ class TableModel:
                     f"Converting `{cls.INSTANCE_KEY}: {instance_key}` to integer dtype.", UserWarning, stacklevel=2
                 )
                 adata.obs[instance_key] = adata.obs[instance_key].astype(int)
-            except ValueError:
-                logger.error(f"Values within table.obs['{instance_key}'] must be able to be coerced to int dtype.")
+            except IntCastingNaNError as exc:
+                raise ValueError("Values within table.obs[] must be able to be coerced to int dtype.") from exc
 
         attr = {"region": region, "region_key": region_key, "instance_key": instance_key}
         adata.uns[cls.ATTRS_KEY] = attr

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -857,6 +857,14 @@ class TableModel:
             adata.obs[region_key] = pd.Categorical(adata.obs[region_key])
         if instance_key is None:
             raise ValueError("`instance_key` must be provided.")
+        if adata.obs[instance_key].dtype != int:
+            try:
+                warnings.warn(
+                    f"Converting `{cls.INSTANCE_KEY}: {instance_key}` to integer dtype.", UserWarning, stacklevel=2
+                )
+                adata.obs[instance_key] = adata.obs[instance_key].astype(int)
+            except ValueError:
+                logger.error(f"Values within table.obs['{instance_key}'] must be able to be coerced to int dtype.")
 
         attr = {"region": region, "region_key": region_key, "instance_key": instance_key}
         adata.uns[cls.ATTRS_KEY] = attr

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -247,7 +247,7 @@ def _get_shapes() -> dict[str, GeoDataFrame]:
     points["radius"] = rng.normal(size=(len(points), 1))
 
     out["poly"] = ShapesModel.parse(poly)
-    out["poly"].index = ["a", "b", "c", "d", "e"]
+    out["poly"].index = [0, 1, 2, 3, 4]
     out["multipoly"] = ShapesModel.parse(multipoly)
     out["circles"] = ShapesModel.parse(points)
 

--- a/tests/core/operations/test_spatialdata_operations.py
+++ b/tests/core/operations/test_spatialdata_operations.py
@@ -376,7 +376,7 @@ def test_subset(full_sdata: SpatialData) -> None:
 
     adata = AnnData(
         shape=(10, 0),
-        obs={"region": ["circles"] * 5 + ["poly"] * 5, "instance_id": [0, 1, 2, 3, 4, "a", "b", "c", "d", "e"]},
+        obs={"region": ["circles"] * 5 + ["poly"] * 5, "instance_id": [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]},
     )
     del full_sdata.table
     sdata_table = TableModel.parse(adata, region=["circles", "poly"], region_key="region", instance_key="instance_id")

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import tempfile
 from copy import deepcopy
 from functools import partial
@@ -305,7 +306,7 @@ class TestModels:
         region: str | np.ndarray,
     ) -> None:
         region_key = "reg"
-        obs = pd.DataFrame(RNG.integers(0, 100, size=(10, 3)), columns=["A", "B", "C"])
+        obs = pd.DataFrame(RNG.choice(np.arange(0, 100), size=(10, 3), replace=False), columns=["A", "B", "C"])
         obs[region_key] = region
         adata = AnnData(RNG.normal(size=(10, 2)), obs=obs)
         table = model.parse(adata, region=region, region_key=region_key, instance_key="A")
@@ -327,6 +328,21 @@ class TestModels:
         obs["A"] = pd.Series(len([chr(ord("a") + i) for i in range(10)]))
         adata = AnnData(RNG.normal(size=(10, 2)), obs=obs)
         with pytest.raises(ValueError, match="Values within"):
+            model.parse(adata, region=region, region_key=region_key, instance_key="A")
+
+    @pytest.mark.parametrize("model", [TableModel])
+    @pytest.mark.parametrize("region", [["sample_1"] * 5 + ["sample_2"] * 5])
+    def test_table_instance_key_values_not_unique(self, model: TableModel, region: str | np.ndarray):
+        region_key = "region"
+        obs = pd.DataFrame(RNG.integers(0, 100, size=(10, 3)), columns=["A", "B", "C"])
+        obs[region_key] = region
+        obs["A"] = [1] * 5 + list(range(5))
+        adata = AnnData(RNG.normal(size=(10, 2)), obs=obs)
+        with pytest.raises(ValueError, match=re.escape("Instance key column for region(s) `sample_1`")):
+            model.parse(adata, region=region, region_key=region_key, instance_key="A")
+
+        adata.obs["A"] = [1] * 10
+        with pytest.raises(ValueError, match=re.escape("Instance key column for region(s) `sample_1, sample_2`")):
             model.parse(adata, region=region, region_key=region_key, instance_key="A")
 
 

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -319,6 +319,16 @@ class TestModels:
         assert TableModel.REGION_KEY_KEY in table.uns[TableModel.ATTRS_KEY]
         assert table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY] == region
 
+        obs["A"] = obs["A"].astype(str)
+        adata = AnnData(RNG.normal(size=(10, 2)), obs=obs)
+        with pytest.warns(UserWarning, match="Converting"):
+            model.parse(adata, region=region, region_key=region_key, instance_key="A")
+
+        obs["A"] = pd.Series(len([chr(ord("a") + i) for i in range(10)]))
+        adata = AnnData(RNG.normal(size=(10, 2)), obs=obs)
+        with pytest.raises(ValueError, match="Values within"):
+            model.parse(adata, region=region, region_key=region_key, instance_key="A")
+
 
 def test_get_schema():
     images = _get_images()


### PR DESCRIPTION
Pretty much as in the title. It also checks whether for each region the values in the `instance_key` column in `obs` are unique.