### PR TITLE
Update build.yaml to use setup-python v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,9 +12,10 @@ jobs:
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.10
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: "3.10"
+                  cache: pip
             - name: Install build dependencies
               run: python -m pip install --upgrade pip wheel twine build
             - name: Build package

--- a/.github/workflows/test_and_deploy.yaml
+++ b/.github/workflows/test_and_deploy.yaml
@@ -35,9 +35,10 @@ jobs:
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python ${{ matrix.python }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python }}
+                  cache: pip
 
             - name: Get pip cache dir
               id: pip-cache-dir


### PR DESCRIPTION
Using setup-python v4 with pip caching. It should run noticeably faster, let's see.

We may need to upload a second commit to see the caching mechanism in action.