### PR TITLE
fix rasterize_bins for polygons; fix points model for unsorted index

### DIFF
--- a/src/spatialdata/_core/operations/rasterize_bins.py
+++ b/src/spatialdata/_core/operations/rasterize_bins.py
@@ -9,6 +9,7 @@ from dask.dataframe import DataFrame as DaskDataFrame
 from geopandas import GeoDataFrame
 from numpy.random import default_rng
 from scipy.sparse import csc_matrix
+from shapely import MultiPolygon, Point, Polygon
 from skimage.transform import estimate_transform
 from xarray import DataArray
 
@@ -155,8 +156,13 @@ def rasterize_bins(
 
     src = np.stack([sub_table.obs[col_key] - min_col, sub_table.obs[row_key] - min_row], axis=1)
     if isinstance(sub_df, GeoDataFrame):
-        sub_x = sub_df.geometry.x.values
-        sub_y = sub_df.geometry.y.values
+        if isinstance(sub_df.iloc[0].geometry, Point):
+            sub_x = sub_df.geometry.x.values
+            sub_y = sub_df.geometry.y.values
+        else:
+            assert isinstance(sub_df.iloc[0].geometry, (Polygon, MultiPolygon))
+            sub_x = sub_df.centroid.x
+            sub_y = sub_df.centroid.y
     else:
         assert isinstance(sub_df, DaskDataFrame)
         sub_x = sub_df.x.compute().values

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -688,9 +688,10 @@ class PointsModel:
         if Z not in axes and Z in data.columns:
             logger.info(f"Column `{Z}` in `data` will be ignored since the data is 2D.")
         for c in set(data.columns) - {feature_key, instance_key, *coordinates.values(), X, Y, Z}:
-            table[c] = dd.from_pandas(
-                data[c].compute(), npartitions=table.npartitions, sort=index_monotonically_increasing
-            )
+            column = data[c]
+            if isinstance(column, dd.Series):
+                column = column.compute()
+            table[c] = dd.from_pandas(column, npartitions=table.npartitions, sort=index_monotonically_increasing)
 
         validated = cls._add_metadata_and_validate(
             table, feature_key=feature_key, instance_key=instance_key, transformations=transformations

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -647,7 +647,9 @@ class PointsModel:
                 )
         ndim = len(coordinates)
         axes = [X, Y, Z][:ndim]
-        index_monotonically_increasing = data.index.is_monotonic_increasing.compute()
+        index_monotonically_increasing = data.index.is_monotonic_increasing
+        if not isinstance(index_monotonically_increasing, bool):
+            index_monotonically_increasing = index_monotonically_increasing.compute()
         if isinstance(data, pd.DataFrame):
             if not index_monotonically_increasing:
                 warnings.warn(

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -453,3 +453,14 @@ def test_force2d():
     assert_elements_are_identical(circles_3d, expected_circles_2d)
     assert_elements_are_identical(polygons_3d, expected_polygons_2d)
     assert_elements_are_identical(multipolygons_3d, expected_multipolygons_2d)
+
+
+def test_dask_points_unsorted_index(points):
+    element = points["points_0"]
+    new_order = RNG.permutation(len(element))
+    with pytest.warns(
+        UserWarning,
+        match=r"The index of the dataframe is not monotonic increasing\.",
+    ):
+        ordered = PointsModel.parse(element.compute().iloc[new_order, :])
+    assert np.all(ordered.index.compute().to_numpy() == new_order)


### PR DESCRIPTION
closes #650 
closes #649

More on the linked issues, but in short:
- rasterize bins now work also for polygons and multipolygons
- there was a problem when parsing points whose index was not monotonically increasing

