### PR TITLE
improve data loader performance

### DIFF
--- a/src/spatialdata/_core/query/spatial_query.py
+++ b/src/spatialdata/_core/query/spatial_query.py
@@ -496,7 +496,8 @@ def _(
     target_coordinate_system
         The coordinate system the bounding box is defined in.
     return_array
-        If `True`, return the query result as a `numpy.ndarray` and it does not parse it into a SpatialImage.
+        If `True`, return the query result as a `numpy.ndarray` and it does not parse it into a `SpatialImage`
+        or `MultiscaleSpatialImage`.
     """
     from spatialdata.transformations import get_transformation, set_transformation
 


### PR DESCRIPTION
so I've been wanting to take another look at this for a long time, I used https://github.com/benfred/py-spy with `speedscope`  format, you can see screenshot below. 
<img width="1409" alt="image" src="https://github.com/scverse/spatialdata/assets/25887487/b257d9d8-b5c3-453b-8682-0863602b4234">

I've been doing this on the `xenium_rep_1` dataset from the paper, and been using the following code (adapting  from @LucaMarconato code ):

<details>
<summary>Details</summary>

```python
import json

import numpy as np
import pandas as pd
import torchvision.transforms.v2 as T
from spatialdata.dataloader.datasets import ImageTilesDataset
from spatialdata.transformations import Scale, get_transformation
from spatialdata.transformations import Sequence as SequenceTransformation
from torch.utils.data import DataLoader
from tqdm import tqdm

from pathlib import Path
import spatialdata as sd

xeniumrep1 = Path(
  "/path/to/xenium_rep1_data_aligned.zarr"
)
sdata1 = sd.read_zarr(xeniumrep1)

visium = Path(
    "/path/to/visium_data_aligned.zarr"
)
sdata3 = sd.read_zarr(visium)

TILE_SCALE = 10.0
REGION = "xeniumrep1"
sdata = sdata1
sdata.images["hne"] = sdata3.images["CytAssist_FFPE_Human_Breast_Cancer_full_image"]

def get_ds(sdata: sd.SpatialData):
    img_size = 224

    transform_tv = T.Compose(
        [
            T.ToImage(),
            T.Resize((img_size, img_size), antialias=True, interpolation=T.InterpolationMode.BICUBIC),
            T.ToTensor(),
        ]
    )

    def transform(output):
        image, anno = output
        instance_id, celltype = anno[:, 0].squeeze(), anno[:, 1].squeeze()
        image = transform_tv(image.data.transpose(1, 2, 0).compute(scheduler="single-threaded"))
        out = {"img": image, "instance_id": instance_id.tolist(), "celltype": celltype.tolist()}
        return out

    mu = sdata.shapes["cell_circles"]["radius"].mean()
    std = sdata.shapes["cell_circles"]["radius"].std()
    # large radius to cover most of the cells
    large_radius = mu + 2 * std
    neighbors_contex = large_radius
    sdata.shapes["cell_circles"]["radius"] = neighbors_contex
    instance_key = sdata.tables["table"].uns["spatialdata_attrs"]["instance_key"]

    ds = ImageTilesDataset(
        sdata=sdata,
        regions_to_images={"cell_circles": "hne"},
        regions_to_coordinate_systems={"cell_circles": "aligned"},
        return_annotations=[instance_key, "celltype_major"],
        tile_scale=TILE_SCALE,
        transform=transform,
        table_name="table",
    )
    return ds

ds = get_ds(sdata)
dl = DataLoader(
    ds,
    batch_size=256,
    num_workers=0,
    shuffle=False,
)

```

</details>

this made me realize that, if we want to return the array, than there is an unnecessary step of instantiating the `SpatialImage|MultiscaleSpatialImage` that is not necessary, and the dask array could be simply returned. This halved the `fetch` step (across 6 iterations) from ~43s  to ~23s total, see below
<img width="1408" alt="image" src="https://github.com/scverse/spatialdata/assets/25887487/5900c725-9e01-4a0c-a7b4-979439028a4f">

I think the `fetch` step is what ultimately we want to improve, as it's the one that stream the tiles from the zarr array to the GPU. Now the two main blocks are the `transform` call and the `compute` call. The `transform` call is visualized under `compute` but it's effectively the `wrapper` call, where all the `DataArray.isel` happen, which is where the crops are defined, transformed and set, before the computation is actually triggered with `compute`.
<img width="721" alt="image" src="https://github.com/scverse/spatialdata/assets/25887487/d0603658-5912-47a6-b8e1-a3dfc124e291">
I wonder what could be the next step here to chase performance gain: I think one option would be to basically "prepare" the transformation before on the full array, and then trigger it only at the tile creation in the `compute` (whereas now, transformation and tile creation is done jointly for each tile). This I think would require significant refactoring though so I wonder if it makes sense at all, and if anyone has other ideas to explore @scverse/spatialdata 
