### PR TITLE
3 and 4 channels default to rgb

### DIFF
--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -186,6 +186,8 @@ class RasterSchema(DataArraySchema):
                 ) from e
 
         # finally convert to spatial image
+        if "rgb" not in kwargs:
+            kwargs["rgb"] = None
         data = to_spatial_image(array_like=data, dims=cls.dims.dims, **kwargs)
         # parse transformations
         _parse_transformations(data, transformations)


### PR DESCRIPTION
The default parameter `rgb=False` in `to_spatial_image()` ([code here](https://github.com/spatial-image/spatial-image/blob/8bc3c54d6d8595f6ba217e97cf5e35f4716ab5bc/spatial_image.py#L1149)) implies that if we have an RGB image with no channels specified, the image will be parsed by calling its channels `'0', '1', ...`. This means that napari-spatialdata will show the image as separating channels and using grayscale coloring.

This PR sets `rgb=None`, which will set the default channel names to `'r', 'g', 'b'` (`'a'`) when `c_coords` is not set, leading to correct visualization in `napari-spatialdata`.