### PR TITLE
Added `transform_to_data_extent()`, improved `transform()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,18 @@ and this project adheres to [Semantic Versioning][].
 
 ## [0.0.x] - tbd
 
-### Minor
-
--   improved usability and robustness of sdata.write() when overwrite=True @aeisenbarth
-
 ### Added
 
 -   added SpatialData.subset() API
 -   added SpatialData.locate_element() API
+-   added transform_to_data_extent()
+-   added utils function: are_extents_equal()
+-   added utils function: postpone_transformation()
+-   added utils function: remove_transformations_to_coordinate_system()
+
+### Minor
+
+-   improved usability and robustness of sdata.write() when overwrite=True @aeisenbarth
 
 ### Fixed
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,6 +32,7 @@ Operations on `SpatialData` objects.
     transform
     rasterize
     aggregate
+    filter_by_coordinate_system
 ```
 
 ### Operations Utilities

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,6 +41,7 @@ Operations on `SpatialData` objects.
     :toctree: generated
 
     unpad_raster
+    are_extents_equal
 ```
 
 ## Models
@@ -111,6 +112,7 @@ The transformations that can be defined between elements and coordinate systems 
     get_transformation_between_coordinate_systems
     get_transformation_between_landmarks
     align_elements_using_landmarks
+    remove_transformations_to_coordinate_system
 ```
 
 ## DataLoader

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,7 +32,6 @@ Operations on `SpatialData` objects.
     transform
     rasterize
     aggregate
-    filter_by_coordinate_system
 ```
 
 ### Operations Utilities

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -29,11 +29,12 @@ __all__ = [
     "unpad_raster",
     "save_transformations",
     "get_dask_backing_files",
+    "are_extents_equal",
 ]
 
 from spatialdata import dataloader, models, transformations
 from spatialdata._core.concatenate import concatenate
-from spatialdata._core.data_extent import get_extent
+from spatialdata._core.data_extent import are_extents_equal, get_extent
 from spatialdata._core.operations.aggregate import aggregate
 from spatialdata._core.operations.rasterize import rasterize
 from spatialdata._core.operations.transform import transform

--- a/src/spatialdata/_core/data_extent.py
+++ b/src/spatialdata/_core/data_extent.py
@@ -360,7 +360,6 @@ def _compute_extent_in_coordinate_system(
     )
     df = pd.DataFrame(corners.data, columns=corners.axis.data.tolist())
     d = get_transformation(element, get_all=True)
-    assert isinstance(d, dict)
     points = PointsModel.parse(df, coordinates={k: k for k in axes}, transformations=d)
     transformed_corners = pd.DataFrame(transform(points, to_coordinate_system=coordinate_system).compute())
     # Make sure min and max values are in the same order as axes

--- a/src/spatialdata/_core/data_extent.py
+++ b/src/spatialdata/_core/data_extent.py
@@ -289,9 +289,7 @@ def _(e: GeoDataFrame, coordinate_system: str = "global", exact: bool = True) ->
             coordinate_system=coordinate_system,
             extent=extent,
         )
-    t = get_transformation(e, to_coordinate_system=coordinate_system)
-    assert isinstance(t, BaseTransformation)
-    transformed = transform(e, t)
+    transformed = transform(e, to_coordinate_system=coordinate_system)
     return _get_extent_of_shapes(transformed)
 
 
@@ -305,9 +303,7 @@ def _(e: DaskDataFrame, coordinate_system: str = "global", exact: bool = True) -
             coordinate_system=coordinate_system,
             extent=extent,
         )
-    t = get_transformation(e, to_coordinate_system=coordinate_system)
-    assert isinstance(t, BaseTransformation)
-    transformed = transform(e, t)
+    transformed = transform(e, to_coordinate_system=coordinate_system)
     return _get_extent_of_points(transformed)
 
 

--- a/src/spatialdata/_core/data_extent.py
+++ b/src/spatialdata/_core/data_extent.py
@@ -171,7 +171,7 @@ def get_extent(
     The exact extent is the bounding box `[minx, miny, maxx, maxy] = [0, 0, 0, 1.414]`, while the approximate extent is
     the box `[minx, miny, maxx, maxy] = [-0.707, 0, 0.707, 1.414]`.
     """
-    raise ValueError("The object type is not supported.")
+    raise ValueError(f"The object type {type(e)} is not supported.")
 
 
 @get_extent.register
@@ -369,16 +369,16 @@ def _compute_extent_in_coordinate_system(
     return extent
 
 
-def are_extents_equal(sdata0: SpatialData, sdata1: SpatialData, atol: float = 0.1) -> bool:
+def are_extents_equal(extent0: BoundingBoxDescription, extent1: BoundingBoxDescription, atol: float = 0.1) -> bool:
     """
-    Check if the extents of two SpatialData objects are equal.
+    Check if two data extents, as returned by `get_extent()` are equal up to approximation errors.
 
     Parameters
     ----------
-    sdata0
-        The first SpatialData object.
-    sdata1
-        The second SpatialData object.
+    extent0
+        The first data extent.
+    extent1
+        The second data extent.
     atol
         The absolute tolerance to use when comparing the extents.
 
@@ -392,6 +392,4 @@ def are_extents_equal(sdata0: SpatialData, sdata1: SpatialData, atol: float = 0.
     rasterized data slightly different from the extent of the original data. This bug is tracked in
     https://github.com/scverse/spatialdata/issues/165
     """
-    e0 = get_extent(sdata0)
-    e1 = get_extent(sdata1, coordinate_system="transformed_back")
-    return all(np.allclose(e0[k], e1[k], atol=atol) for k in set(e0.keys()).union(e1.keys()))
+    return all(np.allclose(extent0[k], extent1[k], atol=atol) for k in set(extent0.keys()).union(extent1.keys()))

--- a/src/spatialdata/_core/data_extent.py
+++ b/src/spatialdata/_core/data_extent.py
@@ -367,3 +367,31 @@ def _compute_extent_in_coordinate_system(
     for ax in axes:
         extent[ax] = (transformed_corners[ax].min(), transformed_corners[ax].max())
     return extent
+
+
+def are_extents_equal(sdata0: SpatialData, sdata1: SpatialData, atol: float = 0.1) -> bool:
+    """
+    Check if the extents of two SpatialData objects are equal.
+
+    Parameters
+    ----------
+    sdata0
+        The first SpatialData object.
+    sdata1
+        The second SpatialData object.
+    atol
+        The absolute tolerance to use when comparing the extents.
+
+    Returns
+    -------
+    Whether the extents are equal or not.
+
+    Notes
+    -----
+    The default value of `atol` is currently high because of a bug of `rasterize()` that makes the extent of the
+    rasterized data slightly different from the extent of the original data. This bug is tracked in
+    https://github.com/scverse/spatialdata/issues/165
+    """
+    e0 = get_extent(sdata0)
+    e1 = get_extent(sdata1, coordinate_system="transformed_back")
+    return all(np.allclose(e0[k], e1[k], atol=atol) for k in set(e0.keys()).union(e1.keys()))

--- a/src/spatialdata/_core/operations/_utils.py
+++ b/src/spatialdata/_core/operations/_utils.py
@@ -63,24 +63,27 @@ def transform_to_data_extent(
     sdata_raster = SpatialData(images=dict(sdata.images), labels=dict(sdata.labels))
     sdata_vector_transformed = sdata_vector.transform_to_coordinate_system(coordinate_system)
 
-    de = get_extent(sdata, coordinate_system=coordinate_system)
-    de_axes = tuple(de.keys())
-    translation_to_origin = Translation([-de[ax][0] for ax in de_axes], axes=de_axes)
+    data_extent = get_extent(sdata, coordinate_system=coordinate_system)
+    data_extent_axes = tuple(data_extent.keys())
+    translation_to_origin = Translation([-data_extent[ax][0] for ax in data_extent_axes], axes=data_extent_axes)
 
-    sizes = [de[ax][1] - de[ax][0] for ax in de_axes]
+    sizes = [data_extent[ax][1] - data_extent[ax][0] for ax in data_extent_axes]
     target_width, target_height, target_depth = _compute_target_dimensions(
-        spatial_axes=de_axes,
-        min_coordinate=[0 for _ in de_axes],
+        spatial_axes=data_extent_axes,
+        min_coordinate=[0 for _ in data_extent_axes],
         max_coordinate=sizes,
         target_unit_to_pixels=target_unit_to_pixels,
         target_width=target_width,
         target_height=target_height,
         target_depth=target_depth,
     )
-    scale_to_target_d = {"x": target_width / sizes[de_axes.index("x")], "y": target_height / sizes[de_axes.index("y")]}
+    scale_to_target_d = {
+        "x": target_width / sizes[data_extent_axes.index("x")],
+        "y": target_height / sizes[data_extent_axes.index("y")],
+    }
     if target_depth is not None:
-        scale_to_target_d["z"] = target_depth / sizes[de_axes.index("z")]
-    scale_to_target = Scale([scale_to_target_d[ax] for ax in de_axes], axes=de_axes)
+        scale_to_target_d["z"] = target_depth / sizes[data_extent_axes.index("z")]
+    scale_to_target = Scale([scale_to_target_d[ax] for ax in data_extent_axes], axes=data_extent_axes)
 
     for el in sdata_vector_transformed._gen_elements_values():
         t = get_transformation(el, to_coordinate_system=coordinate_system)
@@ -100,9 +103,9 @@ def transform_to_data_extent(
         if isinstance(element, (MultiscaleSpatialImage, SpatialImage)):
             rasterized = rasterize(
                 element,
-                axes=de_axes,
-                min_coordinate=[de[ax][0] for ax in de_axes],
-                max_coordinate=[de[ax][1] for ax in de_axes],
+                axes=data_extent_axes,
+                min_coordinate=[data_extent[ax][0] for ax in data_extent_axes],
+                max_coordinate=[data_extent[ax][1] for ax in data_extent_axes],
                 target_coordinate_system=coordinate_system,
                 target_unit_to_pixels=None,
                 target_width=target_width,

--- a/src/spatialdata/_core/operations/_utils.py
+++ b/src/spatialdata/_core/operations/_utils.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-import uuid
 from typing import TYPE_CHECKING
+
+from multiscale_spatial_image import MultiscaleSpatialImage
+from spatial_image import SpatialImage
 
 if TYPE_CHECKING:
     from spatialdata._core.spatialdata import SpatialData
@@ -16,23 +18,23 @@ def transform_to_data_extent(
     target_depth: float | None = None,
 ) -> SpatialData:
     """
-    Transform the spatial data to match the data extent and setting all the transformations to Identity.
+    Transform the spatial data to match the data extent, keeping the positioning, and making all transformations equal.
 
     Parameters
     ----------
     sdata
         The spatial data to transform.
     coordinate_system
-        The coordinate system to use to compute the extent and to transform the data.
+        The coordinate system to use to compute the extent and to transform the data to.
     target_unit_to_pixels
-        The number of pixels per unit of the target coordinate system.
+        The required number of pixels per unit (units in the target coordinate system) of the data that will be
+        produced.
     target_width
-        The width of the data extent in the units of the selected coordinate system
+        The width of the data extent, in pixels, for the data that will be produced.
     target_height
-        The height of the data extent in the units of the selected coordinate system
+        The height of the data extent, in pixels, for the data that will be produced.
     target_depth
-        The depth of the data extent in the units of the selected coordinate system
-
+        The depth of the data extent, in pixels, for the data that will be produced.
 
     Returns
     -------
@@ -50,12 +52,17 @@ def transform_to_data_extent(
     """
     # TODO: change "all the elements have idenity" with "all the elements have the same transformation"
     from spatialdata._core.data_extent import get_extent
-    from spatialdata._core.operations.rasterize import _compute_target_dimensions
+    from spatialdata._core.operations.rasterize import _compute_target_dimensions, rasterize
     from spatialdata._core.spatialdata import SpatialData
     from spatialdata.transformations.operations import get_transformation, set_transformation
     from spatialdata.transformations.transformations import BaseTransformation, Scale, Sequence, Translation
 
     sdata = sdata.filter_by_coordinate_system(coordinate_system=coordinate_system)
+    # calling transform_to_coordinate_system will likely decrease the resolution, let's use rasterize() instead
+    sdata_vector = SpatialData(shapes=dict(sdata.shapes), points=dict(sdata.points))
+    sdata_raster = SpatialData(images=dict(sdata.images), labels=dict(sdata.labels))
+    sdata_vector_transformed = sdata_vector.transform_to_coordinate_system(coordinate_system)
+
     de = get_extent(sdata, coordinate_system=coordinate_system)
     de_axes = tuple(de.keys())
     translation_to_origin = Translation([-de[ax][0] for ax in de_axes], axes=de_axes)
@@ -75,50 +82,36 @@ def transform_to_data_extent(
         scale_to_target_d["z"] = target_depth / sizes[de_axes.index("z")]
     scale_to_target = Scale([scale_to_target_d[ax] for ax in de_axes], axes=de_axes)
 
-    sdata_transformed = sdata.transform_to_coordinate_system(coordinate_system)
-
-    random_uuid = str(uuid.uuid4())
-    for el in sdata_transformed._gen_elements_values():
+    for el in sdata_vector_transformed._gen_elements_values():
         t = get_transformation(el, to_coordinate_system=coordinate_system)
         assert isinstance(t, BaseTransformation)
         sequence = Sequence([t, translation_to_origin, scale_to_target])
-        set_transformation(el, transformation=sequence, to_coordinate_system=random_uuid)
-    sdata_transformed_inplace = sdata_transformed.transform_to_coordinate_system(random_uuid, maintain_positioning=True)
-    print(get_extent(sdata_transformed_inplace, coordinate_system=random_uuid))
+        set_transformation(el, transformation=sequence, to_coordinate_system=coordinate_system)
+    sdata_vector_transformed_inplace = sdata_vector_transformed.transform_to_coordinate_system(
+        coordinate_system, maintain_positioning=True
+    )
 
-    sdata_to_return_elements = {}
+    sdata_to_return_elements = {
+        **sdata_vector_transformed_inplace.shapes,
+        **sdata_vector_transformed_inplace.points,
+    }
 
-    for _, element_name, element in sdata_transformed._gen_elements():
-        # debugging
-        sdata_to_return_elements[element_name] = element
-    #     # the call of transform_to_coordinate_system() above didn't remove any coordinate system but we just need
-    #     # the coordinate system `random_uuid`; let's remove all the other coordinate systems
-    #     t = get_transformation(element, to_coordinate_system=random_uuid)
-    #     assert isinstance(t, BaseTransformation)
-    #     set_transformation(element, transformation={random_uuid: t}, set_all=True)
-    #
-    #     # let's resample (with rasterize()) the raster data into the target dimensions, let's keep the vector data as
-    #     # it is (since it has been already transformed)
-    #     if isinstance(element, (MultiscaleSpatialImage, SpatialImage)):
-    #         rasterized = rasterize(
-    #             element,
-    #             axes=de_axes,
-    #             min_coordinate=[de[ax][0] for ax in de_axes],
-    #             max_coordinate=[de[ax][1] for ax in de_axes],
-    #             target_coordinate_system=random_uuid,
-    #             target_unit_to_pixels=None,
-    #             target_width=target_width,
-    #             target_height=None,
-    #             target_depth=None,
-    #         )
-    #         sdata_to_return_elements[element_name] = rasterized
-    #     else:
-    #         sdata_to_return_elements[element_name] = element
-    if sdata_transformed_inplace.table is not None:
-        sdata_to_return_elements["table"] = sdata_transformed_inplace.table
-    sdata_to_return = SpatialData.from_elements_dict(sdata_to_return_elements)
-
-    from napari_spatialdata import Interactive
-
-    Interactive([sdata_to_return, sdata, sdata_transformed])
-    pass
+    for _, element_name, element in sdata_raster._gen_elements():
+        if isinstance(element, (MultiscaleSpatialImage, SpatialImage)):
+            rasterized = rasterize(
+                element,
+                axes=de_axes,
+                min_coordinate=[de[ax][0] for ax in de_axes],
+                max_coordinate=[de[ax][1] for ax in de_axes],
+                target_coordinate_system=coordinate_system,
+                target_unit_to_pixels=None,
+                target_width=target_width,
+                target_height=None,
+                target_depth=None,
+            )
+            sdata_to_return_elements[element_name] = rasterized
+        else:
+            sdata_to_return_elements[element_name] = element
+    if sdata.table is not None:
+        sdata_to_return_elements["table"] = sdata.table
+    return SpatialData.from_elements_dict(sdata_to_return_elements)

--- a/src/spatialdata/_core/operations/_utils.py
+++ b/src/spatialdata/_core/operations/_utils.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spatialdata._core.spatialdata import SpatialData
+
+
+def transform_to_data_extent(
+    sdata: SpatialData,
+    coordinate_system: str,
+    target_unit_to_pixels: float | None = None,
+    target_width: float | None = None,
+    target_height: float | None = None,
+    target_depth: float | None = None,
+) -> SpatialData:
+    """
+    Transform the spatial data to match the data extent and setting all the transformations to Identity.
+
+    Parameters
+    ----------
+    sdata
+        The spatial data to transform.
+    coordinate_system
+        The coordinate system to use to compute the extent and to transform the data.
+    target_unit_to_pixels
+        The number of pixels per unit of the target coordinate system.
+    target_width
+        The width of the data extent in the units of the selected coordinate system
+    target_height
+        The height of the data extent in the units of the selected coordinate system
+    target_depth
+        The depth of the data extent in the units of the selected coordinate system
+
+
+    Returns
+    -------
+    SpatialData
+        The transformed spatial data with downscaled and padded images and adjusted vector coordinates; all the
+        transformations will set to Identity and the coordinates of the vector data will be aligned to the pixel
+        coordinates.
+
+    Notes
+    -----
+        - The data extent is the smallest rectangle that contains all the images and geometries.
+        - MultiscaleSpatialImage objects will be converted to SpatialImage objects.
+        - This helper function will be deprecated when https://github.com/scverse/spatialdata/issues/308 is closed,
+          as this function will be easily recovered by `transform_to_coordinate_system()`
+    """
+    # TODO: change "all the elements have idenity" with "all the elements have the same transformation"
+    from spatialdata._core.data_extent import get_extent
+    from spatialdata._core.operations.rasterize import _compute_target_dimensions
+    from spatialdata._core.spatialdata import SpatialData
+    from spatialdata.transformations.operations import get_transformation, set_transformation
+    from spatialdata.transformations.transformations import BaseTransformation, Scale, Sequence, Translation
+
+    sdata = sdata.filter_by_coordinate_system(coordinate_system=coordinate_system)
+    de = get_extent(sdata, coordinate_system=coordinate_system)
+    de_axes = tuple(de.keys())
+    translation_to_origin = Translation([-de[ax][0] for ax in de_axes], axes=de_axes)
+
+    sizes = [de[ax][1] - de[ax][0] for ax in de_axes]
+    target_width, target_height, target_depth = _compute_target_dimensions(
+        spatial_axes=de_axes,
+        min_coordinate=[0 for _ in de_axes],
+        max_coordinate=sizes,
+        target_unit_to_pixels=target_unit_to_pixels,
+        target_width=target_width,
+        target_height=target_height,
+        target_depth=target_depth,
+    )
+    scale_to_target_d = {"x": target_width / sizes[de_axes.index("x")], "y": target_height / sizes[de_axes.index("y")]}
+    if target_depth is not None:
+        scale_to_target_d["z"] = target_depth / sizes[de_axes.index("z")]
+    scale_to_target = Scale([scale_to_target_d[ax] for ax in de_axes], axes=de_axes)
+
+    sdata_transformed = sdata.transform_to_coordinate_system(coordinate_system)
+
+    random_uuid = str(uuid.uuid4())
+    for el in sdata_transformed._gen_elements_values():
+        t = get_transformation(el, to_coordinate_system=coordinate_system)
+        assert isinstance(t, BaseTransformation)
+        sequence = Sequence([t, translation_to_origin, scale_to_target])
+        set_transformation(el, transformation=sequence, to_coordinate_system=random_uuid)
+    sdata_transformed_inplace = sdata_transformed.transform_to_coordinate_system(random_uuid, maintain_positioning=True)
+    print(get_extent(sdata_transformed_inplace, coordinate_system=random_uuid))
+
+    sdata_to_return_elements = {}
+
+    for _, element_name, element in sdata_transformed._gen_elements():
+        # debugging
+        sdata_to_return_elements[element_name] = element
+    #     # the call of transform_to_coordinate_system() above didn't remove any coordinate system but we just need
+    #     # the coordinate system `random_uuid`; let's remove all the other coordinate systems
+    #     t = get_transformation(element, to_coordinate_system=random_uuid)
+    #     assert isinstance(t, BaseTransformation)
+    #     set_transformation(element, transformation={random_uuid: t}, set_all=True)
+    #
+    #     # let's resample (with rasterize()) the raster data into the target dimensions, let's keep the vector data as
+    #     # it is (since it has been already transformed)
+    #     if isinstance(element, (MultiscaleSpatialImage, SpatialImage)):
+    #         rasterized = rasterize(
+    #             element,
+    #             axes=de_axes,
+    #             min_coordinate=[de[ax][0] for ax in de_axes],
+    #             max_coordinate=[de[ax][1] for ax in de_axes],
+    #             target_coordinate_system=random_uuid,
+    #             target_unit_to_pixels=None,
+    #             target_width=target_width,
+    #             target_height=None,
+    #             target_depth=None,
+    #         )
+    #         sdata_to_return_elements[element_name] = rasterized
+    #     else:
+    #         sdata_to_return_elements[element_name] = element
+    if sdata_transformed_inplace.table is not None:
+        sdata_to_return_elements["table"] = sdata_transformed_inplace.table
+    sdata_to_return = SpatialData.from_elements_dict(sdata_to_return_elements)
+
+    from napari_spatialdata import Interactive
+
+    Interactive([sdata_to_return, sdata, sdata_transformed])
+    pass

--- a/src/spatialdata/_core/operations/aggregate.py
+++ b/src/spatialdata/_core/operations/aggregate.py
@@ -170,8 +170,8 @@ def aggregate(
         target_coordinate_system,  # type: ignore[assignment]
     )
     if not (by_transform == values_transform and isinstance(values_transform, Identity)):
-        by_ = transform(by_, by_transform)
-        values_ = transform(values_, values_transform)
+        by_ = transform(by_, to_coordinate_system=target_coordinate_system)
+        values_ = transform(values_, to_coordinate_system=target_coordinate_system)
 
     # dispatch
     adata = None

--- a/src/spatialdata/_core/operations/rasterize.py
+++ b/src/spatialdata/_core/operations/rasterize.py
@@ -448,7 +448,8 @@ def _(
     if schema in (Labels2DModel, Labels3DModel):
         kwargs = {"prefilter": False, "order": 0}
     elif schema in (Image2DModel, Image3DModel):
-        kwargs = {}
+        kwargs = {"order": 0}
+        # kwargs = {}
     else:
         raise ValueError(f"Unsupported schema {schema}")
 

--- a/src/spatialdata/_core/operations/rasterize.py
+++ b/src/spatialdata/_core/operations/rasterize.py
@@ -449,7 +449,6 @@ def _(
         kwargs = {"prefilter": False, "order": 0}
     elif schema in (Image2DModel, Image3DModel):
         kwargs = {"order": 0}
-        # kwargs = {}
     else:
         raise ValueError(f"Unsupported schema {schema}")
 

--- a/src/spatialdata/_core/operations/transform.py
+++ b/src/spatialdata/_core/operations/transform.py
@@ -228,18 +228,18 @@ def transform(
     maintain_positioning
         The default and recommended behavior is to leave this parameter to False.
 
-            - If True, in the transformed element, each transformation that was present in the original element will be
-              prepended with the inverse of the transformation used to transform the data (i.e. the current
-              transformation for which .transform() is called). In this way the data is transformed but the
-              positioning (for each coordinate system) is maintained. A use case is changing the orientation/scale/etc.
-              of the data but keeping the alignment of the data within each coordinate system.
+        - If True, in the transformed element, each transformation that was present in the original element will be
+            prepended with the inverse of the transformation used to transform the data (i.e. the current
+            transformation for which .transform() is called). In this way the data is transformed but the
+            positioning (for each coordinate system) is maintained. A use case is changing the
+            orientation/scale/etc. of the data but keeping the alignment of the data within each coordinate system.
 
-            - If False, the data is transformed and the positioning changes; only the coordinate system in which the
-              data is transformed to is kept. For raster data, the translation part of the transformation is assigned to
-              the element (see Notes below for more details). Furthermore, for raster data, the returned object will
-              have a translation to take into account for the pixel (0, 0) position. Also, rotated raster data will be
-              padded in the corners with a black color, such padding will be reflected into the rotation. Please
-               see notes for more details of how this parameter interact with xarray.DataArray for raster data.
+        - If False, the data is transformed and the positioning changes; only the coordinate system in which the
+            data is transformed to is kept. For raster data, the translation part of the transformation is assigned
+            to the element (see Notes below for more details). Furthermore, for raster data, the returned object
+            will have a translation to take into account for the pixel (0, 0) position. Also, rotated raster data
+            will be padded in the corners with a black color, such padding will be reflected into the rotation.
+            Please see notes for more details of how this parameter interact with xarray.DataArray for raster data.
 
     to_coordinate_system
         The coordinate system to which the data should be transformed. The coordinate system must be present in the

--- a/src/spatialdata/_core/operations/transform.py
+++ b/src/spatialdata/_core/operations/transform.py
@@ -157,13 +157,14 @@ def _adjust_transformations(
     assert isinstance(d[DEFAULT_COORDINATE_SYSTEM], Identity)
     remove_transformation(element, remove_all=True)
 
-    if maintain_positioning:
+    # if maintain_positioning:
+    if True:
         for cs, t in old_transformations.items():
             new_t: BaseTransformation
             new_t = Sequence([to_prepend, t])
             set_transformation(element, new_t, to_coordinate_system=cs)
-    else:
-        set_transformation(element, to_prepend, to_coordinate_system=DEFAULT_COORDINATE_SYSTEM)
+    # else:
+    #     set_transformation(element, to_prepend, to_coordinate_system=DEFAULT_COORDINATE_SYSTEM)
 
 
 @singledispatch
@@ -231,6 +232,7 @@ def _(data: SpatialImage, transformation: BaseTransformation, maintain_positioni
     c_coords = data.indexes["c"].values if "c" in data.indexes else None
     # mypy thinks that schema could be ShapesModel, PointsModel, ...
     transformed_data = schema.parse(transformed_dask, dims=axes, c_coords=c_coords)  # type: ignore[call-arg,arg-type]
+    assert isinstance(transformed_data, SpatialImage)
     old_transformations = get_transformation(data, get_all=True)
     assert isinstance(old_transformations, dict)
     _adjust_transformations(

--- a/src/spatialdata/_core/operations/transform.py
+++ b/src/spatialdata/_core/operations/transform.py
@@ -271,6 +271,7 @@ def _(
 
     get_axes_names(data)
     transformed_dict = {}
+    raster_translation: Translation | None = None
     for k, v in data.items():
         assert len(v) == 1
         xdata = v.values().__iter__().__next__()
@@ -282,9 +283,11 @@ def _(
             scale = _get_scale(xdata.attrs["transform"])
             composed = Sequence([scale, transformation, scale.inverse()])
 
-        transformed_dask, raster_translation = _transform_raster(
+        transformed_dask, raster_translation_single_scale = _transform_raster(
             data=xdata.data, axes=xdata.dims, transformation=composed, **kwargs
         )
+        if raster_translation is None:
+            raster_translation = raster_translation_single_scale
         # we set a dummy empty dict for the transformation that will be replaced with the correct transformation for
         # each scale later in this function, when calling set_transformation()
         transformed_dict[k] = SpatialImage(

--- a/src/spatialdata/_core/query/spatial_query.py
+++ b/src/spatialdata/_core/query/spatial_query.py
@@ -523,7 +523,6 @@ def _(
     target_coordinate_system: str,
 ) -> DaskDataFrame | None:
     from spatialdata import transform
-    from spatialdata.transformations import BaseTransformation, get_transformation
 
     min_coordinate = _parse_list_into_array(min_coordinate)
     max_coordinate = _parse_list_into_array(max_coordinate)
@@ -572,10 +571,8 @@ def _(
     points_in_intrinsic_bounding_box = points_in_intrinsic_bounding_box.drop(columns=["idx"])
 
     # transform the element to the query coordinate system
-    transform_to_query_space = get_transformation(points, to_coordinate_system=target_coordinate_system)
-    assert isinstance(transform_to_query_space, BaseTransformation)
     points_query_coordinate_system = transform(
-        points_in_intrinsic_bounding_box, transform_to_query_space, maintain_positioning=False
+        points_in_intrinsic_bounding_box, to_coordinate_system=target_coordinate_system, maintain_positioning=False
     )  # type: ignore[union-attr]
 
     # get a mask for the points in the bounding box

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -510,15 +510,19 @@ class SpatialData:
 
         t = get_transformation_between_coordinate_systems(self, element, target_coordinate_system)
         if maintain_positioning:
-            transformed = transform(element, t, maintain_positioning=maintain_positioning)
+            transformed = transform(element, transformation=t, maintain_positioning=maintain_positioning)
         else:
             d = get_transformation(element, get_all=True)
             assert isinstance(d, dict)
+            to_remove = False
             if target_coordinate_system not in d:
                 d[target_coordinate_system] = t
+                to_remove = True
             transformed = transform(
                 element, to_coordinate_system=target_coordinate_system, maintain_positioning=maintain_positioning
             )
+            if to_remove:
+                del d[target_coordinate_system]
         if not maintain_positioning:
             d = get_transformation(transformed, get_all=True)
             assert isinstance(d, dict)

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -513,6 +513,7 @@ class SpatialData:
             transformed = transform(element, transformation=t, maintain_positioning=maintain_positioning)
         else:
             d = get_transformation(element, get_all=True)
+            assert isinstance(d, dict)
             to_remove = False
             if target_coordinate_system not in d:
                 d[target_coordinate_system] = t
@@ -524,6 +525,7 @@ class SpatialData:
                 del d[target_coordinate_system]
         if not maintain_positioning:
             d = get_transformation(transformed, get_all=True)
+            assert isinstance(d, dict)
             assert len(d) == 1
             t = list(d.values())[0]
             remove_transformation(transformed, remove_all=True)
@@ -534,6 +536,7 @@ class SpatialData:
             # system), then the transformation to the target coordinate system is not needed # because the data is now
             # already transformed; here we remove such transformation.
             d = get_transformation(transformed, get_all=True)
+            assert isinstance(d, dict)
             if target_coordinate_system in d:
                 # Because of how spatialdata._core.operations.transform._adjust_transformations() is implemented, we
                 # know that the transformation tt below is a sequence of transformations with two transformations,

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -513,7 +513,6 @@ class SpatialData:
             transformed = transform(element, transformation=t, maintain_positioning=maintain_positioning)
         else:
             d = get_transformation(element, get_all=True)
-            assert isinstance(d, dict)
             to_remove = False
             if target_coordinate_system not in d:
                 d[target_coordinate_system] = t
@@ -525,7 +524,6 @@ class SpatialData:
                 del d[target_coordinate_system]
         if not maintain_positioning:
             d = get_transformation(transformed, get_all=True)
-            assert isinstance(d, dict)
             assert len(d) == 1
             t = list(d.values())[0]
             remove_transformation(transformed, remove_all=True)
@@ -536,7 +534,6 @@ class SpatialData:
             # system), then the transformation to the target coordinate system is not needed # because the data is now
             # already transformed; here we remove such transformation.
             d = get_transformation(transformed, get_all=True)
-            assert isinstance(d, dict)
             if target_coordinate_system in d:
                 # Because of how spatialdata._core.operations.transform._adjust_transformations() is implemented, we
                 # know that the transformation tt below is a sequence of transformations with two transformations,

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -479,7 +479,7 @@ class SpatialData:
             set_transformation(element=element, transformation=new_transformations, set_all=True)
 
     def transform_element_to_coordinate_system(
-        self, element: SpatialElement, target_coordinate_system: str
+        self, element: SpatialElement, target_coordinate_system: str, maintain_positioning: bool = False
     ) -> SpatialElement:
         """
         Transform an element to a given coordinate system.
@@ -490,29 +490,61 @@ class SpatialData:
             The element to transform.
         target_coordinate_system
             The target coordinate system.
+        maintain_positioning
+            Default False (most common use case). If True, the data will be transformed but a transformation will be
+            added so that the positioning of the data in the target coordinate system will not change. If you want to
+            align datasets to a common coordinate system you should use the default value.
 
         Returns
         -------
         The transformed element.
         """
         from spatialdata import transform
-        from spatialdata.transformations import Identity
+        from spatialdata.models._utils import DEFAULT_COORDINATE_SYSTEM
+        from spatialdata.transformations import Sequence
         from spatialdata.transformations.operations import (
+            get_transformation,
             get_transformation_between_coordinate_systems,
             remove_transformation,
             set_transformation,
         )
 
         t = get_transformation_between_coordinate_systems(self, element, target_coordinate_system)
-        transformed = transform(element, t, maintain_positioning=False)
-        remove_transformation(transformed, remove_all=True)
-        set_transformation(transformed, Identity(), target_coordinate_system)
-
+        transformed = transform(element, t, maintain_positioning=maintain_positioning)
+        if not maintain_positioning:
+            d = get_transformation(transformed, get_all=True)
+            assert isinstance(d, dict)
+            assert len(d) == 1
+            assert list(d.keys())[0] == DEFAULT_COORDINATE_SYSTEM
+            t = d[DEFAULT_COORDINATE_SYSTEM]
+            remove_transformation(transformed, remove_all=True)
+            set_transformation(transformed, t, target_coordinate_system)
+        else:
+            # When maintaining positioning is true, and if the element has a transformation to target_coordinate_system
+            # (this may not be the case because it could be that the element is not directly mapped to that coordinate
+            # system), then the transformation to the target coordinate system is not needed # because the data is now
+            # already transformed; here we remove such transformation.
+            d = get_transformation(transformed, get_all=True)
+            assert isinstance(d, dict)
+            if target_coordinate_system in d:
+                # Because of how spatialdata._core.operations.transform._adjust_transformations() is implemented, we
+                # know that the transformation tt below is a sequence of transformations with two transformations,
+                # with the second transformation equal to t.transformations[0]. Let's remove the second transformation.
+                # since target_coordinate_system is in d, we have that t is a Sequence with only one transformation.
+                assert isinstance(t, Sequence)
+                assert len(t.transformations) == 1
+                seq = get_transformation(transformed, to_coordinate_system=target_coordinate_system)
+                assert isinstance(seq, Sequence)
+                assert len(seq.transformations) == 2
+                assert seq.transformations[1] is t.transformations[0]
+                new_tt = seq.transformations[0]
+                set_transformation(transformed, new_tt, target_coordinate_system)
         return transformed
 
     def transform_to_coordinate_system(
         self,
         target_coordinate_system: str,
+        maintain_positioning: bool = False,
     ) -> SpatialData:
         """
         Transform the SpatialData to a given coordinate system.
@@ -521,6 +553,10 @@ class SpatialData:
         ----------
         target_coordinate_system
             The target coordinate system.
+        maintain_positioning
+            Default False (most common use case). If True, the data will be transformed but a transformation will be
+            added so that the positioning of the data in the target coordinate system will not change. If you want to
+            align datasets to a common coordinate system you should use the default value.
 
         Returns
         -------
@@ -529,7 +565,9 @@ class SpatialData:
         sdata = self.filter_by_coordinate_system(target_coordinate_system, filter_table=False)
         elements: dict[str, dict[str, SpatialElement]] = {}
         for element_type, element_name, element in sdata._gen_elements():
-            transformed = sdata.transform_element_to_coordinate_system(element, target_coordinate_system)
+            transformed = sdata.transform_element_to_coordinate_system(
+                element, target_coordinate_system, maintain_positioning=maintain_positioning
+            )
             if element_type not in elements:
                 elements[element_type] = {}
             elements[element_type][element_name] = transformed

--- a/src/spatialdata/transformations/__init__.py
+++ b/src/spatialdata/transformations/__init__.py
@@ -4,6 +4,7 @@ from spatialdata.transformations.operations import (
     get_transformation_between_coordinate_systems,
     get_transformation_between_landmarks,
     remove_transformation,
+    remove_transformations_to_coordinate_system,
     set_transformation,
 )
 from spatialdata.transformations.transformations import (
@@ -30,4 +31,5 @@ __all__ = [
     "get_transformation_between_coordinate_systems",
     "get_transformation_between_landmarks",
     "align_elements_using_landmarks",
+    "remove_transformations_to_coordinate_system",
 ]

--- a/src/spatialdata/transformations/operations.py
+++ b/src/spatialdata/transformations/operations.py
@@ -460,3 +460,18 @@ def align_elements_using_landmarks(
             reference_element, new_reference_transformation, new_coordinate_system, write_to_sdata=write_to_sdata
         )
     return new_moving_transformation
+
+
+def remove_transformations_to_coordinate_system(sdata: SpatialData, coordinate_system: str) -> None:
+    """
+    Remove (inplace) all transformations to a specific coordinate system from all the elements of a SpatialData object.
+
+    Parameters
+    ----------
+    sdata
+        The SpatialData object.
+    coordinate_system
+        The coordinate system to remove the transformations from.
+    """
+    for element in sdata._gen_elements_values():
+        remove_transformation(element, coordinate_system)

--- a/src/spatialdata/transformations/operations.py
+++ b/src/spatialdata/transformations/operations.py
@@ -371,7 +371,8 @@ def get_transformation_between_landmarks(
             input_axes=("x", "y"),
             output_axes=("x", "y"),
         )
-        flipped_moving = transform(moving_coords, flip, maintain_positioning=False)
+        set_transformation(moving_coords, transformation=flip, to_coordinate_system="flipped")
+        flipped_moving = transform(moving_coords, to_coordinate_system="flipped")
         if isinstance(flipped_moving, GeoDataFrame):
             flipped_moving_xy = np.stack([flipped_moving.geometry.x, flipped_moving.geometry.y], axis=1)
         elif isinstance(flipped_moving, DaskDataFrame):

--- a/src/spatialdata/transformations/operations.py
+++ b/src/spatialdata/transformations/operations.py
@@ -64,8 +64,10 @@ def set_transformation(
             transformations[to_coordinate_system] = transformation
             _set_transformations(element, transformations)
         else:
-            assert isinstance(transformation, dict)
-            assert to_coordinate_system is None
+            assert isinstance(transformation, dict), (
+                "If set_all=True, transformation must be of type " "dict[str, BaseTransformation]."
+            )
+            assert to_coordinate_system is None, "If set_all=True, to_coordinate_system must be None."
             _set_transformations(element, transformation)
     else:
         if len(write_to_sdata.locate_element(element)) == 0:
@@ -117,7 +119,7 @@ def get_transformation(
             raise ValueError(f"Transformation to {to_coordinate_system} not found in element {element}.")
         return transformations[to_coordinate_system]
     else:
-        assert to_coordinate_system is None
+        assert to_coordinate_system is None, "If get_all=True, to_coordinate_system must be None."
         # get the dict of all the transformations
         return transformations
 
@@ -161,7 +163,7 @@ def remove_transformation(
             del transformations[to_coordinate_system]
             _set_transformations(element, transformations)
         else:
-            assert to_coordinate_system is None
+            assert to_coordinate_system is None, "If remove_all=True, to_coordinate_system must be None."
             _set_transformations(element, {})
     else:
         if len(write_to_sdata.locate_element(element)) == 0:

--- a/tests/core/operations/test_spatialdata_operations.py
+++ b/tests/core/operations/test_spatialdata_operations.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import numpy as np
 import pytest
 from anndata import AnnData
@@ -9,6 +11,7 @@ from geopandas import GeoDataFrame
 from multiscale_spatial_image import MultiscaleSpatialImage
 from spatial_image import SpatialImage
 from spatialdata._core.concatenate import _concatenate_tables, concatenate
+from spatialdata._core.operations._utils import transform_to_data_extent
 from spatialdata._core.spatialdata import SpatialData
 from spatialdata.datasets import blobs
 from spatialdata.models import (
@@ -19,7 +22,7 @@ from spatialdata.models import (
     TableModel,
 )
 from spatialdata.transformations.operations import get_transformation, set_transformation
-from spatialdata.transformations.transformations import Identity, Scale
+from spatialdata.transformations.transformations import Affine, Identity, Scale, Sequence, Translation
 
 from tests.conftest import _get_table
 
@@ -385,3 +388,25 @@ def test_subset(full_sdata: SpatialData) -> None:
     assert subset1.table is not None
     assert len(subset1.table) == 5
     assert subset1.table.obs["region"].unique().tolist() == ["poly"]
+
+
+def test_transform_to_data_extent(full_sdata: SpatialData):
+    theta = math.pi / 6
+    rotation = Affine(
+        [
+            [math.cos(theta), -math.sin(theta), 0],
+            [math.sin(theta), math.cos(theta), 0],
+            [0, 0, 1],
+        ],
+        input_axes=("x", "y"),
+        output_axes=("x", "y"),
+    )
+    scale = Scale([2.0], axes=("x",))
+    translation = Translation([-100.0, 200.0], axes=("x", "y"))
+    sequence = Sequence([rotation, scale, translation])
+    for el in full_sdata._gen_elements_values():
+        set_transformation(el, sequence, "global")
+    full_sdata = full_sdata.subset(
+        ["image2d", "image2d_multiscale", "labels2d", "labels2d_multiscale", "points_0", "circles", "multipoly", "poly"]
+    )
+    sdata = transform_to_data_extent(full_sdata, "global", target_width=1000)

--- a/tests/core/operations/test_spatialdata_operations.py
+++ b/tests/core/operations/test_spatialdata_operations.py
@@ -22,7 +22,14 @@ from spatialdata.models import (
     TableModel,
 )
 from spatialdata.transformations.operations import get_transformation, set_transformation
-from spatialdata.transformations.transformations import Affine, Identity, Scale, Sequence, Translation
+from spatialdata.transformations.transformations import (
+    Affine,
+    BaseTransformation,
+    Identity,
+    Scale,
+    Sequence,
+    Translation,
+)
 
 from tests.conftest import _get_table
 
@@ -410,3 +417,15 @@ def test_transform_to_data_extent(full_sdata: SpatialData):
         ["image2d", "image2d_multiscale", "labels2d", "labels2d_multiscale", "points_0", "circles", "multipoly", "poly"]
     )
     sdata = transform_to_data_extent(full_sdata, "global", target_width=1000)
+
+    matrices = []
+    for el in sdata._gen_elements_values():
+        t = get_transformation(el, to_coordinate_system="global")
+        assert isinstance(t, BaseTransformation)
+        a = t.to_affine_matrix(input_axes=("x", "y", "z"), output_axes=("x", "y", "z"))
+        matrices.append(a)
+
+    first_a = matrices[0]
+    for a in matrices[1:]:
+        # we are not pixel perfect because of this bug: https://github.com/scverse/spatialdata/issues/165
+        assert np.allclose(a, first_a, rtol=0.005)

--- a/tests/core/operations/test_transform.py
+++ b/tests/core/operations/test_transform.py
@@ -21,7 +21,14 @@ from spatialdata.transformations.operations import (
     remove_transformation,
     set_transformation,
 )
-from spatialdata.transformations.transformations import Affine, Identity, Scale, Sequence, Translation
+from spatialdata.transformations.transformations import (
+    Affine,
+    BaseTransformation,
+    Identity,
+    Scale,
+    Sequence,
+    Translation,
+)
 
 
 class TestElementsTransform:
@@ -116,6 +123,13 @@ def _unpad_rasters(sdata: SpatialData) -> SpatialData:
 from napari_spatialdata import Interactive
 
 
+def _set_transformation_for_all_elements(
+    sdata: SpatialData, transformation: BaseTransformation, to_coordinate_system: str
+):
+    for element in sdata._gen_elements_values():
+        set_transformation(element, transformation=transformation, to_coordinate_system=to_coordinate_system)
+
+
 def test_transform_image_spatial_image(images: SpatialData):
     sdata = SpatialData(images={k: v for k, v in images.images.items() if isinstance(v, SpatialImage)})
     e = get_extent(sdata["image2d"])
@@ -138,10 +152,11 @@ def test_transform_image_spatial_image(images: SpatialData):
     #     sdata.images["face"] = im_element
 
     affine = _get_affine(small_translation=False)
-    sdata_transformed = transform(sdata, affine, maintain_positioning=False)
-    padded = transform(sdata_transformed, affine.inverse(), maintain_positioning=False)
+    _set_transformation_for_all_elements(sdata, affine, "transformed")
+    sdata_transformed = transform(sdata, to_coordinate_system="transformed")
+    _set_transformation_for_all_elements(sdata_transformed, affine.inverse(), "transformed_back")
+    padded = transform(sdata_transformed, to_coordinate_system="transformed_back")
     _unpad_rasters(padded)
-    Interactive([sdata, sdata_transformed])
     Interactive([sdata, padded])
     pass
     # raise NotImplementedError("TODO: plot the images")
@@ -155,7 +170,7 @@ def test_transform_image_spatial_multiscale_spatial_image(images: SpatialData):
         transform(sdata, affine, maintain_positioning=False), affine.inverse(), maintain_positioning=False
     )
     _unpad_rasters(padded)
-    Interactive([padded, sdata])
+    # Interactive([padded, sdata])
     pass
     # TODO: unpad the image
     # raise NotImplementedError("TODO: compare the transformed images with the original ones")
@@ -168,7 +183,7 @@ def test_transform_labels_spatial_image(labels: SpatialData):
         transform(sdata, affine, maintain_positioning=False), affine.inverse(), maintain_positioning=False
     )
     _unpad_rasters(padded)
-    Interactive([padded, sdata])
+    # Interactive([padded, sdata])
     pass
     # TODO: unpad the labels
     # raise NotImplementedError("TODO: compare the transformed images with the original ones")
@@ -181,7 +196,7 @@ def test_transform_labels_spatial_multiscale_spatial_image(labels: SpatialData):
         transform(sdata, affine, maintain_positioning=False), affine.inverse(), maintain_positioning=False
     )
     _unpad_rasters(padded)
-    Interactive([padded, sdata])
+    # Interactive([padded, sdata])
     pass
     # TODO: unpad the labels
     # raise NotImplementedError("TODO: compare the transformed images with the original ones")

--- a/tests/core/operations/test_transform.py
+++ b/tests/core/operations/test_transform.py
@@ -470,7 +470,7 @@ def test_transform_elements_and_entire_spatial_data_object(full_sdata: SpatialDa
         )
         t = get_transformation(transformed_element, to_coordinate_system="my_space")
         a = t.to_affine_matrix(input_axes=("x",), output_axes=("x",))
-        print(maintain_positioning)
+        # print(maintain_positioning)
         if maintain_positioning:
             assert np.allclose(a, np.array([[1 / k, 0], [0, 1]]))
             t = get_transformation(transformed_element, to_coordinate_system="global")
@@ -483,7 +483,7 @@ def test_transform_elements_and_entire_spatial_data_object(full_sdata: SpatialDa
             assert "global" not in d
 
     # this calls transform_element_to_coordinate_system() internally()
-    transformed = full_sdata.transform_to_coordinate_system("my_space", maintain_positioning=maintain_positioning)
+    _ = full_sdata.transform_to_coordinate_system("my_space", maintain_positioning=maintain_positioning)
     # TODO: add test for element1 -> cs1 <- element2 -> cs2 and transforming element1 to cs2
 
 

--- a/tests/core/test_data_extent.py
+++ b/tests/core/test_data_extent.py
@@ -262,8 +262,8 @@ def test_get_extent_affine_circles():
     # Create a Polygon from the points
     bounding_box = Polygon(points)
     gdf = GeoDataFrame(geometry=[bounding_box])
-    gdf = ShapesModel.parse(gdf)
-    transformed_bounding_box = transform(gdf, affine)
+    gdf = ShapesModel.parse(gdf, transformations={"transformed": affine})
+    transformed_bounding_box = transform(gdf, to_coordinate_system="transformed")
 
     transformed_bounding_box_extent = get_extent(transformed_bounding_box)
 

--- a/tests/transformations/test_transformations.py
+++ b/tests/transformations/test_transformations.py
@@ -7,8 +7,7 @@ import xarray.testing
 from spatialdata import transform
 from spatialdata.datasets import blobs
 from spatialdata.models import Image2DModel, PointsModel
-from spatialdata.models._utils import ValidAxis_t
-from spatialdata.transformations import get_transformation
+from spatialdata.models._utils import DEFAULT_COORDINATE_SYSTEM, ValidAxis_t
 from spatialdata.transformations.ngff._utils import get_default_coordinate_system
 from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
 from spatialdata.transformations.ngff.ngff_transformations import (
@@ -992,8 +991,7 @@ def test_compose_in_xy_and_operate_in_cyx():
 def test_keep_numerical_coordinates_c():
     c_coords = range(3)
     sdata = blobs(n_channels=len(c_coords))
-    t = get_transformation(sdata.images["blobs_image"])
-    t_blobs = transform(sdata.images["blobs_image"], t)
+    t_blobs = transform(sdata.images["blobs_image"], to_coordinate_system=DEFAULT_COORDINATE_SYSTEM)
     assert np.array_equal(t_blobs.coords["c"], c_coords)
 
 
@@ -1001,6 +999,5 @@ def test_keep_string_coordinates_c():
     c_coords = ["a", "b", "c"]
     # n_channels will be ignored, testing also that this works
     sdata = blobs(c_coords=c_coords, n_channels=4)
-    t = get_transformation(sdata.images["blobs_image"])
-    t_blobs = transform(sdata.images["blobs_image"], t)
+    t_blobs = transform(sdata.images["blobs_image"], to_coordinate_system=DEFAULT_COORDINATE_SYSTEM)
     assert np.array_equal(t_blobs.coords["c"], c_coords)


### PR DESCRIPTION
# New API:
- Added utils function `transform_to_data_extent()`, useful to create a converted with downscaled images, where all the -transformations are applied and where 1 pixel = 1 physical unit.

# Improved robustness and tests of transformations
- Added `maintain_positioning` argument to`SpatialData.transform_to_coordinate_system()` and `SpatialData.transform_element_to_coordinate_system()`.
- Fixed bug: incorrect offset translation vector for raster data when calling the two above functions, `transform()` was not affected)
- Fixed bug: `transform()` on multiscale raster was returning the offset translation for the most low res scale, not scale0

Most importantly:
- `transform()` now requires the argument `to_coordinate_system` instead of `transformation` (unless `maintain_positioning` is `True`); in fact, non-explicit target coordinate systems may lead to unintuitive results when an element is aligned to multiple coordinate systems. This change is communicated to the user by an informative exception; in some cases backward compatibility could be ensured so only an informative warning is given.

Note:
The above bugs were not affecting the rest of the codebase because `query()`, `aggregate()`, ... make either use of `transform()` for non-raster data, either operate on the transformations directly, without transforming raster data.