### PR TITLE
Add clip parameter to polygon_query; tests missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,22 @@ and this project adheres to [Semantic Versioning][].
 
 ## [0.x.x] - 2024-xx-xx
 
+### Minor
+
+-   Added `clip: bool = False` parameter to `polygon_query()` #670
+
 ## [0.2.2] - 2024-08-07
 
-# Major
+### Major
 
 -   New disk format for shapes using `GeoParquet` (the change is backward compatible) #542
 
-# Minor
+### Minor
 
 -   Add `return_background` as argument to `get_centroids` and `get_element_instances` #621
 -   Ability to save data using older disk formats #542
 
-# Fixed
+### Fixed
 
 -   Circles validation now checks for inf or nan radii #653
 -   Bug with table name in torch dataset #654 @LLehner

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -2225,6 +2225,7 @@ class QueryManager:
         polygon: Polygon | MultiPolygon,
         target_coordinate_system: str,
         filter_table: bool = True,
+        clip: bool = False,
     ) -> SpatialData:
         """
         Perform a polygon query on the SpatialData object.
@@ -2239,6 +2240,7 @@ class QueryManager:
             polygon=polygon,
             target_coordinate_system=target_coordinate_system,
             filter_table=filter_table,
+            clip=clip,
         )
 
     def __call__(self, request: BaseSpatialRequest, **kwargs) -> SpatialData:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
Closes https://github.com/scverse/spatialdata/issues/644.

This PR adds `clip: bool = False` as a parameter to `polygon_query`. The behavior is described in the docstring, that I copy here: 

```
    clip
        If `True`, the shapes are clipped to the polygon. This behavior is implemented only when querying
        polygons/multipolygons or circles, and it is ignored for other types of elements (images, labels, points).
        Importantly, when clipping is enabled, the circles will be converted to polygons before the clipping. This may
        affect downstream operations that rely on the circle radius or on performance, so it is recommended to disable
        clipping when querying circles or when querying a `SpatialData` object that contains circles.
```

Importantly also:
- clipping is not enabled for a bounding box query. It will be better to drop the bounding box query implementation for poylgons and points and rely only on the polygon query one, as described here: https://github.com/scverse/spatialdata/issues/644
- I don't entire like the fact that when clipping is enabled the circles are converted to polygons; but it's documented in the docstring, so it should be ok.