### PR TITLE
Fix dataloader table names

### DIFF
--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -261,11 +261,13 @@ class ImageTilesDataset(Dataset):
 
             if table_name is not None:
                 table_subset = filtered_table[filtered_table.obs[region_key] == region_name]
-                circles_sdata = SpatialData.init_from_elements({region_name: circles}, tables=table_subset.copy())
+                circles_sdata = SpatialData.init_from_elements(
+                    {region_name: circles}, tables={"table": table_subset.copy()}
+                )
                 _, table = join_spatialelement_table(
                     sdata=circles_sdata,
                     spatial_element_names=region_name,
-                    table_name=table_name,
+                    table_name="table",
                     how="left",
                     match_rows="left",
                 )
@@ -320,9 +322,10 @@ class ImageTilesDataset(Dataset):
             )
         # return spatialdata consisting of the image tile and, if available, the associated table
         if table_name:
-            # let's reset the target annotation metadata to avoid a warning when constructing the SpatialData object
             table_row = dataset_table[idx].copy()
-            del table_row.uns[TableModel.ATTRS_KEY]
+            # let's reset the target annotation metadata to avoid a warning when constructing the SpatialData object
+            if TableModel.ATTRS_KEY in table_row.uns:
+                del table_row.uns[TableModel.ATTRS_KEY]
             # TODO: add the shape used for constructing the tile; in the case of the label consider adding the circles
             # or a crop of the label
             return SpatialData(

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -206,7 +206,7 @@ class ImageTilesDataset(Dataset):
                 else:
                     indices = region_elem.index.tolist()
                 table = sdata.tables[table_name]
-                if not isinstance(sdata.tables["table"].obs[region_key].dtype, CategoricalDtype):
+                if not isinstance(sdata.tables[table_name].obs[region_key].dtype, CategoricalDtype):
                     raise TypeError(
                         f"The `regions_element` column `{region_key}` in the table must be a categorical dtype. "
                         f"Please convert it."
@@ -231,8 +231,8 @@ class ImageTilesDataset(Dataset):
         """Preprocess the dataset."""
         if table_name is not None:
             _, region_key, instance_key = get_table_keys(self.sdata.tables[table_name])
-            filtered_table = self.sdata.tables["table"][
-                self.sdata.tables["table"].obs[region_key].isin(self.regions)
+            filtered_table = self.sdata.tables[table_name][
+                self.sdata.tables[table_name].obs[region_key].isin(self.regions)
             ]  # filtered table for the data loader
 
         index_df = []
@@ -327,7 +327,7 @@ class ImageTilesDataset(Dataset):
             # or a crop of the label
             return SpatialData(
                 images={dataset_index.iloc[idx][ImageTilesDataset.IMAGE_KEY]: tile},
-                tables={"table": table_row},
+                tables={table_name: table_row},
             )
         return SpatialData(images={dataset_index.iloc[idx][ImageTilesDataset.IMAGE_KEY]: tile})
 

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -265,7 +265,7 @@ class ImageTilesDataset(Dataset):
                 _, table = join_spatialelement_table(
                     sdata=circles_sdata,
                     spatial_element_names=region_name,
-                    table_name=table_name,
+                    table_name="table",
                     how="left",
                     match_rows="left",
                 )

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -265,7 +265,7 @@ class ImageTilesDataset(Dataset):
                 _, table = join_spatialelement_table(
                     sdata=circles_sdata,
                     spatial_element_names=region_name,
-                    table_name="table",
+                    table_name=table_name,
                     how="left",
                     match_rows="left",
                 )

--- a/tests/dataloader/test_datasets.py
+++ b/tests/dataloader/test_datasets.py
@@ -4,7 +4,6 @@ from spatialdata.dataloader import ImageTilesDataset
 from spatialdata.datasets import blobs_annotating_element
 
 
-@pytest.mark.skip(reason="To be worked on out in separate PR.")
 class TestImageTilesDataset:
     @pytest.mark.parametrize("image_element", ["blobs_image", "blobs_multiscale_image"])
     @pytest.mark.parametrize(


### PR DESCRIPTION
The `ImageTilesDataset` class cannot be used if the table you want to work with is not called "table", since there are lines where this name is hard-coded, even though the class allows for a `table_name` to be specified. 

An example where this fails is if you follow this [tutorial](https://spatialdata.scverse.org/en/latest/tutorials/notebooks/notebooks/examples/densenet.html) but specify a different table name when creating the dataset. 

This PR replaces instances of "table" with `table_name`.