### PR TITLE
Removed int contraint for instance_key column

### DIFF
--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -866,14 +866,6 @@ class TableModel:
             adata.obs[region_key] = pd.Categorical(adata.obs[region_key])
         if instance_key is None:
             raise ValueError("`instance_key` must be provided.")
-        # if adata.obs[instance_key].dtype != int:
-        #     try:
-        #         warnings.warn(
-        #             f"Converting `{cls.INSTANCE_KEY}: {instance_key}` to integer dtype.", UserWarning, stacklevel=2
-        #         )
-        #         adata.obs[instance_key] = adata.obs[instance_key].astype(int)
-        #     except IntCastingNaNError as exc:
-        #         raise ValueError("Values within table.obs[] must be able to be coerced to int dtype.") from exc
 
         grouped = adata.obs.groupby(region_key, observed=True)
         grouped_size = grouped.size()

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -20,7 +20,6 @@ from multiscale_spatial_image import to_multiscale
 from multiscale_spatial_image.multiscale_spatial_image import MultiscaleSpatialImage
 from multiscale_spatial_image.to_multiscale.to_multiscale import Methods
 from pandas import CategoricalDtype
-from pandas.errors import IntCastingNaNError
 from shapely._geometry import GeometryType
 from shapely.geometry import MultiPolygon, Point, Polygon
 from shapely.geometry.collection import GeometryCollection
@@ -867,14 +866,14 @@ class TableModel:
             adata.obs[region_key] = pd.Categorical(adata.obs[region_key])
         if instance_key is None:
             raise ValueError("`instance_key` must be provided.")
-        if adata.obs[instance_key].dtype != int:
-            try:
-                warnings.warn(
-                    f"Converting `{cls.INSTANCE_KEY}: {instance_key}` to integer dtype.", UserWarning, stacklevel=2
-                )
-                adata.obs[instance_key] = adata.obs[instance_key].astype(int)
-            except IntCastingNaNError as exc:
-                raise ValueError("Values within table.obs[] must be able to be coerced to int dtype.") from exc
+        # if adata.obs[instance_key].dtype != int:
+        #     try:
+        #         warnings.warn(
+        #             f"Converting `{cls.INSTANCE_KEY}: {instance_key}` to integer dtype.", UserWarning, stacklevel=2
+        #         )
+        #         adata.obs[instance_key] = adata.obs[instance_key].astype(int)
+        #     except IntCastingNaNError as exc:
+        #         raise ValueError("Values within table.obs[] must be able to be coerced to int dtype.") from exc
 
         grouped = adata.obs.groupby(region_key, observed=True)
         grouped_size = grouped.size()


### PR DESCRIPTION
@melonora @giovp I realized that if we force instance_key to be an int we need to update the storage format because some technologies, in particular Xenium, relies on having instance_key as string. I would therefore, unless this leads to problems in napari-spatialdata, etc, to keep allowing strings for instance_key and eventually change this in the future, when the versioning of the data format is improved and we can provide a migration tool for the data.