### PR TITLE
support AnnData table with get_values

### DIFF
--- a/src/spatialdata/_core/operations/rasterize.py
+++ b/src/spatialdata/_core/operations/rasterize.py
@@ -336,7 +336,7 @@ def rasterize(
         if value_key is not None:
             element_name = data if isinstance(data, str) else None
             kwargs = {"sdata": sdata, "element_name": element_name} if element_name is not None else {"element": data}
-            values = get_values(value_key, table_name=table_name, **kwargs).iloc[:, 0]  # type: ignore[arg-type]
+            values = get_values(value_key, table_name=table_name, **kwargs).iloc[:, 0]  # type: ignore[arg-type, union-attr]
             max_index = np.max(values.index)
             assigner = np.zeros(max_index + 1, dtype=values.dtype)
             assigner[values.index] = values
@@ -651,7 +651,7 @@ def rasterize_shapes_points(
 
     if value_key is not None:
         kwargs = {"sdata": sdata, "element_name": element_name} if element_name is not None else {"element": data}
-        data[VALUES_COLUMN] = get_values(value_key, table_name=table_name, **kwargs).iloc[:, 0]  # type: ignore[arg-type]
+        data[VALUES_COLUMN] = get_values(value_key, table_name=table_name, **kwargs).iloc[:, 0]  # type: ignore[arg-type, union-attr]
     elif isinstance(data, GeoDataFrame):
         value_key = VALUES_COLUMN
         data[VALUES_COLUMN] = data.index.astype("category")

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -762,7 +762,7 @@ def get_values(
     sdata: SpatialData | None = None,
     element_name: str | None = None,
     table_name: str | None = None,
-    return_array: bool = False,
+    return_obsm_as_is: bool = False,
 ) -> pd.DataFrame | npt.NDArray[Any]:
     """
     Get the values from the element, from any location: df columns, obs or var columns (table).
@@ -781,6 +781,9 @@ def get_values(
         annotating the element_name.
     table_name
         Name of the table to get the values from.
+    return_obsm_as_is
+        In case the value is in obsm the value of the key can be returned as is if return_obsm_as_is is True, otherwise
+        creates a dataframe and returns it.
 
     Returns
     -------
@@ -858,9 +861,9 @@ def get_values(
             data = {}
             for key in value_key_values:
                 data_values = matched_table.obsm[key]
-                if len(value_key_values) == 1 and return_array:
+                if len(value_key_values) == 1 and return_obsm_as_is:
                     return data_values
-                if len(value_key_values) > 1 and return_array:
+                if len(value_key_values) > 1 and return_obsm_as_is:
                     warnings.warn(
                         "Multiple value_keys are specified. If you want to return an array only 1 should be specified",
                         UserWarning,

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 
 import dask.array as da
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 from anndata import AnnData
 from dask.dataframe.core import DataFrame as DaskDataFrame
@@ -761,7 +762,8 @@ def get_values(
     sdata: SpatialData | None = None,
     element_name: str | None = None,
     table_name: str | None = None,
-) -> pd.DataFrame:
+    return_array: bool = False,
+) -> pd.DataFrame | npt.NDArray[Any]:
     """
     Get the values from the element, from any location: df columns, obs or var columns (table).
 
@@ -856,6 +858,14 @@ def get_values(
             data = {}
             for key in value_key_values:
                 data_values = matched_table.obsm[key]
+                if len(value_key_values) == 1 and return_array:
+                    return data_values
+                if len(value_key_values) > 1 and return_array:
+                    warnings.warn(
+                        "Multiple value_keys are specified. If you want to return an array only 1 should be specified",
+                        UserWarning,
+                        stacklevel=2,
+                    )
                 for i in range(data_values.shape[1]):
                     data[key + f"_{i}"] = data_values[:, i]
             df = pd.DataFrame(data)

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -10,7 +10,6 @@ from typing import Any, Literal
 
 import dask.array as da
 import numpy as np
-import numpy.typing as npt
 import pandas as pd
 from anndata import AnnData
 from dask.dataframe.core import DataFrame as DaskDataFrame
@@ -18,6 +17,7 @@ from multiscale_spatial_image import MultiscaleSpatialImage
 from spatial_image import SpatialImage
 
 from spatialdata._core.spatialdata import SpatialData
+from spatialdata._types import ArrayLike
 from spatialdata._utils import _inplace_fix_subset_categorical_obs
 from spatialdata.models import (
     Image2DModel,
@@ -763,7 +763,7 @@ def get_values(
     element_name: str | None = None,
     table_name: str | None = None,
     return_obsm_as_is: bool = False,
-) -> pd.DataFrame | npt.NDArray[Any]:
+) -> pd.DataFrame | ArrayLike:
     """
     Get the values from the element, from any location: df columns, obs or var columns (table).
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,17 +34,8 @@ from spatialdata.models import (
 )
 from xarray import DataArray
 
-RNG = default_rng(seed=0)
-
-try:
-    from numpy.typing import NDArray
-
-    NDArrayA = NDArray[Any]
-except (ImportError, TypeError):
-    NDArray = np.ndarray  # type: ignore[misc]
-    NDArrayA = np.ndarray  # type: ignore[misc]
-
-SEED = 42
+SEED = 0
+RNG = default_rng(seed=SEED)
 
 POLYGON_PATH = Path(__file__).parent / "data/polygon.json"
 MULTIPOLYGON_PATH = Path(__file__).parent / "data/polygon.json"
@@ -249,7 +240,7 @@ def _get_shapes() -> dict[str, GeoDataFrame]:
             ]
         }
     )
-    rng = np.random.default_rng(seed=0)
+    rng = np.random.default_rng(seed=SEED)
     points["radius"] = np.abs(rng.normal(size=(len(points), 1)))
 
     out["poly"] = ShapesModel.parse(poly)
@@ -302,7 +293,7 @@ def _get_table(
 
 
 def _get_new_table(spatial_element: None | str | Sequence[str], instance_id: None | Sequence[Any]) -> AnnData:
-    adata = AnnData(np.random.default_rng(seed=0).random(10, 20000))
+    adata = AnnData(np.random.default_rng(seed=SEED).random(10, 20000))
     return TableModel.parse(adata=adata, spatial_element=spatial_element, instance_id=instance_id)
 
 
@@ -473,7 +464,7 @@ def generate_adata(n_var: int, obs: pd.DataFrame, obsm: dict[Any, Any], uns: dic
     )
 
 
-def _get_blobs_galaxy() -> tuple[NDArrayA, NDArrayA]:
+def _get_blobs_galaxy() -> tuple[ArrayLike, ArrayLike]:
     blobs = data.binary_blobs(rng=SEED)
     blobs = ndi.label(blobs)[0]
     return blobs, data.hubble_deep_field()[: blobs.shape[0], : blobs.shape[0]]
@@ -499,19 +490,10 @@ def adata_labels() -> AnnData:
         index=np.arange(n_obs_labels),
     )
     uns_labels = {
-        "spatial": {
-            "labels": {
-                "scalefactors": {
-                    "spot_diameter_fullres": 10,
-                    "tissue_hires_scalef": 1,
-                    "tissue_segmentation_scalef": 1,
-                }
-            }
-        },
         "spatialdata_attrs": {"region": "test", "region_key": "region", "instance_key": "instance_id"},
     }
     obsm_labels = {
-        "spatial": rng.integers(0, blobs.shape[0], size=(n_obs_labels, 2)),
-        "spatial_copy": rng.integers(0, blobs.shape[0], size=(n_obs_labels, 2)),
+        "tensor": rng.integers(0, blobs.shape[0], size=(n_obs_labels, 2)),
+        "tensor_copy": rng.integers(0, blobs.shape[0], size=(n_obs_labels, 2)),
     }
     return generate_adata(n_var, obs_labels, obsm_labels, uns_labels)

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -621,6 +621,12 @@ def test_get_values_df(sdata_query_aggregation):
         )
 
 
+def test_get_values_obsm(adata_labels: AnnData):
+    get_values(value_key="spatial", element=adata_labels)
+
+    get_values(value_key=["spatial", "spatial_copy"], element=adata_labels)
+
+
 def test_get_values_table(sdata_blobs):
     get_values(value_key="channel_0_sum", element=sdata_blobs["table"])
 

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -622,11 +622,11 @@ def test_get_values_df(sdata_query_aggregation):
 
 
 def test_get_values_obsm(adata_labels: AnnData):
-    get_values(value_key="spatial", element=adata_labels)
+    get_values(value_key="tensor", element=adata_labels)
 
-    get_values(value_key=["spatial", "spatial_copy"], element=adata_labels)
+    get_values(value_key=["tensor", "tensor_copy"], element=adata_labels)
 
-    values = get_values(value_key="spatial", element=adata_labels, return_obsm_as_is=True)
+    values = get_values(value_key="tensor", element=adata_labels, return_obsm_as_is=True)
     assert isinstance(values, np.ndarray)
 
 

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -625,6 +625,10 @@ def test_get_values_table(sdata_blobs):
     get_values(value_key="channel_0_sum", element=sdata_blobs["table"])
 
 
+def test_get_values_table_element_name(sdata_blobs):
+    get_values(value_key="channel_0_sum", element=sdata_blobs["table"], element_name="blobs_labels")
+
+
 def test_get_values_labels_bug(sdata_blobs):
     # https://github.com/scverse/spatialdata-plot/issues/165
     get_values("channel_0_sum", sdata=sdata_blobs, element_name="blobs_labels", table_name="table")

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -626,6 +626,9 @@ def test_get_values_obsm(adata_labels: AnnData):
 
     get_values(value_key=["spatial", "spatial_copy"], element=adata_labels)
 
+    values = get_values(value_key="spatial", element=adata_labels, return_array=True)
+    assert isinstance(values, np.ndarray)
+
 
 def test_get_values_table(sdata_blobs):
     get_values(value_key="channel_0_sum", element=sdata_blobs["table"])

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -626,7 +626,7 @@ def test_get_values_obsm(adata_labels: AnnData):
 
     get_values(value_key=["spatial", "spatial_copy"], element=adata_labels)
 
-    values = get_values(value_key="spatial", element=adata_labels, return_array=True)
+    values = get_values(value_key="spatial", element=adata_labels, return_obsm_as_is=True)
     assert isinstance(values, np.ndarray)
 
 

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -621,10 +621,12 @@ def test_get_values_df(sdata_query_aggregation):
         )
 
 
+def test_get_values_table(sdata_blobs):
+    get_values(value_key="channel_0_sum", element=sdata_blobs["table"])
+
+
 def test_get_values_labels_bug(sdata_blobs):
     # https://github.com/scverse/spatialdata-plot/issues/165
-    from spatialdata import get_values
-
     get_values("channel_0_sum", sdata=sdata_blobs, element_name="blobs_labels", table_name="table")
 
 

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -631,11 +631,19 @@ def test_get_values_obsm(adata_labels: AnnData):
 
 
 def test_get_values_table(sdata_blobs):
-    get_values(value_key="channel_0_sum", element=sdata_blobs["table"])
+    df = get_values(value_key="channel_0_sum", element=sdata_blobs["table"])
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 26
 
 
 def test_get_values_table_element_name(sdata_blobs):
-    get_values(value_key="channel_0_sum", element=sdata_blobs["table"], element_name="blobs_labels")
+    sdata_blobs["table"].obs["region"] = sdata_blobs["table"].obs["region"].cat.add_categories("another_region")
+    sdata_blobs["table"].obs.loc["1", "region"] = "another_region"
+    sdata_blobs["table"].uns["spatialdata_attrs"]["region"] = ["blobs_labels", "another_region"]
+    sdata_blobs["another_region"] = sdata_blobs["blobs_labels"]
+    df = get_values(value_key="channel_0_sum", element=sdata_blobs["table"], element_name="blobs_labels")
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 25
 
 
 def test_get_values_labels_bug(sdata_blobs):


### PR DESCRIPTION
This PR allows to also pass an `AnnData` table as `element`. If `element_name` is `None` then a whole column is returned but if it is specified than the column is a subset only including those rows annotating the `element_name`. Docstrings have been updated to reflect this.

Furthermore, this PR also allows for getting values from `obsm`.