### PR TITLE
Removed recently added pygeos dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "pandas",
     "pooch",
     "pyarrow",
-    "pygeos",
     "rich",
     "setuptools",
     "shapely>=2.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "click",
     "dask-image",
     "dask>=2024.2.1",
-    "fsspec<=2023.6",
+    "fsspec",
     "geopandas>=0.14",
     "multiscale_spatial_image>=1.0.0",
     "networkx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "click",
     "dask-image",
     "dask>=2024.2.1",
-    "fsspec",
+    "fsspec<=2023.6",
     "geopandas>=0.14",
     "multiscale_spatial_image>=1.0.0",
     "networkx",


### PR DESCRIPTION
Removing the recently incorreclty added `pygeos` dependency (I had incorrectly readded it when trying to fix the conda install).

I will try, in this PR, also to relax the `fsspec` constraint.