### PR TITLE
Added validation check for inf/nan radius for shapes

### DIFF
--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -342,7 +342,9 @@ class ShapesModel:
                 raise ValueError(f"Column `{cls.RADIUS_KEY}` not found." + SUGGESTION)
             radii = data[cls.RADIUS_KEY].values
             if np.any(radii <= 0):
-                raise ValueError("Radii of circles must be positive." + SUGGESTION)
+                raise ValueError("Radii of circles must be positive.")
+            if np.any(np.isnan(radii)) or np.any(np.isinf(radii)):
+                raise ValueError("Radii of circles must not be nan or inf.")
         if cls.TRANSFORM_KEY not in data.attrs:
             raise ValueError(f":class:`geopandas.GeoDataFrame` does not contain `{TRANSFORM_KEY}`." + SUGGESTION)
         if len(data) > 0:

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -221,6 +221,12 @@ class TestModels:
             poly[ShapesModel.RADIUS_KEY].iloc[0] = 0
             with pytest.raises(ValueError, match="Radii of circles must be positive."):
                 ShapesModel.validate(poly)
+            poly[ShapesModel.RADIUS_KEY].iloc[0] = np.nan
+            with pytest.raises(ValueError, match="Radii of circles must not be nan or inf."):
+                ShapesModel.validate(poly)
+            poly[ShapesModel.RADIUS_KEY].iloc[0] = np.inf
+            with pytest.raises(ValueError, match="Radii of circles must not be nan or inf."):
+                ShapesModel.validate(poly)
 
     @pytest.mark.parametrize("model", [PointsModel])
     @pytest.mark.parametrize("instance_key", [None, "cell_id"])


### PR DESCRIPTION
Nan or inf values for radii in shapes (circles) were passing validation and potentially leading to bugs downstream, such as one reported for Xenium 2.0.0 data: https://github.com/scverse/spatialdata-io/issues/173.