### PR TITLE
minor fixes aggregate (.buffer() resolution), model dtype

### DIFF
--- a/src/spatialdata/_core/query/_utils.py
+++ b/src/spatialdata/_core/query/_utils.py
@@ -12,13 +12,14 @@ from spatialdata._types import ArrayLike
 from spatialdata._utils import Number, _parse_list_into_array
 
 
-def circles_to_polygons(df: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+# TODO: move this function into "to_polygons()"
+def circles_to_polygons(df: gpd.GeoDataFrame, buffer_resolution: int = 16) -> gpd.GeoDataFrame:
     # We should only be buffering points, not polygons. Unfortunately this is an expensive check.
     from spatialdata.models import ShapesModel
 
     values_geotypes = list(df.geom_type.unique())
     if values_geotypes == ["Point"]:
-        buffered_df = df.set_geometry(df.geometry.buffer(df[ShapesModel.RADIUS_KEY]))
+        buffered_df = df.set_geometry(df.geometry.buffer(df[ShapesModel.RADIUS_KEY], resolution=buffer_resolution))
         # TODO replace with a function to copy the metadata (the parser could also do this): https://github.com/scverse/spatialdata/issues/258
         buffered_df.attrs[ShapesModel.TRANSFORM_KEY] = df.attrs[ShapesModel.TRANSFORM_KEY]
         return buffered_df

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -803,12 +803,12 @@ class TableModel:
             raise ValueError(f"`{attr[self.REGION_KEY_KEY]}` not found in `adata.obs`.")
         if attr[self.INSTANCE_KEY] not in data.obs:
             raise ValueError(f"`{attr[self.INSTANCE_KEY]}` not found in `adata.obs`.")
-        if (dtype := data.obs[attr[self.INSTANCE_KEY]].dtype) not in [np.int16, np.int32, np.int64, "O"] or (
+        if (dtype := data.obs[attr[self.INSTANCE_KEY]].dtype) not in [int, np.int16, np.int32, np.int64, "O"] or (
             dtype == "O" and (val_dtype := type(data.obs[attr[self.INSTANCE_KEY]].iloc[0])) != str
         ):
             dtype = dtype if dtype != "O" else val_dtype
             raise TypeError(
-                f"Only np.int16, np.int32, np.int64 or string allowed as dtype for "
+                f"Only int, np.int16, np.int32, np.int64 or string allowed as dtype for "
                 f"instance_key column in obs. Dtype found to be {dtype}"
             )
         expected_regions = attr[self.REGION_KEY] if isinstance(attr[self.REGION_KEY], list) else [attr[self.REGION_KEY]]


### PR DESCRIPTION
Tiny PR.

- fixes dtype for instance_key allowing it to be `int` and not just `np.int16`, `np.int32`, `np.int64`, `"O"`
- adds `resolution` for the conversion of circles to polygons, especially when used in `aggregate()`