### PR TITLE
refactor `filter_table_by_elements`

### DIFF
--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -58,31 +58,6 @@ def get_element_annotators(sdata: SpatialData, element_name: str) -> set[str]:
     return table_names
 
 
-def _filter_table_by_element_names(table: AnnData | None, element_names: str | list[str]) -> AnnData | None:
-    """
-    Filter an AnnData table to keep only the rows that are in the coordinate system.
-
-    Parameters
-    ----------
-    table
-        The table to filter; if None, returns None
-    element_names
-        The element_names to keep in the tables obs.region column
-
-    Returns
-    -------
-    The filtered table, or None if the input table was None
-    """
-    if table is None or not table.uns.get(TableModel.ATTRS_KEY):
-        return None
-    table_mapping_metadata = table.uns[TableModel.ATTRS_KEY]
-    region_key = table_mapping_metadata[TableModel.REGION_KEY_KEY]
-    table.obs = pd.DataFrame(table.obs)
-    table = table[table.obs[region_key].isin(element_names)].copy()
-    table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY] = table.obs[region_key].unique().tolist()
-    return table
-
-
 @singledispatch
 def get_element_instances(
     element: SpatialElement,

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -145,8 +145,8 @@ def _(
 
 # TODO: replace function use throughout repo by `join_sdata_spatialelement_table`
 def _filter_table_by_elements(
-    table: AnnData | None, elements_dict: dict[str, dict[str, Any]], match_rows: bool = False
-) -> AnnData | None:
+    table: AnnData, elements_dict: dict[str, dict[str, Any]], match_rows: bool = False
+) -> AnnData:
     """
     Filter an AnnData table to keep only the rows that are in the elements.
 
@@ -168,8 +168,6 @@ def _filter_table_by_elements(
     assert any(
         len(elements) > 0 for elements in elements_dict.values()
     ), "elements_dict must contain at least one dict which contains at least one element"
-    if table is None:
-        return None
     to_keep = np.zeros(len(table), dtype=bool)
     region_key = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]
     instance_key = table.uns[TableModel.ATTRS_KEY][TableModel.INSTANCE_KEY]

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -145,7 +145,7 @@ def _(
 
 # TODO: replace function use throughout repo by `join_sdata_spatialelement_table`
 def _filter_table_by_elements(
-    table: AnnData, elements_dict: dict[str, dict[str, Any]], match_rows: bool = False
+    table: AnnData | list[AnnData], elements_dict: dict[str, dict[str, Any]], match_rows: bool = False
 ) -> AnnData:
     """
     Filter an AnnData table to keep only the rows that are in the elements.
@@ -216,6 +216,7 @@ def _filter_table_by_elements(
 
     original_table = table
     table = _filter_table(table, to_keep)
+
     if match_rows:
         assert instances is not None
         assert isinstance(instances, np.ndarray)

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -735,10 +735,17 @@ class SpatialData:
                     continue
                 # each mode here requires paths or elements, using assert here to avoid mypy errors.
                 if by == "cs":
-                    from spatialdata._core.query.relational_query import _filter_table_by_element_names
+                    from spatialdata._core.query.relational_query import _filter_table_by_elements
 
                     assert element_names is not None
-                    table = _filter_table_by_element_names(table, element_names)
+                    elements_dict = {}
+                    for element_type in ["images", "labels", "shapes", "points"]:
+                        elements = getattr(self, element_type)
+                        if elements:  # Check if the dictionary is not empty
+                            elements_dict[element_type] = {
+                                name: elements[name] for name in element_names if name in elements
+                            }
+                    table = _filter_table_by_elements(table, elements_dict=elements_dict)
                     if len(table) != 0:
                         tables[table_name] = table
                 elif by == "elements":

--- a/tests/core/operations/test_spatialdata_operations.py
+++ b/tests/core/operations/test_spatialdata_operations.py
@@ -135,9 +135,15 @@ def test_filter_by_coordinate_system(full_sdata: SpatialData) -> None:
 def test_filter_by_coordinate_system_also_table(full_sdata: SpatialData) -> None:
     from spatialdata.models import TableModel
 
-    rng = np.random.default_rng(seed=0)
-    full_sdata["table"].obs["annotated_shapes"] = rng.choice(["circles", "poly"], size=full_sdata["table"].shape[0])
-    adata = full_sdata["table"]
+    adata = full_sdata["table"].copy()
+
+    circles_instances = full_sdata["circles"].index.values
+    poly_instances = full_sdata["poly"].index.values
+
+    adata = adata[: len(circles_instances) + len(poly_instances), :].copy()
+    adata.obs["annotated_shapes"] = ["circles"] * len(circles_instances) + ["poly"] * len(poly_instances)
+    adata.obs["instance_id"] = np.concatenate([circles_instances, poly_instances])
+
     del adata.uns[TableModel.ATTRS_KEY]
     del full_sdata.tables["table"]
     full_sdata.table = TableModel.parse(


### PR DESCRIPTION
I would like to refactor this function in order to support multiple tables.

### Features

Let's say I have a region element `shapes1`, I would like to filter the table or tables that contain instances from that region. This filtering should have the following features:
- [ ] do not copy, but return a view
- [ ] optionally return a mapping `table_name -> instances` or the same list of tables

@melonora @LucaMarconato I have looked back at the multiple table in-memory design, but I couldn't find a clear description of any constraint or expected behaviour in the conversation or in the design document. In particular, from our previous conversations, I understood that:
- a table can map to multiple elements (e.g. diff views of the same annotation)
- a table can have rows that map to an element, and rows that don't map to any element
- a table can also not map to any element

can two tables map to the same element?
Thanks for the clarification


