### PR TITLE
fix dask dataframe dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "xarray-spatial>=0.3.5",
     "tqdm",
     "fsspec<=2023.6",
+	"dask<=2024.2.1"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Dask DataFrame is now using `dask-expr` as backend; pinning down the version temporarily until we address the changes required to support it (example there is no `.attrs` in the dataframe).