### PR TITLE
fix models docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
-## [0.1.2] - 2024-xx-xx
+## [0.1.3] - 2024-xx-xx
+
+## [0.1.2] - 2024-03-30
 
 ### Minor
 
 -   Made `get_channels()` public.
+-   Added utils `force_2d()` to force 3D shapes to 2D (this is a temporary solution until `.force_2d()` is available in `geopandas`).
 
 ## [0.1.1] - 2024-03-28
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -84,6 +84,7 @@ The elements (building-blocks) that consitute `SpatialData`.
     points_geopandas_to_dask_dataframe
     points_dask_dataframe_to_geopandas
     get_channels
+    force_2d
 ```
 
 ## Transformations

--- a/src/spatialdata/models/__init__.py
+++ b/src/spatialdata/models/__init__.py
@@ -6,6 +6,7 @@ from spatialdata.models._utils import (
     X,
     Y,
     Z,
+    force_2d,
     get_axes_names,
     get_channels,
     get_spatial_axes,
@@ -50,4 +51,5 @@ __all__ = [
     "check_target_region_column_symmetry",
     "get_table_keys",
     "get_channels",
+    "force_2d",
 ]

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -512,11 +512,12 @@ class PointsModel:
             Data to parse:
 
                 - If :class:`numpy.ndarray`, an `annotation` :class:`pandas.DataFrame`
-                  must be provided, as well as the `feature_key` in the `annotation`. Furthermore,
+                  can be provided, as well as a `feature_key` column in the `annotation` dataframe. Furthermore,
                   :class:`numpy.ndarray` is assumed to have shape `(n_points, axes)`, with `axes` being
                   "x", "y" and optionally "z".
-                - If :class:`pandas.DataFrame`, a `coordinates` mapping must be provided
-                  with key as *valid axes* and value as column names in dataframe.
+                - If :class:`pandas.DataFrame`, a `coordinates` mapping can be provided
+                  with key as *valid axes* ('x', 'y', 'z') and value as column names in dataframe. If the dataframe
+                  already has columns named 'x', 'y' and 'z', the mapping can be omitted.
 
         annotation
             Annotation dataframe. Only if `data` is :class:`numpy.ndarray`. If data is an array, the index of the
@@ -524,12 +525,15 @@ class PointsModel:
         coordinates
             Mapping of axes names (keys) to column names (valus) in `data`. Only if `data` is
             :class:`pandas.DataFrame`. Example: {'x': 'my_x_column', 'y': 'my_y_column'}.
-            If not provided and `data` is :class:`pandas.DataFrame`, and `x`, `y` and optinally `z` are column names,
+            If not provided and `data` is :class:`pandas.DataFrame`, and `x`, `y` and optionally `z` are column names,
             then they will be used as coordinates.
         feature_key
-            Feature key in `annotation` or `data`.
+            Optional, feature key in `annotation` or `data`. Example use case: gene id categorical column describing the
+            gene identity of each point.
         instance_key
-            Instance key in `annotation` or `data`.
+            Optional, instance key in `annotation` or `data`. Example use case: cell id column, describing which cell
+            a point belongs to. This argument is likely going to be deprecated:
+            https://github.com/scverse/spatialdata/issues/503.
         transformations
             Transformations of points.
         kwargs

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -345,7 +345,9 @@ class ShapesModel:
             if n != 2:
                 warnings.warn(
                     f"The geometry column of the GeoDataFrame has {n} dimensions, while 2 is expected. Please consider "
-                    "discarding the third dimension as it could led to unexpected behaviors.",
+                    "discarding the third dimension as it could led to unexpected behaviors. To achieve so, you can use"
+                    " `.force_2d()` if you are using `geopandas > 0.14.3, otherwise you can use `force_2d()` from "
+                    "`spatialdata.models`.",
                     UserWarning,
                     stacklevel=2,
                 )


### PR DESCRIPTION
- fixed docstrings data model
- added an implementation of `force_2d()` utils function valid for `GeoDataFrame` constructed with `ShapesModel.parse()`. `force_2d()` is available in `geopandas` but not release yet and it's needed for https://github.com/scverse/napari-spatialdata/issues/218.