### PR TITLE
fix str column showing object dtype

### DIFF
--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -794,7 +794,10 @@ class TableModel:
             raise ValueError(f"`{attr[self.REGION_KEY_KEY]}` not found in `adata.obs`.")
         if attr[self.INSTANCE_KEY] not in data.obs:
             raise ValueError(f"`{attr[self.INSTANCE_KEY]}` not found in `adata.obs`.")
-        if (dtype := data.obs[attr[self.INSTANCE_KEY]].dtype) not in [np.int16, np.int32, np.int64, str]:
+        if (dtype := data.obs[attr[self.INSTANCE_KEY]].dtype) not in [np.int16, np.int32, np.int64, "O"] or (
+            dtype == "O" and (val_dtype := type(data.obs[attr[self.INSTANCE_KEY]][0])) != str
+        ):
+            dtype = dtype if dtype != "O" else val_dtype
             raise TypeError(
                 f"Only np.int16, np.int32, np.int64 or string allowed as dtype for "
                 f"instance_key column in obs. Dtype found to be {dtype}"


### PR DESCRIPTION
The table validation currently fails when the `instance_key` column contains `str` values. This is because when setting the dtype of such a column to `str`, the dtype is actually `object`. This PR corrects the check so that an `instance_key` column having the `object` dtype and having as first element a `str` value, would still pass the check.