### PR TITLE
Adjust transform_element_to_coordinate_system parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning][].
 
 -   Using `DataArray` directly instead of the subclass `SpatialImage` (removed install constraint for the `spatial_image` package) #587
 -   Using `DataTree` directly instead of the subclass `MultiscaleSpatialImage` (removed install constraint for the `multiscale_spatial_image` package) #587
+-   Changed `element`parameter (deprecation in v0.3.0) of `transform_element_to_coordinate_system` to a string `element_name` #611
 
 ### Major
 

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -801,16 +801,17 @@ class SpatialData:
             # set the new transformations
             set_transformation(element=element, transformation=new_transformations, set_all=True)
 
+    @_deprecation_alias(element="element_name", version="0.3.0")
     def transform_element_to_coordinate_system(
-        self, element: SpatialElement, target_coordinate_system: str, maintain_positioning: bool = False
+        self, element_name: str, target_coordinate_system: str, maintain_positioning: bool = False
     ) -> SpatialElement:
         """
         Transform an element to a given coordinate system.
 
         Parameters
         ----------
-        element
-            The element to transform.
+        element_name:
+            The name of the element to transform.
         target_coordinate_system
             The target coordinate system.
         maintain_positioning
@@ -830,6 +831,18 @@ class SpatialData:
             remove_transformation,
             set_transformation,
         )
+
+        # TODO remove after deprecation
+        if not isinstance(element_name, str):
+            warnings.warn(
+                "Passing a SpatialElement is as element will be deprecated in SpatialData v0.3.0. Pass"
+                "element_name as string to silence this warning.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            element = element_name
+        else:
+            element = self.get(element_name)
 
         t = get_transformation_between_coordinate_systems(self, element, target_coordinate_system)
         if maintain_positioning:

--- a/tests/core/operations/test_transform.py
+++ b/tests/core/operations/test_transform.py
@@ -489,10 +489,11 @@ def test_transform_elements_and_entire_spatial_data_object(full_sdata: SpatialDa
     scale = Scale([k], axes=("x",))
     translation = Translation([k], axes=("x",))
     sequence = Sequence([scale, translation])
-    for element in full_sdata._gen_spatial_element_values():
+    for _, element_name, _ in full_sdata.gen_spatial_elements():
+        element = full_sdata[element_name]
         set_transformation(element, sequence, "my_space")
         transformed_element = full_sdata.transform_element_to_coordinate_system(
-            element, "my_space", maintain_positioning=maintain_positioning
+            element_name, "my_space", maintain_positioning=maintain_positioning
         )
         t = get_transformation(transformed_element, to_coordinate_system="my_space")
         a = t.to_affine_matrix(input_axes=("x",), output_axes=("x",))


### PR DESCRIPTION
closes #604 

Changed the parameter to `element_name` which should be a string. I opted against allowing both elements and element_name as this would require a default of `None` for both which would require a change in argument order.