### PR TITLE
Workaround for nan radii xenium

### DIFF
--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -344,7 +344,14 @@ class ShapesModel:
             if np.any(radii <= 0):
                 raise ValueError("Radii of circles must be positive.")
             if np.any(np.isnan(radii)) or np.any(np.isinf(radii)):
-                raise ValueError("Radii of circles must not be nan or inf.")
+                # using logger.warning instead of warnings.warn to avoid the warning to being silenced in some cases
+                # (e.g. PyCharm console)
+                logger.warning(
+                    "Radii of circles must not be nan or inf (this warning will be turned into a ValueError in the "
+                    "next code release). If you are seeing this warning after reading previously saved Xenium data, "
+                    "please see https://github.com/scverse/spatialdata/discussions/657 for a solution. Otherwise, "
+                    "please correct the radii of the circles before calling the parser function.",
+                )
         if cls.TRANSFORM_KEY not in data.attrs:
             raise ValueError(f":class:`geopandas.GeoDataFrame` does not contain `{TRANSFORM_KEY}`." + SUGGESTION)
         if len(data) > 0:

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -222,12 +222,16 @@ class TestModels:
             poly[ShapesModel.RADIUS_KEY].iloc[0] = 0
             with pytest.raises(ValueError, match="Radii of circles must be positive."):
                 ShapesModel.validate(poly)
-            poly[ShapesModel.RADIUS_KEY].iloc[0] = np.nan
-            with pytest.raises(ValueError, match="Radii of circles must not be nan or inf."):
-                ShapesModel.validate(poly)
-            poly[ShapesModel.RADIUS_KEY].iloc[0] = np.inf
-            with pytest.raises(ValueError, match="Radii of circles must not be nan or inf."):
-                ShapesModel.validate(poly)
+
+            # tests to be restored when the validation is re-enabled (now it just raises a warning, that is tricky to
+            # capture)
+            # poly[ShapesModel.RADIUS_KEY].iloc[0] = np.nan
+            # with pytest.raises(ValueError, match="Radii of circles must not be nan or inf."):
+            #     ShapesModel.validate(poly)
+            #
+            # poly[ShapesModel.RADIUS_KEY].iloc[0] = np.inf
+            # with pytest.raises(ValueError, match="Radii of circles must not be nan or inf."):
+            #     ShapesModel.validate(poly)
 
     @pytest.mark.parametrize("model", [PointsModel])
     @pytest.mark.parametrize("instance_key", [None, "cell_id"])


### PR DESCRIPTION
Relaxing and exception to a warning to be able to read and fix xenium data with radii being nan.

You can find more info here: https://github.com/scverse/spatialdata/discussions/657