### PR TITLE
allow table to be None in get_values and _locate_values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ docs = [
     # For notebooks
     "ipython>=8.6.0",
     "sphinx-copybutton",
+    "sphinx-pytest",
 ]
 test = [
     "pytest",

--- a/src/spatialdata/_core/operations/aggregate.py
+++ b/src/spatialdata/_core/operations/aggregate.py
@@ -19,7 +19,7 @@ from xrspatial import zonal_stats
 
 from spatialdata._core.operations.transform import transform
 from spatialdata._core.query._utils import circles_to_polygons
-from spatialdata._core.query.relational_query import get_values
+from spatialdata._core.query.relational_query import _get_element_annotators, get_values
 from spatialdata._core.spatialdata import SpatialData
 from spatialdata._types import ArrayLike
 from spatialdata.models import (
@@ -153,6 +153,7 @@ def aggregate(
     """
     if values_sdata is not None:
         assert table_name is not None, f"The name of the table annotating `{values}` must be provided as `table_name`"
+        assert table_name in _get_element_annotators(values_sdata, values)
 
     values_ = _parse_element(element=values, sdata=values_sdata, str_for_exception="values")
     by_ = _parse_element(element=by, sdata=by_sdata, str_for_exception="by")

--- a/src/spatialdata/_core/operations/aggregate.py
+++ b/src/spatialdata/_core/operations/aggregate.py
@@ -127,7 +127,7 @@ def aggregate(
         Whether to deepcopy the shapes in the returned `SpatialData` object. If the shapes are large (e.g. large
         multiscale labels), you may consider disabling the deepcopy to use a lazy Dask representation.
     table_name
-        The name of the table resulting from the aggregation.
+        The table optionally containing the value_key and the name of the table in the returned `SpatialData` object.
     kwargs
         Additional keyword arguments to pass to :func:`xrspatial.zonal_stats`.
 
@@ -355,6 +355,8 @@ def _aggregate_shapes(
         Column in value dataframe to perform aggregation on.
     agg_func
         Aggregation function to apply over grouped values. Passed to pandas.DataFrame.groupby.agg.
+    table_name
+        Name of the table optionally containing the value_key column.
     """
     from spatialdata.models import points_dask_dataframe_to_geopandas
 

--- a/src/spatialdata/_core/operations/aggregate.py
+++ b/src/spatialdata/_core/operations/aggregate.py
@@ -19,7 +19,7 @@ from xrspatial import zonal_stats
 
 from spatialdata._core.operations.transform import transform
 from spatialdata._core.query._utils import circles_to_polygons
-from spatialdata._core.query.relational_query import _get_element_annotators, get_values
+from spatialdata._core.query.relational_query import get_values
 from spatialdata._core.spatialdata import SpatialData
 from spatialdata._types import ArrayLike
 from spatialdata.models import (
@@ -151,10 +151,6 @@ def aggregate(
     to a large memory usage. This Github issue https://github.com/scverse/spatialdata/issues/210 keeps track of the
     changes required to address this behavior.
     """
-    if values_sdata is not None:
-        assert table_name is not None, f"The name of the table annotating `{values}` must be provided as `table_name`"
-        assert table_name in _get_element_annotators(values_sdata, values)
-
     values_ = _parse_element(element=values, sdata=values_sdata, str_for_exception="values")
     by_ = _parse_element(element=by, sdata=by_sdata, str_for_exception="by")
 

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -637,7 +637,7 @@ def _locate_value(
     element: SpatialElement | None = None,
     sdata: SpatialData | None = None,
     element_name: str | None = None,
-    table_name: str = "table",
+    table_name: str | None = None,
 ) -> list[_ValueOrigin]:
     el = _get_element(element=element, sdata=sdata, element_name=element_name)
     origins = []
@@ -652,7 +652,7 @@ def _locate_value(
 
     # adding from the obs columns or var
     if model in [ShapesModel, Labels2DModel, Labels3DModel] and sdata is not None:
-        table = sdata[table_name]
+        table = sdata.tables.get(table_name) if table_name is not None else None
         if table is not None:
             # check if the table is annotating the element
             region = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY]
@@ -673,7 +673,7 @@ def get_values(
     element: SpatialElement | None = None,
     sdata: SpatialData | None = None,
     element_name: str | None = None,
-    table_name: str = "table",
+    table_name: str | None = None,
 ) -> pd.DataFrame:
     """
     Get the values from the element, from any location: df columns, obs or var columns (table).
@@ -736,7 +736,7 @@ def get_values(
         if isinstance(el, DaskDataFrame):
             df = df.compute()
         return df
-    if sdata is not None:
+    if sdata is not None and table_name is not None:
         assert element_name is not None
         matched_table = match_table_to_element(sdata=sdata, element_name=element_name, table_name=table_name)
         region_key = matched_table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]

--- a/tests/core/operations/test_aggregations.py
+++ b/tests/core/operations/test_aggregations.py
@@ -46,7 +46,7 @@ def test_aggregate_points_by_shapes(sdata_query_aggregation, by_shapes: str, val
     # testing that we can call aggregate with the two equivalent syntaxes for the values argument
     result_adata = aggregate(values=points, by=shapes, value_key=value_key, agg_func="sum").tables["table"]
     result_adata_bis = aggregate(
-        values_sdata=sdata, values="points", by=shapes, value_key=value_key, agg_func="sum"
+        values_sdata=sdata, values="points", by=shapes, value_key=value_key, agg_func="sum", table_name="table"
     ).tables["table"]
     np.testing.assert_equal(result_adata.X.A, result_adata_bis.X.A)
 
@@ -147,7 +147,7 @@ def test_aggregate_shapes_by_shapes(
     values = _parse_shapes(sdata, values_shapes=values_shapes)
 
     result_adata = aggregate(
-        values_sdata=sdata, values=values_shapes, by=by, value_key=value_key, agg_func="sum"
+        values_sdata=sdata, values=values_shapes, by=by, value_key=value_key, agg_func="sum", table_name="table"
     ).tables["table"]
 
     # testing that we can call aggregate with the two equivalent syntaxes for the values argument (only relevant when
@@ -255,7 +255,7 @@ def test_aggregate_shapes_by_shapes(
     # in the categorical case, check that sum and count behave the same
     if value_key in ["categorical_in_obs", "categorical_in_gdf"]:
         result_adata_count = aggregate(
-            values_sdata=sdata, values=values_shapes, by=by, value_key=value_key, agg_func="count"
+            values_sdata=sdata, values=values_shapes, by=by, value_key=value_key, agg_func="count", table_name="table"
         ).tables["table"]
         assert_equal(result_adata, result_adata_count)
 
@@ -264,7 +264,14 @@ def test_aggregate_shapes_by_shapes(
     if value_key in ["categorical_in_obs", "categorical_in_gdf"]:
         # can't aggregate multiple categorical values
         with pytest.raises(ValueError):
-            aggregate(values_sdata=sdata, values=values_shapes, by=by, value_key=new_value_key, agg_func="sum")
+            aggregate(
+                values_sdata=sdata,
+                values=values_shapes,
+                by=by,
+                value_key=new_value_key,
+                agg_func="sum",
+                table_name="table",
+            )
     else:
         if value_key == "numerical_in_obs":
             sdata.tables["table"].obs["another_numerical_in_obs"] = 1.0
@@ -279,7 +286,7 @@ def test_aggregate_shapes_by_shapes(
             sdata.tables["table"] = new_table
 
         result_adata = aggregate(
-            values_sdata=sdata, values=values_shapes, by=by, value_key=new_value_key, agg_func="sum"
+            values_sdata=sdata, values=values_shapes, by=by, value_key=new_value_key, agg_func="sum", table_name="table"
         ).tables["table"]
         assert result_adata.var_names.to_list() == new_value_key
 
@@ -311,6 +318,7 @@ def test_aggregate_shapes_by_shapes(
                     by=by,
                     value_key=value_key,
                     agg_func="sum",
+                    table_name="table",
                 )
     # test we can't aggregate from mixed categorical and numerical sources (let's just test one case)
     with pytest.raises(ValueError):
@@ -320,6 +328,7 @@ def test_aggregate_shapes_by_shapes(
             by=by,
             value_key=["numerical_values_in_obs", "categorical_values_in_obs"],
             agg_func="sum",
+            table_name="table",
         )
 
 
@@ -494,6 +503,7 @@ def test_aggregate_considering_fractions_multiple_values(
         value_key=["numerical_in_var", "another_numerical_in_var"],
         agg_func="sum",
         fractions=True,
+        table_name="table",
     ).tables["table"]
     overlaps = np.array([0.655781239649211, 1.0000000000000002, 1.0000000000000004, 0.1349639285777728])
     row0 = np.sum(sdata.tables["table"].X[[0, 1, 2, 3], :] * overlaps.reshape(-1, 1), axis=0)

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -173,45 +173,74 @@ def test_locate_value(sdata_query_aggregation):
 
     # var, numerical
     _check_location(
-        _locate_value(value_key="numerical_in_var", sdata=sdata_query_aggregation, element_name="values_circles"),
+        _locate_value(
+            value_key="numerical_in_var",
+            sdata=sdata_query_aggregation,
+            element_name="values_circles",
+            table_name="table",
+        ),
         origin="var",
         is_categorical=False,
     )
     # obs, categorical
     _check_location(
-        _locate_value(value_key="categorical_in_obs", sdata=sdata_query_aggregation, element_name="values_circles"),
+        _locate_value(
+            value_key="categorical_in_obs",
+            sdata=sdata_query_aggregation,
+            element_name="values_circles",
+            table_name="table",
+        ),
         origin="obs",
         is_categorical=True,
     )
     # obs, numerical
     _check_location(
-        _locate_value(value_key="numerical_in_obs", sdata=sdata_query_aggregation, element_name="values_circles"),
+        _locate_value(
+            value_key="numerical_in_obs",
+            sdata=sdata_query_aggregation,
+            element_name="values_circles",
+            table_name="table",
+        ),
         origin="obs",
         is_categorical=False,
     )
     # gdf, categorical
     # sdata + element_name
     _check_location(
-        _locate_value(value_key="categorical_in_gdf", sdata=sdata_query_aggregation, element_name="values_circles"),
+        _locate_value(
+            value_key="categorical_in_gdf",
+            sdata=sdata_query_aggregation,
+            element_name="values_circles",
+            table_name="table",
+        ),
         origin="df",
         is_categorical=True,
     )
     # element
     _check_location(
-        _locate_value(value_key="categorical_in_gdf", element=sdata_query_aggregation["values_circles"]),
+        _locate_value(
+            value_key="categorical_in_gdf", element=sdata_query_aggregation["values_circles"], table_name="table"
+        ),
         origin="df",
         is_categorical=True,
     )
     # gdf, numerical
     # sdata + element_name
     _check_location(
-        _locate_value(value_key="numerical_in_gdf", sdata=sdata_query_aggregation, element_name="values_circles"),
+        _locate_value(
+            value_key="numerical_in_gdf",
+            sdata=sdata_query_aggregation,
+            element_name="values_circles",
+            table_name="table",
+        ),
         origin="df",
         is_categorical=False,
     )
     # element
     _check_location(
-        _locate_value(value_key="numerical_in_gdf", element=sdata_query_aggregation["values_circles"]),
+        _locate_value(
+            value_key="numerical_in_gdf", element=sdata_query_aggregation["values_circles"], table_name="table"
+        ),
         origin="df",
         is_categorical=False,
     )
@@ -245,7 +274,9 @@ def test_locate_value(sdata_query_aggregation):
 
 def test_get_values_df(sdata_query_aggregation):
     # test with a single value, in the dataframe; using sdata + element_name
-    v = get_values(value_key="numerical_in_gdf", sdata=sdata_query_aggregation, element_name="values_circles")
+    v = get_values(
+        value_key="numerical_in_gdf", sdata=sdata_query_aggregation, element_name="values_circles", table_name="table"
+    )
     assert v.shape == (9, 1)
 
     # test with multiple values, in the dataframe; using element
@@ -256,7 +287,9 @@ def test_get_values_df(sdata_query_aggregation):
     assert v.shape == (9, 2)
 
     # test with a single value, in the obs
-    v = get_values(value_key="numerical_in_obs", sdata=sdata_query_aggregation, element_name="values_circles")
+    v = get_values(
+        value_key="numerical_in_obs", sdata=sdata_query_aggregation, element_name="values_circles", table_name="table"
+    )
     assert v.shape == (9, 1)
 
     # test with multiple values, in the obs
@@ -265,11 +298,14 @@ def test_get_values_df(sdata_query_aggregation):
         value_key=["numerical_in_obs", "another_numerical_in_obs"],
         sdata=sdata_query_aggregation,
         element_name="values_circles",
+        table_name="table",
     )
     assert v.shape == (9, 2)
 
     # test with a single value, in the var
-    v = get_values(value_key="numerical_in_var", sdata=sdata_query_aggregation, element_name="values_circles")
+    v = get_values(
+        value_key="numerical_in_var", sdata=sdata_query_aggregation, element_name="values_circles", table_name="table"
+    )
     assert v.shape == (9, 1)
 
     # test with multiple values, in the var
@@ -287,6 +323,7 @@ def test_get_values_df(sdata_query_aggregation):
         value_key=["numerical_in_var", "another_numerical_in_var"],
         sdata=sdata_query_aggregation,
         element_name="values_circles",
+        table_name="table",
     )
     assert v.shape == (9, 2)
 
@@ -294,11 +331,18 @@ def test_get_values_df(sdata_query_aggregation):
     # value found in multiple locations
     sdata_query_aggregation.table.obs["another_numerical_in_gdf"] = np.zeros(21)
     with pytest.raises(ValueError):
-        get_values(value_key="another_numerical_in_gdf", sdata=sdata_query_aggregation, element_name="values_circles")
+        get_values(
+            value_key="another_numerical_in_gdf",
+            sdata=sdata_query_aggregation,
+            element_name="values_circles",
+            table_name="table",
+        )
 
     # value not found
     with pytest.raises(ValueError):
-        get_values(value_key="not_present", sdata=sdata_query_aggregation, element_name="values_circles")
+        get_values(
+            value_key="not_present", sdata=sdata_query_aggregation, element_name="values_circles", table_name="table"
+        )
 
     # mixing categorical and numerical values
     with pytest.raises(ValueError):
@@ -306,6 +350,7 @@ def test_get_values_df(sdata_query_aggregation):
             value_key=["numerical_in_gdf", "categorical_in_gdf"],
             sdata=sdata_query_aggregation,
             element_name="values_circles",
+            table_name="table",
         )
 
     # multiple categorical values
@@ -315,6 +360,7 @@ def test_get_values_df(sdata_query_aggregation):
             value_key=["categorical_in_gdf", "another_categorical_in_gdf"],
             sdata=sdata_query_aggregation,
             element_name="values_circles",
+            table_name="table",
         )
 
     # mixing different origins
@@ -323,6 +369,7 @@ def test_get_values_df(sdata_query_aggregation):
             value_key=["numerical_in_gdf", "numerical_in_obs"],
             sdata=sdata_query_aggregation,
             element_name="values_circles",
+            table_name="table",
         )
 
 
@@ -330,7 +377,7 @@ def test_get_values_labels_bug(sdata_blobs):
     # https://github.com/scverse/spatialdata-plot/issues/165
     from spatialdata import get_values
 
-    get_values("channel_0_sum", sdata=sdata_blobs, element_name="blobs_labels")
+    get_values("channel_0_sum", sdata=sdata_blobs, element_name="blobs_labels", table_name="table")
 
 
 def test_filter_table_categorical_bug(shapes):


### PR DESCRIPTION
The `table_name` in `get_values` and `locate_values` was not allowed to be None, but this can sometimes be a requirement when for example there is no table annotating the element. This can be the case in `spatialdata_plot`. This PR allows for this.

This PR also fixes the issue of failing docs build due to `import error, no module called SpatialData`. In order to replicate the issue I tried the doc build on the denbi machine `using spinx-build source-dir out-dir -P`. The `-P` flag allows for a debugger without ide allowing to manually try the import of `spatialdata`. This gave an error because there was no module called `pytest`. Adding `sphinx-pytest` to the doc dependencies fixed the issue.