### PR TITLE
Update dask dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "anndata>=0.9.1",
     "click",
     "dask-image",
-    "dask>=2024.2.1",
+    "dask>=2024.4.1",
     "fsspec<=2023.6",
     "geopandas>=0.14",
     "multiscale_spatial_image>=1.0.0",


### PR DESCRIPTION
The current dask dependency constraint can cause issues when using python 3.11 as reported here: https://github.com/dask/dask/issues/11038. This PR updates the dependency to the version in which the fix has been implemented.