### PR TITLE
small fixes rasterize_bins() and get_values()

### DIFF
--- a/src/spatialdata/_core/operations/rasterize_bins.py
+++ b/src/spatialdata/_core/operations/rasterize_bins.py
@@ -65,6 +65,9 @@ def rasterize_bins(
     The returned image will have one pixel for each bin, and a coordinate transformation to map the image to the
     original data orientation. In particular, the bins of Visium HD data are in a grid that is slightly rotated;
     the coordinate transformation will adjust for this, so that the returned data is aligned to the original geometries.
+
+    If `spatialdata-plot` is used to visualized the returned image, the parameter `scale='full'` needs to be passed to
+    `.render_shapes()`, to disable an automatic rasterization that would confict with the rasterization performed here.
     """
     element = sdata[bins]
     table = sdata.tables[table_name]

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -904,7 +904,7 @@ def get_values(
             x = matched_table[:, value_key_values].X
             import scipy
 
-            if isinstance(x, scipy.sparse.csr_matrix):
+            if isinstance(x, (scipy.sparse.csr_matrix, scipy.sparse.csc_matrix, scipy.sparse.coo_matrix)):
                 x = x.todense()
             df = pd.DataFrame(x, columns=value_key_values)
         if origin == "obsm":


### PR DESCRIPTION
- only csr matrices were supported in `get_values()`, fixed
- improved docs for `rasterize_bins()` to show how to plot the rasterized image with `spatialdata-plot`