### PR TITLE
Join elements table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning][].
 
 -   Implemented support in SpatialData for storing multiple tables. These tables
     can annotate a SpatialElement but not necessarily so.
+-   Added SQL like joins that can be executed by calling one public function `join_sdata_spatialelement_table`. The following
+    joins are supported: `left`, `left_exclusive`, `right`, `right_exclusive` and `inner`. The function has an option to
+    match rows. For `left` only matching `left` is supported and for `right` join only `right` matching of rows is supported.
+    Not all joins are supported for `Label` elements.
+-   Added function `match_element_to_table` which allows the user to perform a right join of `SpatialElement`(s) with a table
+    with rows matching the row order in the table.
 -   Increased in-memory vs on-disk control: changes performed in-memory (e.g. adding a new image) are not automatically performed on-disk.
 
 #### Minor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning][].
 -   Added SQL like joins that can be executed by calling one public function `join_sdata_spatialelement_table`. The following
     joins are supported: `left`, `left_exclusive`, `right`, `right_exclusive` and `inner`. The function has an option to
     match rows. For `left` only matching `left` is supported and for `right` join only `right` matching of rows is supported.
-    Not all joins are supported for `Label` elements.
+    Not all joins are supported for `Labels` elements.
 -   Added function `match_element_to_table` which allows the user to perform a right join of `SpatialElement`(s) with a table
     with rows matching the row order in the table.
 -   Increased in-memory vs on-disk control: changes performed in-memory (e.g. adding a new image) are not automatically performed on-disk.

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,8 @@ Operations on `SpatialData` objects.
     polygon_query
     get_values
     get_extent
+    join_sdata_spatialelement_table
+    match_element_to_table
     match_table_to_element
     concatenate
     transform

--- a/docs/design_doc.md
+++ b/docs/design_doc.md
@@ -564,6 +564,7 @@ with coordinate systems:
     with axes: c, y, x
     with elements: /images/point8, /labels/point8
 """
+
 sdata0 = sdata.query.coordinate_system("point23", filter_rows=False)
 sdata1 = sdata.query.bounding_box((0, 20, 0, 300))
 sdata1 = sdata.query.polygon("/polygons/annotations")

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -22,6 +22,8 @@ __all__ = [
     "bounding_box_query",
     "polygon_query",
     "get_values",
+    "join_sdata_spatialelement_table",
+    "match_element_to_table",
     "match_table_to_element",
     "SpatialData",
     "get_extent",
@@ -38,7 +40,12 @@ from spatialdata._core.operations.aggregate import aggregate
 from spatialdata._core.operations.rasterize import rasterize
 from spatialdata._core.operations.transform import transform
 from spatialdata._core.query._utils import circles_to_polygons, get_bounding_box_corners
-from spatialdata._core.query.relational_query import get_values, match_table_to_element
+from spatialdata._core.query.relational_query import (
+    get_values,
+    join_sdata_spatialelement_table,
+    match_element_to_table,
+    match_table_to_element,
+)
 from spatialdata._core.query.spatial_query import bounding_box_query, polygon_query
 from spatialdata._core.spatialdata import SpatialData
 from spatialdata._io._utils import get_dask_backing_files, save_transformations

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -208,7 +208,7 @@ def _get_masked_element(
         The spatial element to be masked.
     table_instance_key_column
         The column of a table containing the instance ids
-    match_rows : Literal["left", "right"]
+    match_rows
          Whether to match the indices of the element and table and if so how. If left, element_indices take priority and
         if right table instance ids take priority.
 
@@ -456,8 +456,8 @@ def join_sdata_spatialelement_table(
     joins are symmetric to the `left` joins. In case of an `inner` join of `SpatialElement`(s) and a table, for each an
     element is returned only containing the rows that are present in both the `SpatialElement` and table.
 
-    For `Points` and `Shapes` elements every valid join for argument how is supported. For `Label` elements only `left`
-    joins are fully supported.
+    For `Points` and `Shapes` elements every valid join for argument how is supported. For `Label` elements only the
+    `left` and `right_exclusive` joins are supported.
 
     Parameters
     ----------

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -24,6 +24,7 @@ from spatialdata.models import (
     SpatialElement,
     TableModel,
     get_model,
+    get_table_keys,
 )
 
 
@@ -158,9 +159,7 @@ def _create_element_dict(
 def _right_exclusive_join_spatialelement_table(
     element_dict: dict[str, dict[str, Any]], table: AnnData
 ) -> tuple[dict[str, Any], AnnData | None]:
-    regions = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY]
-    region_column_name = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]
-    instance_key = table.uns[TableModel.ATTRS_KEY][TableModel.INSTANCE_KEY]
+    regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
     mask = []
     for element_type, name_element in element_dict.items():
@@ -188,9 +187,7 @@ def _right_exclusive_join_spatialelement_table(
 def _right_join_spatialelement_table(
     element_dict: dict[str, dict[str, Any]], table: AnnData
 ) -> tuple[dict[str, Any], AnnData]:
-    regions = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY]
-    region_column_name = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]
-    instance_key = table.uns[TableModel.ATTRS_KEY][TableModel.INSTANCE_KEY]
+    regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
     for element_type, name_element in element_dict.items():
         for name, element in name_element.items():
@@ -226,9 +223,7 @@ def _right_join_spatialelement_table(
 def _inner_join_spatialelement_table(
     element_dict: dict[str, dict[str, Any]], table: AnnData
 ) -> tuple[dict[str, Any], AnnData]:
-    regions = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY]
-    region_column_name = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]
-    instance_key = table.uns[TableModel.ATTRS_KEY][TableModel.INSTANCE_KEY]
+    regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
     joined_indices = None
     for element_type, name_element in element_dict.items():
@@ -273,9 +268,7 @@ def _inner_join_spatialelement_table(
 def _left_exclusive_join_spatialelement_table(
     element_dict: dict[str, dict[str, Any]], table: AnnData
 ) -> tuple[dict[str, Any], AnnData | None]:
-    regions = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY]
-    region_column_name = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]
-    instance_key = table.uns[TableModel.ATTRS_KEY][TableModel.INSTANCE_KEY]
+    regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
     for element_type, name_element in element_dict.items():
         for name, element in name_element.items():
@@ -306,9 +299,7 @@ def _left_exclusive_join_spatialelement_table(
 def _left_join_spatialelement_table(
     element_dict: dict[str, dict[str, Any]], table: AnnData
 ) -> tuple[dict[str, Any], AnnData]:
-    regions = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY]
-    region_column_name = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]
-    instance_key = table.uns[TableModel.ATTRS_KEY][TableModel.INSTANCE_KEY]
+    regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
     joined_indices = None
     for element_type, name_element in element_dict.items():

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -237,9 +237,10 @@ def _right_exclusive_join_spatialelement_table(
                 table_instance_key_column = group_df[instance_key]
                 if element_type in ["points", "shapes"]:
                     element_indices = element.index
-                    element_dict[element_type][name] = None
                 else:
                     element_indices = _get_unique_label_values_as_index(element)
+
+                element_dict[element_type][name] = None
                 submask = ~table_instance_key_column.isin(element_indices)
                 mask.append(submask)
             else:

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -264,7 +264,7 @@ def _right_join_spatialelement_table(
     element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "no", "right"]
 ) -> tuple[dict[str, Any], AnnData]:
     if match_rows == "left":
-        warnings.warn("Matching rows `'left'` is not supported for `'right'` join.", UserWarning, stacklevel=2)
+        warnings.warn("Matching rows `''left''` is not supported for `''right''` join.", UserWarning, stacklevel=2)
     regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
     for element_type, name_element in element_dict.items():
@@ -365,7 +365,7 @@ def _left_join_spatialelement_table(
     element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "no", "right"]
 ) -> tuple[dict[str, Any], AnnData]:
     if match_rows == "right":
-        warnings.warn("Matching rows `'right'` is not supported for `'left'` join.", UserWarning, stacklevel=2)
+        warnings.warn("Matching rows `''right''` is not supported for `''left''` join.", UserWarning, stacklevel=2)
     regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
     joined_indices = None
@@ -445,23 +445,23 @@ def join_sdata_spatialelement_table(
     how: str = "left",
     match_rows: Literal["no", "left", "right"] = "no",
 ) -> tuple[dict[str, Any], AnnData]:
-    """Join ``SpatialElement``(s) and table together in SQL like manner.
+    """Join `SpatialElement`(s) and table together in SQL like manner.
 
     The function allows the user to perform SQL like joins of SpatialElements and a table. The elements are not
     returned together in one dataframe like structure, but instead filtered elements are returned. To determine matches,
-    for the ``SpatialElement`` the index is used and for the table the region key column and instance key column. The
+    for the `SpatialElement` the index is used and for the table the region key column and instance key column. The
     elements are not overwritten in the `SpatialData` object.
 
-    The following joins are supported: `'left'`, `'left_exclusive'`, `'inner'`, `'right'` and `'right_exclusive'`. In
-    case of a `'left'` join the `SpatialElements` are returned in a dictionary as is while the table is filtered to
-    only include matching rows. In case of `'left_exclusive'` join None is returned for table while the
-    ``SpatialElements`` returned are filtered to only include indices not present in the table. The cases for
-    `'right'` joins are symmetric to the `'left'` joins. In case of an `'inner'` join of `SpatialElement`(s) and a
-    table, for each an element is returned only containing the rows that are present in both the `SpatialElement` and
-    table.
+    The following joins are supported: `''left''`, `''left_exclusive''`, `''inner''`, `''right''` and
+    `''right_exclusive''`. In case of a `''left''` join the `SpatialElement`s are returned in a dictionary as is
+    while the table is filtered to only include matching rows. In case of `''left_exclusive''` join None is returned
+    for table while the `SpatialElement`s returned are filtered to only include indices not present in the table. The
+    cases for `''right''` joins are symmetric to the `''left''` joins. In case of an `''inner''` join of
+    `SpatialElement`(s) and a table, for each an element is returned only containing the rows that are present in
+    both the `SpatialElement` and table.
 
     For ``Points`` and ``Shapes`` elements every valid join for argument how is supported. For ``Labels`` elements only
-     the `'left'` and `'right_exclusive'` joins are supported.
+     the `''left''` and `''right_exclusive''` joins are supported.
 
     Parameters
     ----------
@@ -472,11 +472,11 @@ def join_sdata_spatialelement_table(
     table_name
         The name of the table to join with the spatial elements.
     how
-        The type of SQL like join to perform, default is `'left'`. Options are `'left'`, `'left_exclusive'`, `'inner'`,
-        `'right'` and `'right_exclusive'`.
+        The type of SQL like join to perform, default is `''left''`. Options are `''left''`, `''left_exclusive''`,
+        `''inner''`, `''right''` and `''right_exclusive''`.
     match_rows
-        Whether to match the indices of the element and table and if so how. If `'left'`, element_indices take priority
-        and if `'right'` table instance ids take priority.
+        Whether to match the indices of the element and table and if so how. If `''left''`, element_indices take
+        priority and if `''right''` table instance ids take priority.
 
     Returns
     -------
@@ -520,7 +520,7 @@ def join_sdata_spatialelement_table(
 
     if match_rows not in MatchTypes.__dict__["_member_names_"]:
         raise TypeError(
-            f"`{match_rows}` is an invalid argument for `match_rows`. Can be either `no`, `'left'` or `'right'`"
+            f"`{match_rows}` is an invalid argument for `match_rows`. Can be either `no`, `''left''` or `''right''`"
         )
     if how in JoinTypes.__dict__["_member_names_"]:
         elements_dict, table = JoinTypes[how](elements_dict, table, match_rows)

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -488,7 +488,6 @@ def join_sdata_spatialelement_table(
         If no table with the given table_name exists in the SpatialData object.
     ValueError
         If the provided join type is not supported.
-
     """
     assert sdata.tables.get(table_name), f"No table with `{table_name}` exists in the SpatialData object."
     table = sdata.tables[table_name]

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -264,7 +264,7 @@ def _right_join_spatialelement_table(
     element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "no", "right"]
 ) -> tuple[dict[str, Any], AnnData]:
     if match_rows == "left":
-        warnings.warn("Matching rows `''left''` is not supported for `''right''` join.", UserWarning, stacklevel=2)
+        warnings.warn("Matching rows ``'left'`` is not supported for ``'right'`` join.", UserWarning, stacklevel=2)
     regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
     for element_type, name_element in element_dict.items():
@@ -365,7 +365,7 @@ def _left_join_spatialelement_table(
     element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "no", "right"]
 ) -> tuple[dict[str, Any], AnnData]:
     if match_rows == "right":
-        warnings.warn("Matching rows `''right''` is not supported for `''left''` join.", UserWarning, stacklevel=2)
+        warnings.warn("Matching rows ``'right'`` is not supported for ``'left'`` join.", UserWarning, stacklevel=2)
     regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
     joined_indices = None
@@ -445,23 +445,23 @@ def join_sdata_spatialelement_table(
     how: str = "left",
     match_rows: Literal["no", "left", "right"] = "no",
 ) -> tuple[dict[str, Any], AnnData]:
-    """Join `SpatialElement`(s) and table together in SQL like manner.
+    """Join SpatialElement(s) and table together in SQL like manner.
 
     The function allows the user to perform SQL like joins of SpatialElements and a table. The elements are not
     returned together in one dataframe like structure, but instead filtered elements are returned. To determine matches,
-    for the `SpatialElement` the index is used and for the table the region key column and instance key column. The
+    for the SpatialElement the index is used and for the table the region key column and instance key column. The
     elements are not overwritten in the `SpatialData` object.
 
-    The following joins are supported: `''left''`, `''left_exclusive''`, `''inner''`, `''right''` and
-    `''right_exclusive''`. In case of a `''left''` join the `SpatialElement`s are returned in a dictionary as is
-    while the table is filtered to only include matching rows. In case of `''left_exclusive''` join None is returned
-    for table while the `SpatialElement`s returned are filtered to only include indices not present in the table. The
-    cases for `''right''` joins are symmetric to the `''left''` joins. In case of an `''inner''` join of
-    `SpatialElement`(s) and a table, for each an element is returned only containing the rows that are present in
-    both the `SpatialElement` and table.
+    The following joins are supported: ``'left'``, ``'left_exclusive'``, ``'inner'``, ``'right'`` and
+    ``'right_exclusive'``. In case of a ``'left'`` join the SpatialElements are returned in a dictionary as is
+    while the table is filtered to only include matching rows. In case of ``'left_exclusive'`` join None is returned
+    for table while the SpatialElements returned are filtered to only include indices not present in the table. The
+    cases for ``'right'`` joins are symmetric to the ``'left'`` joins. In case of an ``'inner'`` join of
+    SpatialElement(s) and a table, for each an element is returned only containing the rows that are present in
+    both the SpatialElement and table.
 
-    For ``Points`` and ``Shapes`` elements every valid join for argument how is supported. For ``Labels`` elements only
-     the `''left''` and `''right_exclusive''` joins are supported.
+    For Points and Shapes elements every valid join for argument how is supported. For Labels elements only
+     the ``'left'`` and ``'right_exclusive'`` joins are supported.
 
     Parameters
     ----------
@@ -472,11 +472,11 @@ def join_sdata_spatialelement_table(
     table_name
         The name of the table to join with the spatial elements.
     how
-        The type of SQL like join to perform, default is `''left''`. Options are `''left''`, `''left_exclusive''`,
-        `''inner''`, `''right''` and `''right_exclusive''`.
+        The type of SQL like join to perform, default is ``'left'``. Options are ``'left'``, ``'left_exclusive'``,
+        ``'inner'``, ``'right'`` and ``'right_exclusive'``.
     match_rows
-        Whether to match the indices of the element and table and if so how. If `''left''`, element_indices take
-        priority and if `''right''` table instance ids take priority.
+        Whether to match the indices of the element and table and if so how. If ``'left'``, element_indices take
+        priority and if ``'right'`` table instance ids take priority.
 
     Returns
     -------
@@ -520,7 +520,7 @@ def join_sdata_spatialelement_table(
 
     if match_rows not in MatchTypes.__dict__["_member_names_"]:
         raise TypeError(
-            f"`{match_rows}` is an invalid argument for `match_rows`. Can be either `no`, `''left''` or `''right''`"
+            f"`{match_rows}` is an invalid argument for `match_rows`. Can be either `no`, ``'left'`` or ``'right'``"
         )
     if how in JoinTypes.__dict__["_member_names_"]:
         elements_dict, table = JoinTypes[how](elements_dict, table, match_rows)

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -155,7 +155,7 @@ def _create_element_dict(
     return elements_dict
 
 
-def _left_exclusive_spatialelement_table(element_dict: dict[str, dict[str, Any]], table: AnnData
+def _left_exclusive_join_spatialelement_table(element_dict: dict[str, dict[str, Any]], table: AnnData
 ) -> tuple[dict[str, Any], AnnData]:
     regions = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY]
     region_column_name = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]
@@ -215,6 +215,7 @@ class JoinTypes(Enum):
     """Available join types for matching elements to tables and vice versa."""
 
     LEFT = left = partial(_left_join_spatialelement_table)
+    LEFT_EXCLUSIVE = left_exclusive = partial(_left_exclusive_join_spatialelement_table)
 
     def __call__(self, *args):
         self.value(*args)

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -263,6 +263,8 @@ def _right_exclusive_join_spatialelement_table(
 def _right_join_spatialelement_table(
     element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "no", "right"]
 ) -> tuple[dict[str, Any], AnnData]:
+    if match_rows == "left":
+        warnings.warn(f"Matching rows `left` is not supported for `right` join.", UserWarning, stacklevel=2)
     regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
     for element_type, name_element in element_dict.items():
@@ -362,6 +364,8 @@ def _left_exclusive_join_spatialelement_table(
 def _left_join_spatialelement_table(
     element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "no", "right"]
 ) -> tuple[dict[str, Any], AnnData]:
+    if match_rows == "right":
+        warnings.warn(f"Matching rows `right` is not supported for `left` join.", UserWarning, stacklevel=2)
     regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
     joined_indices = None

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -264,7 +264,7 @@ def _right_join_spatialelement_table(
     element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "no", "right"]
 ) -> tuple[dict[str, Any], AnnData]:
     if match_rows == "left":
-        warnings.warn(f"Matching rows `left` is not supported for `right` join.", UserWarning, stacklevel=2)
+        warnings.warn("Matching rows `left` is not supported for `right` join.", UserWarning, stacklevel=2)
     regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
     for element_type, name_element in element_dict.items():
@@ -365,7 +365,7 @@ def _left_join_spatialelement_table(
     element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "no", "right"]
 ) -> tuple[dict[str, Any], AnnData]:
     if match_rows == "right":
-        warnings.warn(f"Matching rows `right` is not supported for `left` join.", UserWarning, stacklevel=2)
+        warnings.warn("Matching rows `right` is not supported for `left` join.", UserWarning, stacklevel=2)
     regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
     joined_indices = None

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -431,7 +431,7 @@ def join_sdata_spatialelement_table(
     if JoinTypes.get(how) is not None:
         elements_dict, table = JoinTypes[how](elements_dict, table)
     else:
-        raise ValueError(f"`{how}` is not a valid type of join.")
+        raise TypeError(f"`{how}` is not a valid type of join.")
 
     elements_dict = {
         name: element for outer_key, dict_val in elements_dict.items() for name, element in dict_val.items()

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -68,6 +68,7 @@ def _get_unique_label_values_as_index(element: SpatialElement) -> pd.Index:
     return pd.Index(np.sort(instances))
 
 
+# TODO: replace function use throughout repo by `join_sdata_spatialelement_table`
 def _filter_table_by_elements(
     table: AnnData | None, elements_dict: dict[str, dict[str, Any]], match_rows: bool = False
 ) -> AnnData | None:

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -562,6 +562,29 @@ def match_table_to_element(sdata: SpatialData, element_name: str) -> AnnData:
     return _filter_table_by_elements(sdata.table, elements_dict, match_rows=True)
 
 
+def match_element_to_table(
+    sdata: SpatialData, element_name: str | list[str], table_name: str
+) -> tuple[dict[str, Any], AnnData]:
+    """
+    Filter the elements and make the indices match those in the table.
+
+    Parameters
+    ----------
+    sdata
+       SpatialData object
+    element_name
+       The name(s) of the spatial elements to be joined with the table. Not supported for Label elements.
+    table_name
+       The name of the table to join with the spatial elements.
+
+    Returns
+    -------
+    A tuple containing the joined elements as a dictionary and the joined table as an AnnData object.
+    """
+    element_dict, table = join_sdata_spatialelement_table(sdata, element_name, table_name, "right", match_rows="right")
+    return element_dict, table
+
+
 @dataclass
 class _ValueOrigin:
     origin: str

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -264,7 +264,7 @@ def _right_join_spatialelement_table(
     element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "no", "right"]
 ) -> tuple[dict[str, Any], AnnData]:
     if match_rows == "left":
-        warnings.warn("Matching rows `left` is not supported for `right` join.", UserWarning, stacklevel=2)
+        warnings.warn("Matching rows `'left'` is not supported for `'right'` join.", UserWarning, stacklevel=2)
     regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
     for element_type, name_element in element_dict.items():
@@ -365,7 +365,7 @@ def _left_join_spatialelement_table(
     element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "no", "right"]
 ) -> tuple[dict[str, Any], AnnData]:
     if match_rows == "right":
-        warnings.warn("Matching rows `right` is not supported for `left` join.", UserWarning, stacklevel=2)
+        warnings.warn("Matching rows `'right'` is not supported for `'left'` join.", UserWarning, stacklevel=2)
     regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
     joined_indices = None
@@ -449,18 +449,19 @@ def join_sdata_spatialelement_table(
 
     The function allows the user to perform SQL like joins of SpatialElements and a table. The elements are not
     returned together in one dataframe like structure, but instead filtered elements are returned. To determine matches,
-    for the `SpatialElement` the index is used and for the table the region key column and instance key column. The
+    for the ``SpatialElement`` the index is used and for the table the region key column and instance key column. The
     elements are not overwritten in the `SpatialData` object.
 
-    The following joins are supported: `left`, `left_exclusive`, `inner`, `right`
-    and `right_exclusive`. In case of a `left` join the `SpatialElements` are returned in a dictionary as is while the
-    table is filtered to only include matching rows. In case of `left_exclusive` join None is returned for table while
-    the `SpatialElements` returned are filtered to only include indices not present in the table. The cases for `right`
-    joins are symmetric to the `left` joins. In case of an `inner` join of `SpatialElement`(s) and a table, for each an
-    element is returned only containing the rows that are present in both the `SpatialElement` and table.
+    The following joins are supported: `'left'`, `'left_exclusive'`, `'inner'`, `'right'` and `'right_exclusive'`. In
+    case of a `'left'` join the `SpatialElements` are returned in a dictionary as is while the table is filtered to
+    only include matching rows. In case of `'left_exclusive'` join None is returned for table while the
+    ``SpatialElements`` returned are filtered to only include indices not present in the table. The cases for
+    `'right'` joins are symmetric to the `'left'` joins. In case of an `'inner'` join of `SpatialElement`(s) and a
+    table, for each an element is returned only containing the rows that are present in both the `SpatialElement` and
+    table.
 
-    For `Points` and `Shapes` elements every valid join for argument how is supported. For `Label` elements only the
-    `left` and `right_exclusive` joins are supported.
+    For ``Points`` and ``Shapes`` elements every valid join for argument how is supported. For ``Labels`` elements only
+     the `'left'` and `'right_exclusive'` joins are supported.
 
     Parameters
     ----------
@@ -471,11 +472,11 @@ def join_sdata_spatialelement_table(
     table_name
         The name of the table to join with the spatial elements.
     how
-        The type of SQL like join to perform, default is "left". Options are "left", "left_exclusive", "inner", "right"
-        and "right_exclusive".
+        The type of SQL like join to perform, default is `'left'`. Options are `'left'`, `'left_exclusive'`, `'inner'`,
+        `'right'` and `'right_exclusive'`.
     match_rows
-        Whether to match the indices of the element and table and if so how. If `left`, element_indices take priority
-        and if `right` table instance ids take priority.
+        Whether to match the indices of the element and table and if so how. If `'left'`, element_indices take priority
+        and if `'right'` table instance ids take priority.
 
     Returns
     -------
@@ -519,7 +520,7 @@ def join_sdata_spatialelement_table(
 
     if match_rows not in MatchTypes.__dict__["_member_names_"]:
         raise TypeError(
-            f"`{match_rows}` is an invalid argument for `match_rows`. Can be either `no`, `left` or `right`"
+            f"`{match_rows}` is an invalid argument for `match_rows`. Can be either `no`, `'left'` or `'right'`"
         )
     if how in JoinTypes.__dict__["_member_names_"]:
         elements_dict, table = JoinTypes[how](elements_dict, table, match_rows)

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -445,8 +445,7 @@ def join_sdata_spatialelement_table(
     how: str = "left",
     match_rows: Literal["no", "left", "right"] = "no",
 ) -> tuple[dict[str, Any], AnnData]:
-    """
-    Join `SpatialElement`(s) and table together in SQL like manner.
+    """Join ``SpatialElement``(s) and table together in SQL like manner.
 
     The function allows the user to perform SQL like joins of SpatialElements and a table. The elements are not
     returned together in one dataframe like structure, but instead filtered elements are returned. To determine matches,

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -222,7 +222,7 @@ def _get_masked_element(
     if match_rows == "right":
         mask_values = _match_rows(table_instance_key_column, mask, element_indices, match_rows)
 
-    return element.iloc[mask_values, :]
+    return element.loc[mask_values, :]
 
 
 def _right_exclusive_join_spatialelement_table(
@@ -341,7 +341,7 @@ def _left_exclusive_join_spatialelement_table(
                 if element_type in ["points", "shapes"]:
                     mask = np.full(len(element), True, dtype=bool)
                     mask[table_instance_key_column.values] = False
-                    masked_element = element.iloc[mask, :] if mask.sum() != 0 else None
+                    masked_element = element.loc[mask, :] if mask.sum() != 0 else None
                     element_dict[element_type][name] = masked_element
                 else:
                     warnings.warn(
@@ -384,6 +384,7 @@ def _left_join_spatialelement_table(
                 )
                 continue
 
+    joined_indices = joined_indices.dropna() if joined_indices is not None else None
     joined_table = table[joined_indices, :].copy() if joined_indices is not None else None
 
     return element_dict, joined_table

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -155,7 +155,7 @@ def _create_element_dict(
     return elements_dict
 
 
-def _left_inner_join_spatialelement_table(
+def _left_join_spatialelement_table(
     element_dict: dict[str, dict[str, Any]], table: AnnData
 ) -> tuple[dict[str, Any], AnnData]:
     regions = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY]
@@ -192,7 +192,7 @@ def _left_inner_join_spatialelement_table(
 class JoinTypes(Enum):
     """Available join types for matching elements to tables and vice versa."""
 
-    LEFT_INNER = left_inner = partial(_left_inner_join_spatialelement_table)
+    LEFT = left = partial(_left_join_spatialelement_table)
 
     def __call__(self, *args):
         self.value(*args)
@@ -205,7 +205,7 @@ class JoinTypes(Enum):
 
 
 def join_sdata_spatialelement_table(
-    sdata: SpatialData, spatial_element_name: str | list[str], table_name: str, how: str = "LEFT_INNER"
+    sdata: SpatialData, spatial_element_name: str | list[str], table_name: str, how: str = "LEFT"
 ) -> tuple[dict[str, Any], AnnData]:
     assert sdata.tables.get(table_name), f"No table with {table_name} exists in the SpatialData object."
     table = sdata.tables[table_name]

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -154,7 +154,7 @@ def _get_joined_table_indices(
     joined_indices: pd.Index | None,
     element_indices: pd.RangeIndex,
     table_instance_key_column: pd.Series,
-    match_rows: Literal["left", "right"],
+    match_rows: Literal["left", "no", "right"],
 ) -> pd.Index:
     """
     Get indices of the table that are present in element_indices.
@@ -195,7 +195,7 @@ def _get_masked_element(
     element_indices: pd.RangeIndex,
     element: SpatialElement,
     table_instance_key_column: pd.Series,
-    match_rows: Literal["left", "right"],
+    match_rows: Literal["left", "no", "right"],
 ) -> SpatialElement:
     """
     Get element rows matching the instance ids in the table_instance_key_column.
@@ -226,7 +226,7 @@ def _get_masked_element(
 
 
 def _right_exclusive_join_spatialelement_table(
-    element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: str
+    element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "no", "right"]
 ) -> tuple[dict[str, Any], AnnData | None]:
     regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
@@ -261,7 +261,7 @@ def _right_exclusive_join_spatialelement_table(
 
 
 def _right_join_spatialelement_table(
-    element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "right"]
+    element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "no", "right"]
 ) -> tuple[dict[str, Any], AnnData]:
     regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
@@ -291,7 +291,7 @@ def _right_join_spatialelement_table(
 
 
 def _inner_join_spatialelement_table(
-    element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "right"]
+    element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "no", "right"]
 ) -> tuple[dict[str, Any], AnnData]:
     regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
@@ -329,7 +329,7 @@ def _inner_join_spatialelement_table(
 
 
 def _left_exclusive_join_spatialelement_table(
-    element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: str
+    element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "no", "right"]
 ) -> tuple[dict[str, Any], AnnData | None]:
     regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)
@@ -360,7 +360,7 @@ def _left_exclusive_join_spatialelement_table(
 
 
 def _left_join_spatialelement_table(
-    element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "right"]
+    element_dict: dict[str, dict[str, Any]], table: AnnData, match_rows: Literal["left", "no", "right"]
 ) -> tuple[dict[str, Any], AnnData]:
     regions, region_column_name, instance_key = get_table_keys(table)
     groups_df = table.obs.groupby(by=region_column_name)

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -359,16 +359,22 @@ def join_sdata_spatialelement_table(
     sdata: SpatialData, spatial_element_name: str | list[str], table_name: str, how: str = "left"
 ) -> tuple[dict[str, Any], AnnData]:
     """
-    Join spatial element(s) and table together in SQL like manner.
+    Join `SpatialElement`(s) and table together in SQL like manner.
 
     The function allows the user to perform SQL like joins of SpatialElements and a table. The elements are not
-    returned together in one dataframe like structure, but instead filtered elements are returned, e.g. in case of an
-    inner join of a SpatialElement and a table, for each an element is returned only containing the rows that are
-    present in both tables. To determine matches, for the SpatialElement the index is used and for the table the
-    region key column and instance key column.
+    returned together in one dataframe like structure, but instead filtered elements are returned. To determine matches,
+    for the `SpatialElement` the index is used and for the table the region key column and instance key column. The
+    elements are not overwritten in the `SpatialData` object.
 
-    For Points and Shapes elements every valid join for argument how is supported. For Label elements only  left joins
-    are fully supported.
+    The following joins are supported: `left`, `left_exclusive`, `inner`, `right`
+    and `right_exclusive`. In case of a `left` join the `SpatialElements` are returned in a dictionary as is while the
+    table is filtered to only include matching rows. In case of `left_exclusive` join None is returned for table while
+    the `SpatialElements` returned are filtered to only include indices not present in the table. The cases for `right`
+    joins are symmetric to the `left` joins. In case of an `inner` join of `SpatialElement`(s) and a table, for each an
+    element is returned only containing the rows that are present in both the `SpatialElement` and table.
+
+    For `Points` and `Shapes` elements every valid join for argument how is supported. For `Label` elements only `left`
+    joins are fully supported.
 
     Parameters
     ----------

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -155,7 +155,8 @@ def _create_element_dict(
     return elements_dict
 
 
-def _inner_join_spatialelement_table(element_dict: dict[str, dict[str, Any]], table: AnnData
+def _inner_join_spatialelement_table(
+    element_dict: dict[str, dict[str, Any]], table: AnnData
 ) -> tuple[dict[str, Any], AnnData]:
     regions = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY]
     region_column_name = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]
@@ -170,8 +171,11 @@ def _inner_join_spatialelement_table(element_dict: dict[str, dict[str, Any]], ta
                 if element_type in ["points", "shapes"]:
                     element_indices = element.index
                 else:
-                    warnings.warn(f"Element type `labels` not supported for left exclusive join. Skipping `{name}`",
-                                  UserWarning, stacklevel=2)
+                    warnings.warn(
+                        f"Element type `labels` not supported for left exclusive join. Skipping `{name}`",
+                        UserWarning,
+                        stacklevel=2,
+                    )
                     continue
 
                 mask = table_instance_key_column.isin(element_indices)
@@ -194,7 +198,8 @@ def _inner_join_spatialelement_table(element_dict: dict[str, dict[str, Any]], ta
     return element_dict, joined_table
 
 
-def _left_exclusive_join_spatialelement_table(element_dict: dict[str, dict[str, Any]], table: AnnData
+def _left_exclusive_join_spatialelement_table(
+    element_dict: dict[str, dict[str, Any]], table: AnnData
 ) -> tuple[dict[str, Any], AnnData]:
     regions = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY]
     region_column_name = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]
@@ -211,7 +216,11 @@ def _left_exclusive_join_spatialelement_table(element_dict: dict[str, dict[str, 
                     masked_element = element.iloc[mask, :]
                     element_dict[element_type][name] = masked_element
                 else:
-                    warnings.warn(f"Element type `labels` not supported for left exclusive join. Skipping `{name}`", UserWarning, stacklevel=2)
+                    warnings.warn(
+                        f"Element type `labels` not supported for left exclusive join. Skipping `{name}`",
+                        UserWarning,
+                        stacklevel=2,
+                    )
                     continue
             else:
                 warnings.warn(

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -529,30 +529,7 @@ def join_sdata_spatialelement_table(
     return elements_dict, table
 
 
-def match_element_to_table(
-    sdata: SpatialData, element_name: str | list[str], table_name: str
-) -> tuple[dict[str, Any], AnnData]:
-    """
-    Filter the elements and make the indices match those in the table.
-
-    Parameters
-    ----------
-    sdata
-       SpatialData object
-    element_name
-       The name(s) of the spatial elements to be joined with the table. Not supported for Label elements.
-    table_name
-       The name of the table to join with the spatial elements.
-
-    Returns
-    -------
-    A tuple containing the joined elements as a dictionary and the joined table as an AnnData object.
-    """
-    element_dict, table = join_sdata_spatialelement_table(sdata, element_name, table_name, "right", match_rows="right")
-    return element_dict, table
-
-
-def match_table_to_element(sdata: SpatialData, element_name: str | list[str], table_name: str | None = None) -> AnnData:
+def match_table_to_element(sdata: SpatialData, element_name: str) -> AnnData:
     """
     Filter the table and reorders the rows to match the instances (rows/labels) of the specified SpatialElement.
 
@@ -561,24 +538,28 @@ def match_table_to_element(sdata: SpatialData, element_name: str | list[str], ta
     sdata
         SpatialData object
     element_name
-        The name(s) of the spatial elements to be joined with the table.
-    table_name
-        The name of the table to join with the spatial elements.
+        The name of the spatial elements to be joined with the table.
 
     Returns
     -------
     Table with the rows matching the instances of the element
     """
-    if table_name is None:
-        warnings.warn(
-            "Assumption of table with name `table` being present is being deprecated in SpatialData v0.1. "
-            "Please provide the name of the table as argument to table_name.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        table_name = "table"
-    _, table = join_sdata_spatialelement_table(sdata, element_name, table_name, "left", match_rows="left")
-    return table
+    # TODO: refactor this to make use of the new join_sdata_spatialelement_table function.
+    # if table_name is None:
+    #     warnings.warn(
+    #         "Assumption of table with name `table` being present is being deprecated in SpatialData v0.1. "
+    #         "Please provide the name of the table as argument to table_name.",
+    #         DeprecationWarning,
+    #         stacklevel=2,
+    #     )
+    #     table_name = "table"
+    # _, table = join_sdata_spatialelement_table(sdata, element_name, table_name, "left", match_rows="left")
+    # return table
+    assert sdata.table is not None, "No table found in the SpatialData"
+    element_type, _, element = sdata._find_element(element_name)
+    assert element_type in ["labels", "shapes"], f"Element {element_name} ({element_type}) is not supported"
+    elements_dict = {element_type: {element_name: element}}
+    return _filter_table_by_elements(sdata.table, elements_dict, match_rows=True)
 
 
 @dataclass

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -470,8 +470,8 @@ def join_sdata_spatialelement_table(
         The type of SQL like join to perform, default is "left". Options are "left", "left_exclusive", "inner", "right"
         and "right_exclusive".
     match_rows
-        Whether to match the indices of the element and table and if so how. If left, element_indices take priority and
-        if right table instance ids take priority.
+        Whether to match the indices of the element and table and if so how. If `left`, element_indices take priority
+        and if `right` table instance ids take priority.
 
     Returns
     -------

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -356,8 +356,45 @@ class JoinTypes(Enum):
 
 
 def join_sdata_spatialelement_table(
-    sdata: SpatialData, spatial_element_name: str | list[str], table_name: str, how: str = "LEFT"
+    sdata: SpatialData, spatial_element_name: str | list[str], table_name: str, how: str = "left"
 ) -> tuple[dict[str, Any], AnnData]:
+    """
+    Join spatial element(s) and table together in SQL like manner.
+
+    The function allows the user to perform SQL like joins of SpatialElements and a table. The elements are not
+    returned together in one dataframe like structure, but instead filtered elements are returned, e.g. in case of an
+    inner join of a SpatialElement and a table, for each an element is returned only containing the rows that are
+    present in both tables. To determine matches, for the SpatialElement the index is used and for the table the
+    region key column and instance key column.
+
+    For Points and Shapes elements every valid join for argument how is supported. For Label elements only  left joins
+    are fully supported.
+
+    Parameters
+    ----------
+    sdata
+        The SpatialData object containing the tables and spatial elements.
+    spatial_element_name
+        The name(s) of the spatial elements to be joined with the table.
+    table_name
+        The name of the table to join with the spatial elements.
+    how
+        The type of SQL like join to perform, default is "left". Options are "left", "left_exclusive", "inner", "right"
+        and "right_exclusive".
+
+    Returns
+    -------
+    tuple[dict[str, Any], AnnData]
+        A tuple containing the joined elements as a dictionary and the joined table as an AnnData object.
+
+    Raises
+    ------
+    AssertionError
+        If no table with the given table_name exists in the SpatialData object.
+    ValueError
+        If the provided join type is not supported.
+
+    """
     assert sdata.tables.get(table_name), f"No table with `{table_name}` exists in the SpatialData object."
     table = sdata.tables[table_name]
     if isinstance(spatial_element_name, str):

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -469,11 +469,13 @@ def join_sdata_spatialelement_table(
     how
         The type of SQL like join to perform, default is "left". Options are "left", "left_exclusive", "inner", "right"
         and "right_exclusive".
+    match_rows
+        Whether to match the indices of the element and table and if so how. If left, element_indices take priority and
+        if right table instance ids take priority.
 
     Returns
     -------
-    tuple[dict[str, Any], AnnData]
-        A tuple containing the joined elements as a dictionary and the joined table as an AnnData object.
+    A tuple containing the joined elements as a dictionary and the joined table as an AnnData object.
 
     Raises
     ------
@@ -525,6 +527,29 @@ def join_sdata_spatialelement_table(
         name: element for outer_key, dict_val in elements_dict.items() for name, element in dict_val.items()
     }
     return elements_dict, table
+
+
+def match_element_to_table(
+    sdata: SpatialData, element_name: str | list[str], table_name: str
+) -> tuple[dict[str, Any], AnnData]:
+    """
+    Filter the elements and make the indices match those in the table.
+
+    Parameters
+    ----------
+    sdata
+       SpatialData object
+    element_name
+       The name(s) of the spatial elements to be joined with the table. Not supported for Label elements.
+    table_name
+       The name of the table to join with the spatial elements.
+
+    Returns
+    -------
+    A tuple containing the joined elements as a dictionary and the joined table as an AnnData object.
+    """
+    element_dict, table = join_sdata_spatialelement_table(sdata, element_name, table_name, "right", match_rows="right")
+    return element_dict, table
 
 
 def match_table_to_element(sdata: SpatialData, element_name: str | list[str], table_name: str | None = None) -> AnnData:

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -339,11 +339,11 @@ def _left_join_spatialelement_table(
 class JoinTypes(Enum):
     """Available join types for matching elements to tables and vice versa."""
 
-    LEFT = left = partial(_left_join_spatialelement_table)
-    LEFT_EXCLUSIVE = left_exclusive = partial(_left_exclusive_join_spatialelement_table)
-    INNER = inner = partial(_inner_join_spatialelement_table)
-    RIGHT = right = partial(_right_join_spatialelement_table)
-    RIGHT_EXCLUSIVE = right_exclusive = partial(_right_exclusive_join_spatialelement_table)
+    left = partial(_left_join_spatialelement_table)
+    left_exclusive = partial(_left_exclusive_join_spatialelement_table)
+    inner = partial(_inner_join_spatialelement_table)
+    right = partial(_right_join_spatialelement_table)
+    right_exclusive = partial(_right_exclusive_join_spatialelement_table)
 
     def __call__(self, *args: Any) -> tuple[dict[str, Any], AnnData]:
         return self.value(*args)

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -1538,6 +1538,27 @@ class SpatialData:
         _, _, element = self._find_element(item)
         return element
 
+    def get(self, key: str, default_value: Any = None) -> SpatialElement | AnnData:
+        """
+        Get element from SpatialData object based on corresponding name.
+
+        Parameters
+        ----------
+        key
+            The key to lookup in the spatial elements.
+        default_value : SpatialElement | AnnData, optional
+            The default value to return if the key is not found. Default is None.
+
+        Returns
+        -------
+        The SpatialData element associated with the given key, if found. Otherwise, the default value is returned.
+        """
+        for _, element_name_, element in self.gen_elements():
+            if element_name_ == key:
+                return element
+        else:
+            return default_value
+
     def __setitem__(self, key: str, value: SpatialElement | AnnData) -> None:
         """
         Add the element to the SpatialData object.

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -1538,6 +1538,12 @@ class SpatialData:
         _, _, element = self._find_element(item)
         return element
 
+    def __contains__(self, key: str) -> bool:
+        element_dict = {
+            element_name: element_value for _, element_name, element_value in self._gen_elements(include_table=True)
+        }
+        return key in element_dict
+
     def get(self, key: str, default_value: Any = None) -> SpatialElement | AnnData:
         """
         Get element from SpatialData object based on corresponding name.

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -1544,7 +1544,7 @@ class SpatialData:
         }
         return key in element_dict
 
-    def get(self, key: str, default_value: Any = None) -> SpatialElement | AnnData:
+    def get(self, key: str, default_value: SpatialElement | AnnData | None = None) -> SpatialElement | AnnData:
         """
         Get element from SpatialData object based on corresponding name.
 
@@ -1552,8 +1552,8 @@ class SpatialData:
         ----------
         key
             The key to lookup in the spatial elements.
-        default_value : SpatialElement | AnnData, optional
-            The default value to return if the key is not found. Default is None.
+        default_value
+            The default value (a SpatialElement or a table) to return if the key is not found. Default is None.
 
         Returns
         -------

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -867,7 +867,7 @@ class TableModel:
             except IntCastingNaNError as exc:
                 raise ValueError("Values within table.obs[] must be able to be coerced to int dtype.") from exc
 
-        grouped = adata.obs.groupby(region_key)
+        grouped = adata.obs.groupby(region_key, observed=True)
         grouped_size = grouped.size()
         grouped_nunique = grouped.nunique()
         not_unique = grouped_size[grouped_size != grouped_nunique[instance_key]].index.tolist()

--- a/tests/core/operations/test_aggregations.py
+++ b/tests/core/operations/test_aggregations.py
@@ -124,6 +124,7 @@ def test_aggregate_points_by_shapes(sdata_query_aggregation, by_shapes: str, val
         )
 
 
+# TODO: refactor in smaller functions for easier understanding
 @pytest.mark.parametrize("by_shapes", ["by_circles", "by_polygons"])
 @pytest.mark.parametrize("values_shapes", ["values_circles", "values_polygons"])
 @pytest.mark.parametrize(

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -362,7 +362,7 @@ def test_labels_table_joins(full_sdata):
     with pytest.warns(UserWarning, match="Element type"):
         join_sdata_spatialelement_table(full_sdata, "labels2d", "table", "right")
 
-    # all labels are present in table so shoudl return None
+    # all labels are present in table so should return None
     element_dict, table = join_sdata_spatialelement_table(full_sdata, "labels2d", "table", "right_exclusive")
     assert element_dict["labels2d"] is None
     assert table is None

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -132,6 +132,34 @@ def test_left_exclusive_and_right_join(sdata_query_aggregation):
     )
 
 
+def test_match_rows_join(sdata_query_aggregation):
+    reversed_instance_id = [3, 4, 5, 6, 7, 8, 1, 2, 0] + list(reversed(range(12)))
+    original_instance_id = sdata_query_aggregation.table.obs["instance_id"]
+    sdata_query_aggregation.table.obs["instance_id"] = reversed_instance_id
+
+    element_dict, table = join_sdata_spatialelement_table(
+        sdata_query_aggregation, ["values_circles", "values_polygons"], "table", "left", match_rows="left"
+    )
+    assert all(table.obs["instance_id"].values == original_instance_id.values)
+
+    element_dict, table = join_sdata_spatialelement_table(
+        sdata_query_aggregation, ["values_circles", "values_polygons"], "table", "right", match_rows="right"
+    )
+    indices = [*element_dict["values_circles"].index, *element_dict[("values_polygons")].index]
+    assert all(indices == table.obs["instance_id"])
+
+    element_dict, table = join_sdata_spatialelement_table(
+        sdata_query_aggregation, ["values_circles", "values_polygons"], "table", "inner", match_rows="left"
+    )
+    assert all(table.obs["instance_id"].values == original_instance_id.values)
+
+    element_dict, table = join_sdata_spatialelement_table(
+        sdata_query_aggregation, ["values_circles", "values_polygons"], "table", "inner", match_rows="right"
+    )
+    indices = [*element_dict["values_circles"].index, *element_dict[("values_polygons")].index]
+    assert all(indices == table.obs["instance_id"])
+
+
 def test_locate_value(sdata_query_aggregation):
     def _check_location(locations: list[_ValueOrigin], origin: str, is_categorical: bool):
         assert len(locations) == 1

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -86,7 +86,7 @@ def test_join_spatialelement_table_fail(full_sdata):
         join_sdata_spatialelement_table(full_sdata, ["image2d", "labels2d"], "table", "left_exclusive")
     with pytest.warns(UserWarning, match="Tables:"):
         join_sdata_spatialelement_table(full_sdata, ["labels2d", "table"], "table", "left_exclusive")
-    with pytest.raises(ValueError, match="`not_join` is not a"):
+    with pytest.raises(TypeError, match="`not_join` is not a"):
         join_sdata_spatialelement_table(full_sdata, "labels2d", "table", "not_join")
 
 

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -78,7 +78,13 @@ def test_left_inner_right_exclusive_join(sdata_query_aggregation):
     assert element_dict["by_polygons"] is None
 
 
-# def test_join_spatialelement_table_fail(full_sdata):
+def test_join_spatialelement_table_fail(full_sdata):
+    with pytest.warns(UserWarning, match="Images:"):
+        join_sdata_spatialelement_table(full_sdata, ["image2d", "labels2d"], "table", "left_exclusive")
+    with pytest.warns(UserWarning, match="Tables:"):
+        join_sdata_spatialelement_table(full_sdata, ["labels2d", "table"], "table", "left_exclusive")
+    with pytest.raises(ValueError, match="`not_join` is not a"):
+        join_sdata_spatialelement_table(full_sdata, "labels2d", "table", "not_join")
 
 
 def test_left_exclusive_and_right_join(sdata_query_aggregation):

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -121,10 +121,12 @@ def test_left_exclusive_and_right_join(sdata_query_aggregation):
     )
     assert table is None
     assert not np.array_equal(
-        sdata_query_aggregation["table"].obs.iloc[7:9, 1].values, element_dict["values_circles"].index.values
+        sdata_query_aggregation["table"].obs.iloc[7:9]["instance_id"].values,
+        element_dict["values_circles"].index.values,
     )
     assert not np.array_equal(
-        sdata_query_aggregation["table"].obs.iloc[19:21, 1].values, element_dict["values_polygons"].index.values
+        sdata_query_aggregation["table"].obs.iloc[19:21]["instance_id"].values,
+        element_dict["values_polygons"].index.values,
     )
 
 

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -401,7 +401,6 @@ def test_points_table_joins(full_sdata):
     assert all(element_dict["points_0"].index.values.compute() == list(reversed(range(100))))
     assert all(table.obs["instance_id"] == list(reversed(range(100))))
 
-
     element_dict, table = join_sdata_spatialelement_table(full_sdata, "points_0", "table", "right_exclusive")
     assert element_dict["points_0"] is None
     assert table is None

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -8,12 +8,6 @@ from spatialdata.models.models import TableModel
 
 
 def test_match_table_to_element(sdata_query_aggregation):
-    # table can't annotate points
-    with pytest.raises(AssertionError):
-        match_table_to_element(sdata=sdata_query_aggregation, element_name="points")
-    # table is not annotating "by_circles"
-    with pytest.raises(AssertionError, match="No row matches in the table annotates the element"):
-        match_table_to_element(sdata=sdata_query_aggregation, element_name="by_circles")
     matched_table = match_table_to_element(sdata=sdata_query_aggregation, element_name="values_circles")
     arr = np.array(list(reversed(sdata_query_aggregation["values_circles"].index)))
     sdata_query_aggregation["values_circles"].index = arr

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -337,3 +337,32 @@ def test_filter_table_categorical_bug(shapes):
     adata_subset = adata[adata.obs["categorical"] == "a"].copy()
     shapes.table = adata_subset
     shapes.filter_by_coordinate_system("global")
+
+
+def test_labels_table_joins(full_sdata):
+    element_dict, table = join_sdata_spatialelement_table(
+        full_sdata,
+        "labels2d",
+        "table",
+        "left",
+    )
+    assert all(table.obs["instance_id"] == range(100))
+
+    full_sdata["table"].obs.sample(frac=1).reset_index(drop=True)
+
+    element_dict, table = join_sdata_spatialelement_table(full_sdata, "labels2d", "table", "left", match_rows="left")
+    assert all(table.obs["instance_id"] == range(100))
+
+    with pytest.warns(UserWarning, match="Element type"):
+        join_sdata_spatialelement_table(full_sdata, "labels2d", "table", "left_exclusive")
+
+    with pytest.warns(UserWarning, match="Element type"):
+        join_sdata_spatialelement_table(full_sdata, "labels2d", "table", "inner")
+
+    with pytest.warns(UserWarning, match="Element type"):
+        join_sdata_spatialelement_table(full_sdata, "labels2d", "table", "right")
+
+    # all labels are present in table so shoudl return None
+    element_dict, table = join_sdata_spatialelement_table(full_sdata, "labels2d", "table", "right_exclusive")
+    assert element_dict["labels2d"] is None
+    assert table is None

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -23,7 +23,7 @@ def test_match_table_to_element(sdata_query_aggregation):
     # TODO: add tests for labels
 
 
-def test_left_join(sdata_query_aggregation):
+def test_left_and_inner_join(sdata_query_aggregation):
     sdata_query_aggregation["values_polygons"] = sdata_query_aggregation["values_polygons"].drop([10, 11])
     with pytest.raises(AssertionError, match="No table with"):
         join_sdata_spatialelement_table(sdata_query_aggregation, "values_polygons", "not_existing_table", "left")
@@ -48,6 +48,14 @@ def test_left_join(sdata_query_aggregation):
     sdata_query_aggregation["values_circles"] = sdata_query_aggregation["values_circles"].drop([7, 8])
     element_dict, table = join_sdata_spatialelement_table(
         sdata_query_aggregation, ["values_circles", "values_polygons"], "table", "left"
+    )
+    indices = pd.concat(
+        [element_dict["values_circles"].index.to_series(), element_dict["values_polygons"].index.to_series()]
+    )
+    assert all(table.obs["instance_id"] == indices.values)
+
+    element_dict, table = join_sdata_spatialelement_table(
+        sdata_query_aggregation, ["values_circles", "values_polygons"], "table", "inner"
     )
     indices = pd.concat(
         [element_dict["values_circles"].index.to_series(), element_dict["values_polygons"].index.to_series()]

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -159,6 +159,12 @@ def test_match_rows_join(sdata_query_aggregation):
     indices = [*element_dict["values_circles"].index, *element_dict[("values_polygons")].index]
     assert all(indices == table.obs["instance_id"])
 
+    # check whether table ordering is preserved if not matching
+    element_dict, table = join_sdata_spatialelement_table(
+        sdata_query_aggregation, ["values_circles", "values_polygons"], "table", "left"
+    )
+    assert all(table.obs["instance_id"] == reversed_instance_id)
+
 
 def test_locate_value(sdata_query_aggregation):
     def _check_location(locations: list[_ValueOrigin], origin: str, is_categorical: bool):

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -397,6 +397,11 @@ def test_points_table_joins(full_sdata):
     assert len(element_dict["points_0"]) == 100
     assert all(table.obs["instance_id"] == list(reversed(range(100))))
 
+    element_dict, table = join_sdata_spatialelement_table(full_sdata, "points_0", "table", "right", match_rows="right")
+    assert all(element_dict["points_0"].index.values.compute() == list(reversed(range(100))))
+    assert all(table.obs["instance_id"] == list(reversed(range(100))))
+
+
     element_dict, table = join_sdata_spatialelement_table(full_sdata, "points_0", "table", "right_exclusive")
     assert element_dict["points_0"] is None
     assert table is None

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -66,6 +66,8 @@ def test_left_inner_right_exclusive_join(sdata_query_aggregation):
         )
     assert all(element_dict[key] is None for key in element_dict)
     assert all(table.obs.index == ["7", "8", "19", "20"])
+    assert all(table.obs["instance_id"].values == [7, 8, 10, 11])
+    assert all(table.obs["region"].values == ["values_circles", "values_circles", "values_polygons", "values_polygons"])
 
     # the triggered warning is: UserWarning: The element `{name}` is not annotated by the table. Skipping
     with pytest.warns(UserWarning, match="The element"):

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -348,7 +348,7 @@ def test_labels_table_joins(full_sdata):
     )
     assert all(table.obs["instance_id"] == range(100))
 
-    full_sdata["table"].obs.sample(frac=1).reset_index(drop=True)
+    full_sdata["table"].obs["instance_id"] = list(reversed(range(100)))
 
     element_dict, table = join_sdata_spatialelement_table(full_sdata, "labels2d", "table", "left", match_rows="left")
     assert all(table.obs["instance_id"] == range(100))
@@ -365,4 +365,38 @@ def test_labels_table_joins(full_sdata):
     # all labels are present in table so shoudl return None
     element_dict, table = join_sdata_spatialelement_table(full_sdata, "labels2d", "table", "right_exclusive")
     assert element_dict["labels2d"] is None
+    assert table is None
+
+
+def test_points_table_joins(full_sdata):
+    full_sdata["table"].uns["spatialdata_attrs"]["region"] = "points_0"
+    full_sdata["table"].obs["region"] = ["points_0"] * 100
+
+    element_dict, table = join_sdata_spatialelement_table(full_sdata, "points_0", "table", "left")
+
+    # points should have the same number of rows as before and table as well
+    assert len(element_dict["points_0"]) == 300
+    assert all(table.obs["instance_id"] == range(100))
+
+    full_sdata["table"].obs["instance_id"] = list(reversed(range(100)))
+
+    element_dict, table = join_sdata_spatialelement_table(full_sdata, "points_0", "table", "left", match_rows="left")
+    assert len(element_dict["points_0"]) == 300
+    assert all(table.obs["instance_id"] == range(100))
+
+    # We have 100 table instances so resulting length of points should be 200 as we started with 300
+    element_dict, table = join_sdata_spatialelement_table(full_sdata, "points_0", "table", "left_exclusive")
+    assert len(element_dict["points_0"]) == 200
+    assert table is None
+
+    element_dict, table = join_sdata_spatialelement_table(full_sdata, "points_0", "table", "inner")
+    assert len(element_dict["points_0"]) == 100
+    assert all(table.obs["instance_id"] == list(reversed(range(100))))
+
+    element_dict, table = join_sdata_spatialelement_table(full_sdata, "points_0", "table", "right")
+    assert len(element_dict["points_0"]) == 100
+    assert all(table.obs["instance_id"] == list(reversed(range(100))))
+
+    element_dict, table = join_sdata_spatialelement_table(full_sdata, "points_0", "table", "right_exclusive")
+    assert element_dict["points_0"] is None
     assert table is None

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -67,6 +67,7 @@ def test_left_inner_right_exclusive_join(sdata_query_aggregation):
     assert all(element_dict[key] is None for key in element_dict)
     assert all(table.obs.index == ["7", "8", "19", "20"])
 
+    # the triggered warning is: UserWarning: The element `{name}` is not annotated by the table. Skipping
     with pytest.warns(UserWarning, match="The element"):
         element_dict, table = join_sdata_spatialelement_table(
             sdata_query_aggregation, ["values_circles", "values_polygons", "by_polygons"], "table", "inner"
@@ -95,7 +96,7 @@ def test_left_exclusive_and_right_join(sdata_query_aggregation):
     assert all(element_dict[key] is None for key in element_dict)
     assert table is None
 
-    # Dropped indices correspond to instance ids 7, 8, 10 and 11
+    # Dropped indices correspond to instance ids 7, 8 for 'values_circles' and 10, 11 for 'values_polygons'
     sdata_query_aggregation["table"] = sdata_query_aggregation["table"][
         sdata_query_aggregation["table"].obs.index.drop(["7", "8", "19", "20"])
     ]


### PR DESCRIPTION
Depends on #444 

This PR adds the possibility of SQL like joins for `SpatialElement`(s) and tables. These functions are private but are accessible through one public function and will replace the current `match_table_to_element`. In case a join would result in an empty dataframe or `AnnData` table, `None` is returned for the specific element. A table can be joined to multiple `SpatialElement` at the time. Joins with of table and images and table to table are not supported through the public function.

Currently, labels are only supported for those joins that do not require filtering of the labels, for example, a `left` join. The joins that are currently supported are `left`, `left_exclusive`, `inner`, `right` and `right_exclusive`.

A further refactor and docstrings will be added once initial review has passed.