### PR TITLE
allow for uint

### DIFF
--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -853,12 +853,19 @@ class TableModel:
             raise ValueError(f"`{attr[self.REGION_KEY_KEY]}` not found in `adata.obs`. Please create the column.")
         if attr[self.INSTANCE_KEY] not in data.obs:
             raise ValueError(f"`{attr[self.INSTANCE_KEY]}` not found in `adata.obs`. Please create the column.")
-        if (dtype := data.obs[attr[self.INSTANCE_KEY]].dtype) not in [int, np.int16, np.int32, np.int64, "O"] or (
-            dtype == "O" and (val_dtype := type(data.obs[attr[self.INSTANCE_KEY]].iloc[0])) is not str
-        ):
+        if (dtype := data.obs[attr[self.INSTANCE_KEY]].dtype) not in [
+            int,
+            np.int16,
+            np.uint16,
+            np.int32,
+            np.uint32,
+            np.int64,
+            np.uint64,
+            "O",
+        ] or (dtype == "O" and (val_dtype := type(data.obs[attr[self.INSTANCE_KEY]].iloc[0])) is not str):
             dtype = dtype if dtype != "O" else val_dtype
             raise TypeError(
-                f"Only int, np.int16, np.int32, np.int64 or string allowed as dtype for "
+                f"Only int, np.int16, np.int32, np.int64, uint equivalents or string allowed as dtype for "
                 f"instance_key column in obs. Dtype found to be {dtype}"
             )
         expected_regions = attr[self.REGION_KEY] if isinstance(attr[self.REGION_KEY], list) else [attr[self.REGION_KEY]]


### PR DESCRIPTION
Segmentation models can return `uint`. This wasn't supported. This PR adds the `uint` dtypes to be accepted when validating the table annotation metadata.