### PR TITLE
updated deprecation_alias

### DIFF
--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -24,7 +24,7 @@ from spatial_image import SpatialImage
 from spatialdata._core._elements import Images, Labels, Points, Shapes, Tables
 from spatialdata._logging import logger
 from spatialdata._types import ArrayLike, Raster_T
-from spatialdata._utils import _error_message_add_element, deprecation_alias
+from spatialdata._utils import _deprecation_alias, _error_message_add_element
 from spatialdata.models import (
     Image2DModel,
     Image3DModel,
@@ -108,7 +108,7 @@ class SpatialData:
     annotation directly.
     """
 
-    @deprecation_alias(table="tables")
+    @_deprecation_alias(table="tables", version="version 0.1.0")
     def __init__(
         self,
         images: dict[str, Raster_T] | None = None,
@@ -684,7 +684,7 @@ class SpatialData:
                         " not found in Zarr storage"
                     )
 
-    @deprecation_alias(filter_table="filter_tables")
+    @_deprecation_alias(filter_table="filter_tables", version="version 0.1.0")
     def filter_by_coordinate_system(
         self, coordinate_system: str | list[str], filter_tables: bool = True, include_orphan_tables: bool = False
     ) -> SpatialData:
@@ -1572,7 +1572,7 @@ class SpatialData:
             raise KeyError(f"Could not find element with name {element_name!r}")
 
     @classmethod
-    @deprecation_alias(table="tables")
+    @_deprecation_alias(table="tables", version="version 0.1.0")
     def init_from_elements(
         cls, elements: dict[str, SpatialElement], tables: AnnData | dict[str, AnnData] | None = None
     ) -> SpatialData:

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -108,7 +108,7 @@ class SpatialData:
     annotation directly.
     """
 
-    @_deprecation_alias(table="tables", version="version 0.1.0")
+    @_deprecation_alias(table="tables", version="0.1.0")
     def __init__(
         self,
         images: dict[str, Raster_T] | None = None,
@@ -684,7 +684,7 @@ class SpatialData:
                         " not found in Zarr storage"
                     )
 
-    @_deprecation_alias(filter_table="filter_tables", version="version 0.1.0")
+    @_deprecation_alias(filter_table="filter_tables", version="0.1.0")
     def filter_by_coordinate_system(
         self, coordinate_system: str | list[str], filter_tables: bool = True, include_orphan_tables: bool = False
     ) -> SpatialData:
@@ -1572,7 +1572,7 @@ class SpatialData:
             raise KeyError(f"Could not find element with name {element_name!r}")
 
     @classmethod
-    @_deprecation_alias(table="tables", version="version 0.1.0")
+    @_deprecation_alias(table="tables", version="0.1.0")
     def init_from_elements(
         cls, elements: dict[str, SpatialElement], tables: AnnData | dict[str, AnnData] | None = None
     ) -> SpatialData:

--- a/src/spatialdata/_utils.py
+++ b/src/spatialdata/_utils.py
@@ -239,7 +239,7 @@ def _deprecation_alias(**aliases: str) -> Callable[[Callable[..., RT]], Callable
     Assuming we have an argument 'table' set for deprecation and we want to warn the user and substitute with 'tables':
 
     ```python
-    @_deprecation_alias(table="tables", version="version 0.1.0")
+    @_deprecation_alias(table="tables", version="0.1.0")
     def my_function(tables: AnnData | dict[str, AnnData]):
         pass
     ```
@@ -250,10 +250,11 @@ def _deprecation_alias(**aliases: str) -> Callable[[Callable[..., RT]], Callable
         def wrapper(*args: Any, **kwargs: Any) -> RT:
             class_name = f.__qualname__
             library = f.__module__.split(".")[0]
-            version = aliases.pop("version") if aliases.get("version") is not None else None
+            alias_copy = aliases.copy()
+            version = alias_copy.pop("version") if alias_copy.get("version") is not None else None
             if version is None:
                 raise ValueError("version for deprecation must be specified")
-            rename_kwargs(f.__name__, kwargs, aliases, class_name, library, version)
+            rename_kwargs(f.__name__, kwargs, alias_copy, class_name, library, version)
             return f(*args, **kwargs)
 
         return wrapper

--- a/src/spatialdata/_utils.py
+++ b/src/spatialdata/_utils.py
@@ -250,7 +250,7 @@ def _deprecation_alias(**aliases: str) -> Callable[[Callable[..., RT]], Callable
         def wrapper(*args: Any, **kwargs: Any) -> RT:
             class_name = f.__qualname__
             library = f.__module__.split(".")[0]
-            version = aliases.get("version")
+            version = aliases.pop("test") if aliases.get("version") is not None else None
             if version is None:
                 raise ValueError("version for deprecation must be specified")
             rename_kwargs(f.__name__, kwargs, aliases, class_name, library, version)
@@ -275,7 +275,7 @@ def rename_kwargs(
                 )
             warnings.warn(
                 message=(
-                    f"`{alias}` is being deprecated as an argument to `{class_name}{func_name}` in {library} "
+                    f"`{alias}` is being deprecated as an argument to `{class_name}{func_name}` in {library} version "
                     f"{version}, switch to `{new}` instead."
                 ),
                 category=DeprecationWarning,

--- a/src/spatialdata/_utils.py
+++ b/src/spatialdata/_utils.py
@@ -250,7 +250,7 @@ def _deprecation_alias(**aliases: str) -> Callable[[Callable[..., RT]], Callable
         def wrapper(*args: Any, **kwargs: Any) -> RT:
             class_name = f.__qualname__
             library = f.__module__.split(".")[0]
-            version = aliases.pop("test") if aliases.get("version") is not None else None
+            version = aliases.pop("version") if aliases.get("version") is not None else None
             if version is None:
                 raise ValueError("version for deprecation must be specified")
             rename_kwargs(f.__name__, kwargs, aliases, class_name, library, version)


### PR DESCRIPTION
I have updated the `deprecation_alias` to be flexible enough for implementation across the ecosystems and to handle different arguments with deprecations in different versions.

Example
```
@deprecation_alias(table="tables", version="version 0.1")
def your_function(tables):
      do something...

your_function(table)
```
This will now give a message that table is set for deprecation from version 0.1 onwards. The message will also include the library so if a deprecation_alias decorator is applied in a function in spatialdata-plot then it will indicate the spatialdata-plot library in the message.

@timtreis probably useful for the spatialdata-plot refactor.