### PR TITLE
Fix #580 region column to categorical

### DIFF
--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -37,7 +37,7 @@ from spatialdata.models import (
     get_model,
     get_table_keys,
 )
-from spatialdata.models._utils import SpatialElement, get_axes_names
+from spatialdata.models._utils import SpatialElement, convert_region_column_to_categorical, get_axes_names
 
 if TYPE_CHECKING:
     from spatialdata._core.query.spatial_query import BaseSpatialRequest
@@ -471,6 +471,7 @@ class SpatialData:
             self._set_table_annotation_target(table, region, region_key, instance_key)
         else:
             raise TypeError("No current annotation metadata found. Please specify both region_key and instance_key.")
+        convert_region_column_to_categorical(table)
 
     @property
     def query(self) -> QueryManager:

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -430,7 +430,7 @@ class SpatialData:
     def set_table_annotates_spatialelement(
         self,
         table_name: str,
-        region: str | pd.Series,
+        region: str | pd.Series | list[str],
         region_key: None | str = None,
         instance_key: None | str = None,
     ) -> None:
@@ -459,8 +459,10 @@ class SpatialData:
         """
         table = self.tables[table_name]
         element_names = {element[1] for element in self._gen_elements()}
-        if region not in element_names:
-            raise ValueError(f"Annotation target '{region}' not present as SpatialElement in SpatialData object.")
+        if (isinstance(region, str) and region not in element_names) or (
+            isinstance(element_names, (list, pd.Series))
+            and not all(region_element in element_names for region_element in region)
+        ):
 
         if table.uns.get(TableModel.ATTRS_KEY):
             self._change_table_annotation_target(table, region, region_key, instance_key)

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -463,6 +463,7 @@ class SpatialData:
             isinstance(element_names, (list, pd.Series))
             and not all(region_element in element_names for region_element in region)
         ):
+            raise ValueError(f"Annotation target '{region}' not present as SpatialElement in SpatialData object.")
 
         if table.uns.get(TableModel.ATTRS_KEY):
             self._change_table_annotation_target(table, region, region_key, instance_key)

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -43,6 +43,7 @@ from spatialdata.models._utils import (
     MappingToCoordinateSystem_t,
     SpatialElement,
     _validate_mapping_to_coordinate_system_type,
+    convert_region_column_to_categorical,
 )
 from spatialdata.transformations._utils import (
     _get_transformations,
@@ -939,11 +940,9 @@ class TableModel:
         region_: list[str] = region if isinstance(region, list) else [region]
         if not adata.obs[region_key].isin(region_).all():
             raise ValueError(f"`adata.obs[{region_key}]` values do not match with `{cls.REGION_KEY}` values.")
-        if not isinstance(adata.obs[region_key].dtype, CategoricalDtype):
-            warnings.warn(
-                f"Converting `{cls.REGION_KEY_KEY}: {region_key}` to categorical dtype.", UserWarning, stacklevel=2
-            )
-            adata.obs[region_key] = pd.Categorical(adata.obs[region_key])
+
+        adata = convert_region_column_to_categorical(adata)
+
         if instance_key is None:
             raise ValueError("`instance_key` must be provided.")
 

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -941,8 +941,6 @@ class TableModel:
         if not adata.obs[region_key].isin(region_).all():
             raise ValueError(f"`adata.obs[{region_key}]` values do not match with `{cls.REGION_KEY}` values.")
 
-        adata = convert_region_column_to_categorical(adata)
-
         if instance_key is None:
             raise ValueError("`instance_key` must be provided.")
 
@@ -958,7 +956,7 @@ class TableModel:
         attr = {"region": region, "region_key": region_key, "instance_key": instance_key}
         adata.uns[cls.ATTRS_KEY] = attr
         cls().validate(adata)
-        return adata
+        return convert_region_column_to_categorical(adata)
 
 
 Schema_t = Union[

--- a/tests/io/test_multi_table.py
+++ b/tests/io/test_multi_table.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pandas as pd
 import pytest
 from anndata import AnnData
 from anndata.tests.helpers import assert_equal

--- a/tests/io/test_multi_table.py
+++ b/tests/io/test_multi_table.py
@@ -127,7 +127,6 @@ class TestMultiTable:
         )
         full_sdata.write(tmpdir)
 
-
     def test_old_accessor_deprecation(self, full_sdata, tmp_path):
         # To test self._backed
         tmpdir = Path(tmp_path) / "tmp.zarr"

--- a/tests/io/test_multi_table.py
+++ b/tests/io/test_multi_table.py
@@ -95,7 +95,8 @@ class TestMultiTable:
         ):
             full_sdata.set_table_annotates_spatialelement("table", "non_existing")
 
-    def test_set_table_annotates_spatialelement(self, full_sdata):
+    def test_set_table_annotates_spatialelement(self, full_sdata, tmp_path):
+        tmpdir = Path(tmp_path) / "tmp.zarr"
         del full_sdata["table"].uns[TableModel.ATTRS_KEY]
         with pytest.raises(
             TypeError, match="No current annotation metadata found. " "Please specify both region_key and instance_key."
@@ -119,6 +120,12 @@ class TestMultiTable:
         full_sdata.set_table_annotates_spatialelement(
             "table", pd.Series(["circles", "poly"]), region_key="region", instance_key="instance_id"
         )
+
+        full_sdata["table"].obs["region"] = "circles"
+        full_sdata.set_table_annotates_spatialelement(
+            "table", "circles", region_key="region", instance_key="instance_id"
+        )
+        full_sdata.write(tmpdir)
 
     def test_old_accessor_deprecation(self, full_sdata, tmp_path):
         # To test self._backed

--- a/tests/io/test_multi_table.py
+++ b/tests/io/test_multi_table.py
@@ -112,6 +112,13 @@ class TestMultiTable:
             "table", "labels2d", region_key="region", instance_key="instance_id"
         )
 
+        region = ["circles"] * 50 + ["poly"] * 50
+        full_sdata["table"].obs["region"] = region
+
+        full_sdata.set_table_annotates_spatialelement(
+            "table", pd.Series(["circles", "poly"]), region_key="region", instance_key="instance_id"
+        )
+
     def test_old_accessor_deprecation(self, full_sdata, tmp_path):
         # To test self._backed
         tmpdir = Path(tmp_path) / "tmp.zarr"


### PR DESCRIPTION
closes #580 

When setting a new annotation target of the table, the region column was not checked to be a categorical so if the user didn't do this it would fail on write. This PR fixes that issue by adding a new function to check whether the column is categorical and converting it. This is used in two places, in the parsing method of the table model and in the function that sets the annotation target.