### PR TITLE
Join outside sdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ and this project adheres to [Semantic Versioning][].
 
 -   Implemented support in SpatialData for storing multiple tables. These tables can annotate a SpatialElement but not
     necessarily so.
--   Added SQL like joins that can be executed by calling one public function `join_sdata_spatialelement_table`. The
+-   Added SQL like joins that can be executed by calling one public function `join_spatialelement_table`. The
     following joins are supported: `left`, `left_exclusive`, `right`, `right_exclusive` and `inner`. The function has
     an option to match rows. For `left` only matching `left` is supported and for `right` join only `right` matching of
-    rows is supported. Not all joins are supported for `Labels` elements.
+    rows is supported. Not all joins are supported for `Labels` elements. The elements and table can either exist within
+    a `SpatialData` object or outside.
 -   Added function `match_element_to_table` which allows the user to perform a right join of `SpatialElement`(s) with a
     table with rows matching the row order in the table.
 -   Increased in-memory vs on-disk control: changes performed in-memory (e.g. adding a new image) are not automatically

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,7 +28,7 @@ Operations on `SpatialData` objects.
     get_values
     get_extent
     get_centroids
-    join_sdata_spatialelement_table
+    join_spatialelement_table
     match_element_to_table
     get_centroids
     match_table_to_element

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
     "bounding_box_query",
     "polygon_query",
     "get_values",
-    "join_sdata_spatialelement_table",
+    "join_spatialelement_table",
     "match_element_to_table",
     "match_table_to_element",
     "SpatialData",
@@ -49,7 +49,7 @@ from spatialdata._core.operations.vectorize import to_circles
 from spatialdata._core.query._utils import circles_to_polygons, get_bounding_box_corners
 from spatialdata._core.query.relational_query import (
     get_values,
-    join_sdata_spatialelement_table,
+    join_spatialelement_table,
     match_element_to_table,
     match_table_to_element,
 )

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -20,7 +20,7 @@ from torch.utils.data import Dataset
 from spatialdata._core.centroids import get_centroids
 from spatialdata._core.operations.transform import transform
 from spatialdata._core.operations.vectorize import to_circles
-from spatialdata._core.query.relational_query import _get_unique_label_values_as_index, join_sdata_spatialelement_table
+from spatialdata._core.query.relational_query import _get_unique_label_values_as_index, join_spatialelement_table
 from spatialdata._core.spatialdata import SpatialData
 from spatialdata.models import (
     Image2DModel,
@@ -261,8 +261,12 @@ class ImageTilesDataset(Dataset):
             if table_name is not None:
                 table_subset = filtered_table[filtered_table.obs[region_key] == region_name]
                 circles_sdata = SpatialData.init_from_elements({region_name: circles}, tables=table_subset.copy())
-                _, table = join_sdata_spatialelement_table(
-                    circles_sdata, region_name, table_name, how="left", match_rows="left"
+                _, table = join_spatialelement_table(
+                    sdata=circles_sdata,
+                    spatial_element_names=region_name,
+                    table_name=table_name,
+                    how="left",
+                    match_rows="left",
                 )
                 # get index dictionary, with `instance_id`, `cs`, `region`, and `image`
                 tables_l.append(table)

--- a/tests/core/operations/test_spatialdata_operations.py
+++ b/tests/core/operations/test_spatialdata_operations.py
@@ -129,10 +129,10 @@ def test_filter_by_coordinate_system_also_table(full_sdata: SpatialData) -> None
     from spatialdata.models import TableModel
 
     rng = np.random.default_rng(seed=0)
-    full_sdata.table.obs["annotated_shapes"] = rng.choice(["circles", "poly"], size=full_sdata.table.shape[0])
-    adata = full_sdata.table
+    full_sdata["table"].obs["annotated_shapes"] = rng.choice(["circles", "poly"], size=full_sdata["table"].shape[0])
+    adata = full_sdata["table"]
     del adata.uns[TableModel.ATTRS_KEY]
-    del full_sdata.table
+    del full_sdata.tables["table"]
     full_sdata.table = TableModel.parse(
         adata, region=["circles", "poly"], region_key="annotated_shapes", instance_key="instance_id"
     )
@@ -145,8 +145,8 @@ def test_filter_by_coordinate_system_also_table(full_sdata: SpatialData) -> None
     filtered_sdata1 = full_sdata.filter_by_coordinate_system(coordinate_system="my_space1")
     filtered_sdata2 = full_sdata.filter_by_coordinate_system(coordinate_system="my_space0", filter_table=False)
 
-    assert len(filtered_sdata0.table) + len(filtered_sdata1.table) == len(full_sdata.table)
-    assert len(filtered_sdata2.table) == len(full_sdata.table)
+    assert len(filtered_sdata0["table"]) + len(filtered_sdata1["table"]) == len(full_sdata["table"])
+    assert len(filtered_sdata2["table"]) == len(full_sdata["table"])
 
 
 def test_rename_coordinate_systems(full_sdata: SpatialData) -> None:
@@ -257,7 +257,7 @@ def test_concatenate_sdatas(full_sdata: SpatialData) -> None:
     with pytest.raises(KeyError):
         concatenate([full_sdata, SpatialData(shapes={"circles": full_sdata.shapes["circles"]})])
 
-    assert concatenate([full_sdata, SpatialData()]).table is not None
+    assert concatenate([full_sdata, SpatialData()])["table"] is not None
 
     set_transformation(full_sdata.shapes["circles"], Identity(), "my_space0")
     set_transformation(full_sdata.shapes["poly"], Identity(), "my_space1")
@@ -268,11 +268,11 @@ def test_concatenate_sdatas(full_sdata: SpatialData) -> None:
     # this is needed cause we can't handle regions with same name.
     # TODO: fix this
     new_region = "sample2"
-    table_new = filtered1.table.copy()
-    del filtered1.table
-    filtered1.table = table_new
-    filtered1.table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY] = new_region
-    filtered1.table.obs[filtered1.table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]] = new_region
+    table_new = filtered1["table"].copy()
+    del filtered1.tables["table"]
+    filtered1["table"] = table_new
+    filtered1["table"].uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY] = new_region
+    filtered1["table"].obs[filtered1["table"].uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]] = new_region
     concatenated = concatenate([filtered0, filtered1], concatenate_tables=True)
     assert len(list(concatenated.gen_elements())) == 3
 
@@ -341,20 +341,20 @@ def test_subset(full_sdata: SpatialData) -> None:
     assert "image3d_xarray" in full_sdata.images
     assert unique_names == set(element_names)
     # no table since the labels are not present in the subset
-    assert subset0.table is None
+    assert "table" not in subset0.tables
 
     adata = AnnData(
         shape=(10, 0),
         obs={"region": ["circles"] * 5 + ["poly"] * 5, "instance_id": [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]},
     )
-    del full_sdata.table
+    del full_sdata.tables["table"]
     sdata_table = TableModel.parse(adata, region=["circles", "poly"], region_key="region", instance_key="instance_id")
-    full_sdata.table = sdata_table
+    full_sdata["table"] = sdata_table
     full_sdata.tables["second_table"] = sdata_table
     subset1 = full_sdata.subset(["poly", "second_table"])
-    assert subset1.table is not None
-    assert len(subset1.table) == 5
-    assert subset1.table.obs["region"].unique().tolist() == ["poly"]
+    assert subset1["table"] is not None
+    assert len(subset1["table"]) == 5
+    assert subset1["table"].obs["region"].unique().tolist() == ["poly"]
     assert len(subset1["second_table"]) == 10
 
 

--- a/tests/core/operations/test_transform.py
+++ b/tests/core/operations/test_transform.py
@@ -549,7 +549,7 @@ def test_transform_elements_and_entire_spatial_data_object_multi_hop(
             labels=dict(full_sdata.labels),
             points=dict(full_sdata.points),
             shapes=dict(full_sdata.shapes),
-            table=full_sdata.table,
+            table=full_sdata["table"],
         )
         temp["transformed_element"] = transformed_element
         transformation = get_transformation_between_coordinate_systems(

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -467,7 +467,7 @@ def test_get_values_df(sdata_query_aggregation):
     assert v.shape == (9, 1)
 
     # test with multiple values, in the obs
-    sdata_query_aggregation.table.obs["another_numerical_in_obs"] = v
+    sdata_query_aggregation["table"].obs["another_numerical_in_obs"] = v
     v = get_values(
         value_key=["numerical_in_obs", "another_numerical_in_obs"],
         sdata=sdata_query_aggregation,
@@ -484,13 +484,13 @@ def test_get_values_df(sdata_query_aggregation):
 
     # test with multiple values, in the var
     # prepare the data
-    adata = sdata_query_aggregation.table
+    adata = sdata_query_aggregation["table"]
     X = adata.X
     new_X = np.hstack([X, X[:, 0:1]])
     new_adata = AnnData(
         X=new_X, obs=adata.obs, var=pd.DataFrame(index=["numerical_in_var", "another_numerical_in_var"]), uns=adata.uns
     )
-    del sdata_query_aggregation.table
+    del sdata_query_aggregation.tables["table"]
     sdata_query_aggregation.table = new_adata
     # test
     v = get_values(
@@ -503,7 +503,7 @@ def test_get_values_df(sdata_query_aggregation):
 
     # test exceptions
     # value found in multiple locations
-    sdata_query_aggregation.table.obs["another_numerical_in_gdf"] = np.zeros(21)
+    sdata_query_aggregation["table"].obs["another_numerical_in_gdf"] = np.zeros(21)
     with pytest.raises(ValueError):
         get_values(
             value_key="another_numerical_in_gdf",

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -491,7 +491,7 @@ def test_get_values_df(sdata_query_aggregation):
         X=new_X, obs=adata.obs, var=pd.DataFrame(index=["numerical_in_var", "another_numerical_in_var"]), uns=adata.uns
     )
     del sdata_query_aggregation.tables["table"]
-    sdata_query_aggregation.table = new_adata
+    sdata_query_aggregation["table"] = new_adata
     # test
     v = get_values(
         value_key=["numerical_in_var", "another_numerical_in_var"],
@@ -561,7 +561,7 @@ def test_filter_table_categorical_bug(shapes):
     adata.obs["cell_id"] = np.arange(len(adata))
     adata = TableModel.parse(adata, region=["circles"], region_key="region", instance_key="cell_id")
     adata_subset = adata[adata.obs["categorical"] == "a"].copy()
-    shapes.table = adata_subset
+    shapes["table"] = adata_subset
     shapes.filter_by_coordinate_system("global")
 
 

--- a/tests/core/query/test_spatial_query.py
+++ b/tests/core/query/test_spatial_query.py
@@ -409,15 +409,15 @@ def test_query_filter_table(with_polygon_query: bool):
             target_coordinate_system="global",
         )
 
-    assert len(queried0.table) == 1
-    assert len(queried1.table) == 3
+    assert len(queried0["table"]) == 1
+    assert len(queried1["table"]) == 3
 
 
 def test_polygon_query_with_multipolygon(sdata_query_aggregation):
     sdata = sdata_query_aggregation
     values_sdata = SpatialData(
         shapes={"values_polygons": sdata["values_polygons"], "values_circles": sdata["values_circles"]},
-        tables=sdata.table,
+        tables=sdata["table"],
     )
     polygon = sdata["by_polygons"].geometry.iloc[0]
     circle = sdata["by_circles"].geometry.iloc[0]
@@ -432,19 +432,19 @@ def test_polygon_query_with_multipolygon(sdata_query_aggregation):
     )
     assert len(queried["values_polygons"]) == 4
     assert len(queried["values_circles"]) == 4
-    assert len(queried.table) == 8
+    assert len(queried["table"]) == 8
 
     multipolygon = GeoDataFrame(geometry=[polygon, circle_pol]).unary_union
     queried = polygon_query(values_sdata, polygon=multipolygon, target_coordinate_system="global")
     assert len(queried["values_polygons"]) == 8
     assert len(queried["values_circles"]) == 8
-    assert len(queried.table) == 16
+    assert len(queried["table"]) == 16
 
     multipolygon = GeoDataFrame(geometry=[polygon, polygon]).unary_union
     queried = polygon_query(values_sdata, polygon=multipolygon, target_coordinate_system="global")
     assert len(queried["values_polygons"]) == 4
     assert len(queried["values_circles"]) == 4
-    assert len(queried.table) == 8
+    assert len(queried["table"]) == 8
 
     PLOT = False
     if PLOT:

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -5,7 +5,7 @@ def test_datasets() -> None:
     extra_cs = "test"
     sdata_blobs = blobs(extra_coord_system=extra_cs)
 
-    assert len(sdata_blobs.table) == 26
+    assert len(sdata_blobs["table"]) == 26
     assert len(sdata_blobs.shapes["blobs_circles"]) == 5
     assert len(sdata_blobs.shapes["blobs_polygons"]) == 5
     assert len(sdata_blobs.shapes["blobs_multipolygons"]) == 2

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -19,7 +19,7 @@ def test_datasets() -> None:
     _ = str(sdata_blobs)
 
     sdata_raccoon = raccoon()
-    assert sdata_raccoon.table is None
+    assert "table" not in sdata_raccoon.tables
     assert len(sdata_raccoon.shapes["circles"]) == 4
     assert sdata_raccoon.images["raccoon"].shape == (3, 768, 1024)
     assert sdata_raccoon.labels["segmentation"].shape == (768, 1024)

--- a/tests/io/test_readwrite.py
+++ b/tests/io/test_readwrite.py
@@ -73,9 +73,9 @@ class TestReadWrite:
         tmpdir = Path(tmp_path) / "tmp.zarr"
         table.write(tmpdir)
         sdata = SpatialData.read(tmpdir)
-        pd.testing.assert_frame_equal(table.table.obs, sdata.table.obs)
+        pd.testing.assert_frame_equal(table["table"].obs, sdata["table"].obs)
         try:
-            assert table.table.uns == sdata.table.uns
+            assert table["table"].uns == sdata["table"].uns
         except ValueError as e:
             raise e
 

--- a/tests/io/test_readwrite.py
+++ b/tests/io/test_readwrite.py
@@ -305,20 +305,20 @@ def test_io_table(shapes):
     adata.obs["instance"] = shapes.shapes["circles"].index
     adata = TableModel().parse(adata, region="circles", region_key="region", instance_key="instance")
     shapes.table = adata
-    del shapes.table
+    del shapes.tables["table"]
     shapes.table = adata
     with tempfile.TemporaryDirectory() as tmpdir:
         f = os.path.join(tmpdir, "data.zarr")
         shapes.write(f)
         shapes2 = SpatialData.read(f)
-        assert shapes2.table is not None
-        assert shapes2.table.shape == (5, 10)
+        assert "table" in shapes2.tables
+        assert shapes2["table"].shape == (5, 10)
 
-        del shapes2.table
-        assert shapes2.table is None
+        del shapes2.tables["table"]
+        assert "table" not in shapes2.tables
         shapes2.table = adata
-        assert shapes2.table is not None
-        assert shapes2.table.shape == (5, 10)
+        assert "table" in shapes2.tables
+        assert shapes2["table"].shape == (5, 10)
 
 
 def test_bug_rechunking_after_queried_raster():


### PR DESCRIPTION
This PR adds a function `join_spatialelement_table` which is equivalent to `join_sdata_spatialelement_table` but does not require the elements to be part of a SpatialData object.