### PR TITLE
make get_element_annotators public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning][].
 -   Added `datasets` module
 -   Extended `get_values()` to `AnnData` tables #579
 -   Added `get_element_instances()` (replaces `_get_unique_label_values_as_index()`) #582
+-   Added `get_element_annotators()`, retrieving the tables that annotate a particular SpatialElement #595
 
 ## [0.1.2] - 2024-03-30
 

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "aggregate",
     "bounding_box_query",
     "polygon_query",
+    "get_element_annotators",
     "get_element_instances",
     "get_values",
     "join_spatialelement_table",
@@ -48,6 +49,7 @@ from spatialdata._core.operations.transform import transform
 from spatialdata._core.operations.vectorize import to_circles, to_polygons
 from spatialdata._core.query._utils import get_bounding_box_corners
 from spatialdata._core.query.relational_query import (
+    get_element_annotators,
     get_element_instances,
     get_values,
     join_spatialelement_table,

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -34,7 +34,7 @@ from spatialdata.models import (
 )
 
 
-def _get_element_annotators(sdata: SpatialData, element_name: str) -> set[str]:
+def get_element_annotators(sdata: SpatialData, element_name: str) -> set[str]:
     """
     Retrieve names of tables that annotate a SpatialElement in a SpatialData object.
 

--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -4,9 +4,9 @@ import pytest
 from anndata import AnnData
 from spatialdata import get_values, match_table_to_element
 from spatialdata._core.query.relational_query import (
-    _get_element_annotators,
     _locate_value,
     _ValueOrigin,
+    get_element_annotators,
     join_spatialelement_table,
 )
 from spatialdata.models.models import TableModel
@@ -773,13 +773,13 @@ def test_points_table_joins(full_sdata):
 
 
 def test_get_element_annotators(full_sdata):
-    names = _get_element_annotators(full_sdata, "points_0")
+    names = get_element_annotators(full_sdata, "points_0")
     assert len(names) == 0
 
-    names = _get_element_annotators(full_sdata, "labels2d")
+    names = get_element_annotators(full_sdata, "labels2d")
     assert names == {"table"}
 
     another_table = full_sdata.tables["table"].copy()
     full_sdata.tables["another_table"] = another_table
-    names = _get_element_annotators(full_sdata, "labels2d")
+    names = get_element_annotators(full_sdata, "labels2d")
     assert names == {"another_table", "table"}


### PR DESCRIPTION
This makes the `_get_element_annotators` function public. See also: https://github.com/ckmah/bento-tools/issues/140#issuecomment-2186507825