### PR TITLE
vectorize bounding box query

### DIFF
--- a/src/spatialdata/_core/query/_utils.py
+++ b/src/spatialdata/_core/query/_utils.py
@@ -2,14 +2,22 @@ from __future__ import annotations
 
 from typing import Any
 
+import numba as nb
 import numpy as np
 from anndata import AnnData
+from datatree import DataTree
 from xarray import DataArray
 
 from spatialdata._core._elements import Tables
 from spatialdata._core.spatialdata import SpatialData
 from spatialdata._types import ArrayLike
 from spatialdata._utils import Number, _parse_list_into_array
+from spatialdata.transformations._utils import compute_coordinates
+from spatialdata.transformations.transformations import (
+    BaseTransformation,
+    Sequence,
+    Translation,
+)
 
 
 def get_bounding_box_corners(
@@ -86,6 +94,97 @@ def get_bounding_box_corners(
     if num_boxes > 1:
         return output
     return output.squeeze().drop_vars("box")
+
+
+@nb.njit(parallel=False, nopython=True)
+def _create_slices_and_translation(
+    min_values: nb.types.Array[nb.float64, nb.float64],
+    max_values: nb.types.Array[nb.float64, nb.float64],
+) -> tuple[nb.types.Array[nb.float64, nb.float64], nb.types.Array[nb.float64, nb.float64]]:
+    n_boxes, n_dims = min_values.shape
+    slices = np.empty((n_boxes, n_dims, 2), dtype=np.float64)  # (n_boxes, n_dims, [min, max])
+    translation_vectors = np.empty((n_boxes, n_dims), dtype=np.float64)  # (n_boxes, n_dims)
+
+    for i in range(n_boxes):
+        for j in range(n_dims):
+            slices[i, j, 0] = min_values[i, j]
+            slices[i, j, 1] = max_values[i, j]
+            translation_vectors[i, j] = np.ceil(max(min_values[i, j], 0))
+
+    return slices, translation_vectors
+
+
+def _process_data_tree_query_result(query_result: DataTree) -> DataTree | None:
+    d = {}
+    for k, data_tree in query_result.items():
+        v = data_tree.values()
+        assert len(v) == 1
+        xdata = v.__iter__().__next__()
+        if 0 in xdata.shape:
+            if k == "scale0":
+                return None
+        else:
+            d[k] = xdata
+
+    # Remove scales after finding a missing scale
+    scales_to_keep = []
+    for i, scale_name in enumerate(d.keys()):
+        if scale_name == f"scale{i}":
+            scales_to_keep.append(scale_name)
+        else:
+            break
+
+    # Case in which scale0 is not present but other scales are
+    if len(scales_to_keep) == 0:
+        return None
+
+    d = {k: d[k] for k in scales_to_keep}
+    result = DataTree.from_dict(d)
+
+    # Rechunk the data to avoid irregular chunks
+    for scale in result:
+        result[scale]["image"] = result[scale]["image"].chunk("auto")
+
+    return result
+
+
+def _process_query_result(
+    result: DataArray | DataTree, translation_vector: ArrayLike, axes: tuple[str, ...]
+) -> DataArray | DataTree | None:
+    from spatialdata.transformations import get_transformation, set_transformation
+
+    if isinstance(result, DataArray):
+        if 0 in result.shape:
+            return None
+        # rechunk the data to avoid irregular chunks
+        result = result.chunk("auto")
+    elif isinstance(result, DataTree):
+        result = _process_data_tree_query_result(result)
+        if result is None:
+            return None
+
+    result = compute_coordinates(result)
+
+    if not np.allclose(np.array(translation_vector), 0):
+        translation_transform = Translation(translation=translation_vector, axes=axes)
+
+        transformations = get_transformation(result, get_all=True)
+        assert isinstance(transformations, dict)
+
+        new_transformations = {}
+        for coordinate_system, initial_transform in transformations.items():
+            new_transformation: BaseTransformation = Sequence(
+                [translation_transform, initial_transform],
+            )
+            new_transformations[coordinate_system] = new_transformation
+        set_transformation(result, new_transformations, set_all=True)
+
+    # let's make a copy of the transformations so that we don't modify the original object
+    t = get_transformation(result, get_all=True)
+    assert isinstance(t, dict)
+    set_transformation(result, t.copy(), set_all=True)
+
+    return result
 
 
 def _get_filtered_or_unfiltered_tables(

--- a/src/spatialdata/_core/query/_utils.py
+++ b/src/spatialdata/_core/query/_utils.py
@@ -98,9 +98,9 @@ def get_bounding_box_corners(
 
 @nb.njit(parallel=False, nopython=True)
 def _create_slices_and_translation(
-    min_values: nb.types.Array[nb.float64, nb.float64],
-    max_values: nb.types.Array[nb.float64, nb.float64],
-) -> tuple[nb.types.Array[nb.float64, nb.float64], nb.types.Array[nb.float64, nb.float64]]:
+    min_values: nb.types.Array,
+    max_values: nb.types.Array,
+) -> tuple[nb.types.Array, nb.types.Array]:
     n_boxes, n_dims = min_values.shape
     slices = np.empty((n_boxes, n_dims, 2), dtype=np.float64)  # (n_boxes, n_dims, [min, max])
     translation_vectors = np.empty((n_boxes, n_dims), dtype=np.float64)  # (n_boxes, n_dims)

--- a/src/spatialdata/_core/query/spatial_query.py
+++ b/src/spatialdata/_core/query/spatial_query.py
@@ -562,10 +562,10 @@ def _(
             }
             for box_idx in range(len(min_values_np))
         ]
-        translation_vector = translation_vectors.tolist()
+        translation_vectors = translation_vectors.tolist()
     else:  # Single box
         selection = {axis: slice(slices[0, axis_idx, 0], slices[0, axis_idx, 1]) for axis_idx, axis in enumerate(axes)}
-        translation_vector = translation_vectors[0].tolist()
+        translation_vectors = translation_vectors[0].tolist()
 
     if return_request_only:
         return selection
@@ -577,13 +577,13 @@ def _(
 
     if isinstance(query_result, list):
         processed_results = []
-        for result in query_result:
+        for result, translation_vector in zip(query_result, translation_vectors):
             processed_result = _process_query_result(result, translation_vector, axes)
             if processed_result is not None:
                 processed_results.append(processed_result)
         query_result = processed_results if processed_results else None
     else:
-        query_result = _process_query_result(query_result, translation_vector, axes)
+        query_result = _process_query_result(query_result, translation_vectors, axes)
     return query_result
 
 

--- a/src/spatialdata/_core/query/spatial_query.py
+++ b/src/spatialdata/_core/query/spatial_query.py
@@ -230,6 +230,7 @@ def _adjust_bounding_box_to_real_axes(
 
     The bounding box is defined by the user and its axes may not coincide with the axes of the transformation.
     """
+    # axis for slicing, if axis > 0, then the min_/max_coordinate multiple bounding boxes along axis 0
     axis = min_coordinate.ndim - 1
     if set(axes_bb) != set(axes_out_without_c):
         axes_only_in_bb = set(axes_bb) - set(axes_out_without_c)

--- a/src/spatialdata/_core/query/spatial_query.py
+++ b/src/spatialdata/_core/query/spatial_query.py
@@ -230,6 +230,7 @@ def _adjust_bounding_box_to_real_axes(
 
     The bounding box is defined by the user and its axes may not coincide with the axes of the transformation.
     """
+    axis = min_coordinate.ndim - 1
     if set(axes_bb) != set(axes_out_without_c):
         axes_only_in_bb = set(axes_bb) - set(axes_out_without_c)
         axes_only_in_output = set(axes_out_without_c) - set(axes_bb)
@@ -246,8 +247,8 @@ def _adjust_bounding_box_to_real_axes(
         for ax in axes_only_in_output:
             axes_bb = axes_bb + (ax,)
             M = np.finfo(np.float32).max - 1
-            min_coordinate = np.append(min_coordinate, -M)
-            max_coordinate = np.append(max_coordinate, M)
+            min_coordinate = np.append(min_coordinate, -M, axis=axis)
+            max_coordinate = np.append(max_coordinate, M, axis=axis)
     else:
         indices = [axes_bb.index(ax) for ax in axes_out_without_c]
         min_coordinate = min_coordinate[np.array(indices)]

--- a/src/spatialdata/_core/query/spatial_query.py
+++ b/src/spatialdata/_core/query/spatial_query.py
@@ -515,7 +515,7 @@ def _(
     max_coordinate: list[Number] | ArrayLike,
     target_coordinate_system: str,
     return_request_only: bool = False,
-) -> DataArray | DataTree | Mapping[str, slice] | None:
+) -> DataArray | DataTree | Mapping[str, slice] | list[DataArray | DataTree] | None:
     """Implement bounding box query for Spatialdata supported DataArray.
 
     Notes

--- a/src/spatialdata/_core/query/spatial_query.py
+++ b/src/spatialdata/_core/query/spatial_query.py
@@ -142,7 +142,7 @@ def _get_bounding_box_corners_in_intrinsic_coordinates(
     if bounding_box_corners.ndim > 2:  # multiple boxes
         coords = {
             "box": range(len(bounding_box_corners)),
-            "corner": range(len(bounding_box_corners)),
+            "corner": range(bounding_box_corners.shape[1]),
             "axis": list(inverse.output_axes),
         }
     else:

--- a/src/spatialdata/_core/query/spatial_query.py
+++ b/src/spatialdata/_core/query/spatial_query.py
@@ -380,7 +380,12 @@ class BoundingBoxRequest(BaseSpatialRequest):
             raise ValueError(f"Non-spatial axes specified: {non_spatial_axes}")
 
         # validate the axes
-        if len(self.axes) != len(self.min_coordinate) or len(self.axes) != len(self.max_coordinate):
+        if self.min_coordinate.shape != self.max_coordinate.shape:
+            raise ValueError("The `min_coordinate` and `max_coordinate` must have the same shape.")
+
+        n_axes_coordinate = len(self.min_coordinate) if self.min_coordinate.ndim == 1 else self.min_coordinate.shape[1]
+
+        if len(self.axes) != n_axes_coordinate:
             raise ValueError("The number of axes must match the number of coordinates.")
 
         # validate the coordinates

--- a/src/spatialdata/_core/query/spatial_query.py
+++ b/src/spatialdata/_core/query/spatial_query.py
@@ -340,6 +340,7 @@ class BaseSpatialRequest:
         pass
 
 
+@docstring_parameter(min_coordinate_docs=MIN_COORDINATE_DOCS, max_coordinate_docs=MAX_COORDINATE_DOCS)
 @dataclass(frozen=True)
 class BoundingBoxRequest(BaseSpatialRequest):
     """Query with an axis-aligned bounding box.
@@ -349,12 +350,9 @@ class BoundingBoxRequest(BaseSpatialRequest):
     axes
         The axes the coordinates are expressed in.
     min_coordinate
-        PLACEHOLDER
-        The coordinate of the lower left hand corner (i.e., minimum values)
-        of the bounding box.
+        {min_coordinate_docs}
     max_coordinate
-        The coordinate of the upper right hand corner (i.e., maximum values)
-        of the bounding box
+        {max_coordinate_docs}
     """
 
     min_coordinate: ArrayLike
@@ -599,8 +597,7 @@ def _(
         return selection
 
     # query the data
-    # TODO: ADD NONE (But the next line is not None)
-    query_result: DataArray | DataTree | list[DataArray] | list[DataTree] = (
+    query_result: DataArray | DataTree | list[DataArray] | list[DataTree] | None = (
         image.sel(selection) if isinstance(selection, dict) else [image.sel(sel) for sel in selection]
     )
 

--- a/src/spatialdata/_core/query/spatial_query.py
+++ b/src/spatialdata/_core/query/spatial_query.py
@@ -244,11 +244,11 @@ def _adjust_bounding_box_to_real_axes(
 
         # if there are axes in the output axes that are not in the bounding box, we need to add them to the bounding box
         # with a range that includes everything (e.g. querying 3D points with a 2D bounding box)
+        M = np.finfo(np.float32).max - 1
         for ax in axes_only_in_output:
             axes_bb = axes_bb + (ax,)
-            M = np.finfo(np.float32).max - 1
-            min_coordinate = np.append(min_coordinate, -M, axis=axis)
-            max_coordinate = np.append(max_coordinate, M, axis=axis)
+            min_coordinate = np.insert(min_coordinate, min_coordinate.shape[axis], -M, axis=axis)
+            max_coordinate = np.insert(max_coordinate, max_coordinate.shape[axis], M, axis=axis)
     else:
         indices = [axes_bb.index(ax) for ax in axes_out_without_c]
         min_coordinate = np.take(min_coordinate, indices, axis=axis)

--- a/src/spatialdata/_core/query/spatial_query.py
+++ b/src/spatialdata/_core/query/spatial_query.py
@@ -239,8 +239,8 @@ def _adjust_bounding_box_to_real_axes(
         # 3D bounding box)
         indices_to_remove_from_bb = [axes_bb.index(ax) for ax in axes_only_in_bb]
         axes_bb = tuple(ax for ax in axes_bb if ax not in axes_only_in_bb)
-        min_coordinate = np.delete(min_coordinate, indices_to_remove_from_bb)
-        max_coordinate = np.delete(max_coordinate, indices_to_remove_from_bb)
+        min_coordinate = np.delete(min_coordinate, indices_to_remove_from_bb, axis=axis)
+        max_coordinate = np.delete(max_coordinate, indices_to_remove_from_bb, axis=axis)
 
         # if there are axes in the output axes that are not in the bounding box, we need to add them to the bounding box
         # with a range that includes everything (e.g. querying 3D points with a 2D bounding box)
@@ -251,8 +251,8 @@ def _adjust_bounding_box_to_real_axes(
             max_coordinate = np.append(max_coordinate, M, axis=axis)
     else:
         indices = [axes_bb.index(ax) for ax in axes_out_without_c]
-        min_coordinate = min_coordinate[np.array(indices)]
-        max_coordinate = max_coordinate[np.array(indices)]
+        min_coordinate = np.take(min_coordinate, indices, axis=axis)
+        max_coordinate = np.take(max_coordinate, indices, axis=axis)
         axes_bb = axes_out_without_c
     return axes_bb, min_coordinate, max_coordinate
 

--- a/src/spatialdata/_core/query/spatial_query.py
+++ b/src/spatialdata/_core/query/spatial_query.py
@@ -606,7 +606,7 @@ def _(
     min_coordinate: list[Number] | ArrayLike,
     max_coordinate: list[Number] | ArrayLike,
     target_coordinate_system: str,
-) -> DaskDataFrame | None:
+) -> DaskDataFrame | list[DaskDataFrame] | None:
     from spatialdata import transform
     from spatialdata.transformations import get_transformation
 

--- a/src/spatialdata/_docs.py
+++ b/src/spatialdata/_docs.py
@@ -1,0 +1,13 @@
+# from https://stackoverflow.com/questions/10307696/how-to-put-a-variable-into-python-docstring
+from typing import Any, Callable, TypeVar
+
+T = TypeVar("T")
+
+
+def docstring_parameter(*args: Any, **kwargs: Any) -> Callable[[T], T]:
+    def dec(obj: T) -> T:
+        if obj.__doc__:
+            obj.__doc__ = obj.__doc__.format(*args, **kwargs)
+        return obj
+
+    return dec

--- a/tests/core/query/test_spatial_query.py
+++ b/tests/core/query/test_spatial_query.py
@@ -324,7 +324,8 @@ def test_query_raster(
 @pytest.mark.parametrize("is_bb_3d", [True, False])
 @pytest.mark.parametrize("with_polygon_query", [True, False])
 @pytest.mark.parametrize("multiple_boxes", [True, False])
-def test_query_polygons(is_bb_3d: bool, with_polygon_query: bool, multiple_boxes: bool):
+@pytest.mark.parametrize("box_outside_polygon", [True, False])
+def test_query_polygons(is_bb_3d: bool, with_polygon_query: bool, multiple_boxes: bool, box_outside_polygon: bool):
     centroids = np.array([[10, 10], [10, 80], [80, 20], [70, 60]])
     half_widths = [6] * 4
     sd_polygons = _make_squares(centroid_coordinates=centroids, half_widths=half_widths)
@@ -342,10 +343,18 @@ def test_query_polygons(is_bb_3d: bool, with_polygon_query: bool, multiple_boxes
         if is_bb_3d:
             _min_coordinate = np.array([[2, 40, 40], [2, 50, 50]]) if multiple_boxes else np.array([2, 40, 40])
             _max_coordinate = np.array([[7, 100, 100], [7, 110, 110]]) if multiple_boxes else np.array([7, 100, 100])
+            if box_outside_polygon:
+                _min_coordinate = np.array([[2, 100, 100], [2, 50, 50]]) if multiple_boxes else np.array([2, 40, 40])
+                _max_coordinate = (
+                    np.array([[7, 110, 110], [7, 110, 110]]) if multiple_boxes else np.array([7, 100, 100])
+                )
             _axes = ("z", "y", "x")
         else:
             _min_coordinate = np.array([[40, 40], [50, 50]]) if multiple_boxes else np.array([40, 40])
             _max_coordinate = np.array([[100, 100], [110, 110]]) if multiple_boxes else np.array([100, 100])
+            if box_outside_polygon:
+                _min_coordinate = np.array([[100, 100], [50, 50]]) if multiple_boxes else np.array([40, 40])
+                _max_coordinate = np.array([[110, 110], [110, 110]]) if multiple_boxes else np.array([100, 100])
             _axes = ("y", "x")
 
         polygons_result = bounding_box_query(
@@ -359,8 +368,13 @@ def test_query_polygons(is_bb_3d: bool, with_polygon_query: bool, multiple_boxes
     if multiple_boxes and not with_polygon_query:
         assert isinstance(polygons_result, list)
         assert len(polygons_result) == 2
-        assert polygons_result[0].index[0] == 3
-        assert len(polygons_result[1]) == 1
+        if box_outside_polygon:
+
+            assert polygons_result[0] is None
+            assert polygons_result[1].index[0] == 3
+        else:
+            assert polygons_result[0].index[0] == 3
+            assert len(polygons_result[1]) == 1
     else:
         assert len(polygons_result) == 1
         assert polygons_result.index[0] == 3

--- a/tests/core/query/test_spatial_query.py
+++ b/tests/core/query/test_spatial_query.py
@@ -814,3 +814,28 @@ def test_query_with_clipping(sdata_blobs):
 
     query_polyon_contains_queried_data(extent_circles)
     query_polyon_contains_queried_data(extent_polygons)
+
+
+def test_query_multiple_boxes_len_one(sdata_blobs):
+    """
+    Tests that querying by a list of bounding boxes with length one is equivalent to querying by a single bounding box.
+    """
+    min_coordinate = np.array([[80, 80]])
+    max_coordinate = np.array([[165, 150]])
+    axes = ("x", "y")
+
+    queried0 = bounding_box_query(
+        sdata_blobs,
+        axes=axes,
+        min_coordinate=min_coordinate,
+        max_coordinate=max_coordinate,
+        target_coordinate_system="global",
+    )
+    queried1 = bounding_box_query(
+        sdata_blobs,
+        axes=axes,
+        min_coordinate=min_coordinate[0],
+        max_coordinate=max_coordinate[0],
+        target_coordinate_system="global",
+    )
+    assert_spatial_data_objects_are_identical(queried0, queried1)


### PR DESCRIPTION
Trying to vectorize the tiling in the dataloader PR, realized some improvements should be added separately.

With this PR, I enable the vectorization of `bounding_box_query`  for all elements. 

This means that it is now possible to pass an array of bounding boxes (and not just one). 

TODO:
- [x] tests for multiple bounding box queries for raster data
- [x] tests for multiple bounding box queries for shapes
- [x] tests for multiple bounding box queries for points

@LucaMarconato @melonora do you have any suggestion of when this could be used to replace current implementations across the projects? A clear use case (and the motivation for this contribution) is the dataloader, see #687 for the speedup, but I wonder if there are other places where this is useful. 

This also is the groundwork for eventual update to the dataloader, being able to return batches of all elements.

considering that this PR is already getting too large, I would postpone the vectorization of polygon query.