### PR TITLE
Warning for Polygon wiht z dimension

### DIFF
--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -332,6 +332,15 @@ class ShapesModel:
                 raise ValueError("Radii of circles must be positive.")
         if cls.TRANSFORM_KEY not in data.attrs:
             raise ValueError(f":class:`geopandas.GeoDataFrame` does not contain `{TRANSFORM_KEY}`.")
+        if len(data) > 0:
+            n = data.geometry.iloc[0]._ndim
+            if n != 2:
+                warnings.warn(
+                    f"The geometry column of the GeoDataFrame has {n} dimensions, while 2 is expected. Please consider "
+                    "discarding the third dimension as it could led to unexpected behaviors.",
+                    UserWarning,
+                    stacklevel=2,
+                )
 
     @singledispatchmethod
     @classmethod

--- a/tests/core/test_data_extent.py
+++ b/tests/core/test_data_extent.py
@@ -54,9 +54,10 @@ def test_get_extent_shapes(shape_type):
     )
 
 
-def test_get_extent_points():
+@pytest.mark.parametrize("exact", [True, False])
+def test_get_extent_points(exact: bool):
     # 2d case
-    extent = get_extent(sdata["blobs_points"])
+    extent = get_extent(sdata["blobs_points"], exact=exact)
     check_test_results0(
         extent,
         min_coordinates=np.array([3.0, 4.0]),
@@ -68,7 +69,7 @@ def test_get_extent_points():
     data = np.array([[1, 2, 3], [4, 5, 6]])
     df = pd.DataFrame(data, columns=["zeta", "x", "y"])
     points_3d = PointsModel.parse(df, coordinates={"x": "x", "y": "y", "z": "zeta"})
-    extent_3d = get_extent(points_3d)
+    extent_3d = get_extent(points_3d, exact=exact)
     check_test_results0(
         extent_3d,
         min_coordinates=np.array([2, 3, 1]),

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -414,3 +414,16 @@ def test_points_and_shapes_conversions(shapes, points):
     t2 = get_transformation(points2, get_all=True)
     assert t0 == t1
     assert t0 == t2
+
+
+def test_model_polygon_z():
+    import geopandas as gpd
+    from shapely.geometry import Polygon
+
+    polygon = Polygon([(0, 0, 0), (1, 1, 0), (2, 0, 0)])
+
+    with pytest.warns(
+        UserWarning,
+        match="The geometry column of the GeoDataFrame has 3 dimensions, while 2 is expected. Please consider",
+    ):
+        _ = ShapesModel.parse(gpd.GeoDataFrame(geometry=[polygon]))


### PR DESCRIPTION
Polygons with a z dimension may not be handled correctly (for instance get_extent fails). Here I add a warning to inform the user of this possibility.