### PR TITLE
Fix labels multiscales method

### DIFF
--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -255,6 +255,17 @@ class Labels2DModel(RasterSchema):
             **kwargs,
         )
 
+    @classmethod
+    def parse(  # noqa: D102
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> DataArray | DataTree:
+        if kwargs.get("scale_factors") is not None and kwargs.get("method") is None:
+            # Override default scaling method to preserve labels
+            kwargs["method"] = Methods.DASK_IMAGE_NEAREST
+        return super().parse(*args, **kwargs)
+
 
 class Labels3DModel(RasterSchema):
     dims = DimsSchema((Z, Y, X))
@@ -269,6 +280,13 @@ class Labels3DModel(RasterSchema):
             *args,
             **kwargs,
         )
+
+    @classmethod
+    def parse(self, *args: Any, **kwargs: Any) -> DataArray | DataTree:  # noqa: D102
+        if kwargs.get("scale_factors") is not None and kwargs.get("method") is None:
+            # Override default scaling method to preserve labels
+            kwargs["method"] = Methods.DASK_IMAGE_NEAREST
+        return super().parse(*args, **kwargs)
 
 
 class Image2DModel(RasterSchema):


### PR DESCRIPTION
Closes #696 

When passing `scale_factors` to a RasterSchema, and it is for labels instead of images, the default for `to_multiscale`'s `method` argument was `xarray_coarsen` and caused artifacts on labels edges. It is now overriden to `dask_image_nearest`. This avoids artifacts if the user does not explicitly pass a method.

Questions:
- Is there any other scaling method to consider, or can `dask_image_nearest` handle all array types?
- Pydocstyle complains about missing docstring. It is a static analyzer and cannot detect inheritance of docstrings. I didn't want to copy the complete docstring and cause duplication. Currently, I disabled the check. How do you prefer to handle this?