### PR TITLE
Adding `attrs` at the `SpatialData` object level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning][].
 
 ## [0.x.x] - 2024-xx-xx
 
+### Major
+
+-   Added attributes at the SpatialData object level (`.attrs`)
+
 ### Minor
 
 -   Added `clip: bool = False` parameter to `polygon_query()` #670

--- a/src/spatialdata/_core/_deepcopy.py
+++ b/src/spatialdata/_core/_deepcopy.py
@@ -47,7 +47,8 @@ def _(sdata: SpatialData) -> SpatialData:
     elements_dict = {}
     for _, element_name, element in sdata.gen_elements():
         elements_dict[element_name] = deepcopy(element)
-    return SpatialData.from_elements_dict(elements_dict)
+    deepcopied_attrs = _deepcopy(sdata.attrs)
+    return SpatialData.from_elements_dict(elements_dict, attrs=deepcopied_attrs)
 
 
 @deepcopy.register(DataArray)

--- a/src/spatialdata/_core/concatenate.py
+++ b/src/spatialdata/_core/concatenate.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from copy import copy  # Should probably go up at the top
 from itertools import chain
-from typing import Any, Callable
+from typing import Any
 from warnings import warn
 
 import numpy as np

--- a/src/spatialdata/_core/operations/_utils.py
+++ b/src/spatialdata/_core/operations/_utils.py
@@ -134,7 +134,7 @@ def transform_to_data_extent(
             set_transformation(el, transformation={coordinate_system: Identity()}, set_all=True)
     for k, v in sdata.tables.items():
         sdata_to_return_elements[k] = v.copy()
-    return SpatialData.from_elements_dict(sdata_to_return_elements)
+    return SpatialData.from_elements_dict(sdata_to_return_elements, attrs=sdata.attrs)
 
 
 def _parse_element(

--- a/src/spatialdata/_core/operations/rasterize.py
+++ b/src/spatialdata/_core/operations/rasterize.py
@@ -305,7 +305,7 @@ def rasterize(
                     new_labels[new_name] = rasterized
                 else:
                     raise RuntimeError(f"Unsupported model {model} detected as return type of rasterize().")
-        return SpatialData(images=new_images, labels=new_labels, tables=data.tables)
+        return SpatialData(images=new_images, labels=new_labels, tables=data.tables, attrs=data.attrs)
 
     parsed_data = _parse_element(element=data, sdata=sdata, element_var_name="data", sdata_var_name="sdata")
     model = get_model(parsed_data)

--- a/src/spatialdata/_core/operations/transform.py
+++ b/src/spatialdata/_core/operations/transform.py
@@ -300,7 +300,7 @@ def _(
             new_elements[element_type][k] = transform(
                 v, transformation, to_coordinate_system=to_coordinate_system, maintain_positioning=maintain_positioning
             )
-    return SpatialData(**new_elements)
+    return SpatialData(**new_elements, attrs=data.attrs)
 
 
 @transform.register(DataArray)

--- a/src/spatialdata/_core/query/spatial_query.py
+++ b/src/spatialdata/_core/query/spatial_query.py
@@ -529,7 +529,7 @@ def _(
 
     tables = _get_filtered_or_unfiltered_tables(filter_table, new_elements, sdata)
 
-    return SpatialData(**new_elements, tables=tables)
+    return SpatialData(**new_elements, tables=tables, attrs=sdata.attrs)
 
 
 @bounding_box_query.register(DataArray)
@@ -881,7 +881,7 @@ def _(
 
     tables = _get_filtered_or_unfiltered_tables(filter_table, new_elements, sdata)
 
-    return SpatialData(**new_elements, tables=tables)
+    return SpatialData(**new_elements, tables=tables, attrs=sdata.attrs)
 
 
 @polygon_query.register(DataArray)

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -1583,9 +1583,8 @@ class SpatialData:
             zarr_group = zarr.group(store=store, overwrite=False)
 
         version = parsed["SpatialData"].spatialdata_format_version
-        # we currently do not save any specific root level metadata, so we don't need to call
-        # parsed['SpatialData'].dict_to_attrs()
-        attrs_to_write = {"spatialdata_attrs": {"version": version}} | self.attrs
+        version_specific_attrs = parsed["SpatialData"].attrs_to_dict()
+        attrs_to_write = {"spatialdata_attrs": {"version": version} | version_specific_attrs} | self.attrs
 
         try:
             zarr_group.attrs.put(attrs_to_write)

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -1564,9 +1564,6 @@ class SpatialData:
         -----
         When using the methods `write()` and `write_element()`, the metadata is written automatically.
         """
-        if write_attrs:
-            self.write_attrs()
-
         from spatialdata._core._elements import Elements
 
         if element_name is not None:
@@ -1576,6 +1573,9 @@ class SpatialData:
         # TODO: write .uns['spatialdata_attrs'] metadata for AnnData.
         # TODO: write .attrs['spatialdata_attrs'] metadata for DaskDataFrame.
         # TODO: write omero metadata for the channel name of images.
+
+        if write_attrs:
+            self.write_attrs()
 
         if consolidate_metadata is None and self.has_consolidated_metadata():
             consolidate_metadata = True

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -687,7 +687,7 @@ class SpatialData:
             set(), filter_tables, "cs", include_orphan_tables, element_names=element_names_in_coordinate_system
         )
 
-        return SpatialData(**elements, tables=tables)
+        return SpatialData(**elements, tables=tables, attrs=self.attrs)
 
     # TODO: move to relational query with refactor
     def _filter_tables(
@@ -929,7 +929,7 @@ class SpatialData:
                 if element_type not in elements:
                     elements[element_type] = {}
                 elements[element_type][element_name] = transformed
-        return SpatialData(**elements, tables=sdata.tables)
+        return SpatialData(**elements, tables=sdata.tables, attrs=self.attrs)
 
     def elements_are_self_contained(self) -> dict[str, bool]:
         """
@@ -2112,7 +2112,7 @@ class SpatialData:
             include_orphan_tables,
             elements_dict=elements_dict,
         )
-        return SpatialData(**elements_dict, tables=tables)
+        return SpatialData(**elements_dict, tables=tables, attrs=self.attrs)
 
     def __getitem__(self, item: str) -> SpatialElement:
         """

--- a/src/spatialdata/_io/format.py
+++ b/src/spatialdata/_io/format.py
@@ -48,6 +48,16 @@ class SpatialDataFormat(CurrentFormat):
     pass
 
 
+class SpatialDataContainerFormatV01(SpatialDataFormat):
+    @property
+    def spatialdata_format_version(self) -> str:
+        return "0.1"
+
+    # no need for attrs_from_dict as we are not saving specific metadata at the root level
+    def attrs_to_dict(self, data: dict[str, Any]) -> dict[str, str | dict[str, Any]]:
+        return {}
+
+
 class RasterFormatV01(SpatialDataFormat):
     """Formatter for raster data."""
 
@@ -201,6 +211,7 @@ CurrentRasterFormat = RasterFormatV01
 CurrentShapesFormat = ShapesFormatV02
 CurrentPointsFormat = PointsFormatV01
 CurrentTablesFormat = TablesFormatV01
+CurrentSpatialDataContainerFormats = SpatialDataContainerFormatV01
 
 ShapesFormats = {
     "0.1": ShapesFormatV01(),
@@ -215,6 +226,9 @@ TablesFormats = {
 RasterFormats = {
     "0.1": RasterFormatV01(),
 }
+SpatialDataContainerFormats = {
+    "0.1": SpatialDataContainerFormatV01(),
+}
 
 
 def _parse_formats(formats: SpatialDataFormat | list[SpatialDataFormat] | None) -> dict[str, SpatialDataFormat]:
@@ -223,6 +237,7 @@ def _parse_formats(formats: SpatialDataFormat | list[SpatialDataFormat] | None) 
         "shapes": CurrentShapesFormat(),
         "points": CurrentPointsFormat(),
         "tables": CurrentTablesFormat(),
+        "SpatialData": CurrentSpatialDataContainerFormats(),
     }
     if formats is None:
         return parsed
@@ -236,6 +251,7 @@ def _parse_formats(formats: SpatialDataFormat | list[SpatialDataFormat] | None) 
         "shapes": False,
         "points": False,
         "tables": False,
+        "SpatialData": False,
     }
 
     def _check_modified(element_type: str) -> None:
@@ -256,6 +272,9 @@ def _parse_formats(formats: SpatialDataFormat | list[SpatialDataFormat] | None) 
         elif any(isinstance(fmt, type(v)) for v in RasterFormats.values()):
             _check_modified("raster")
             parsed["raster"] = fmt
+        elif any(isinstance(fmt, type(v)) for v in SpatialDataContainerFormats.values()):
+            _check_modified("SpatialData")
+            parsed["SpatialData"] = fmt
         else:
             raise ValueError(f"Unsupported format {fmt}")
     return parsed

--- a/src/spatialdata/_io/format.py
+++ b/src/spatialdata/_io/format.py
@@ -53,9 +53,13 @@ class SpatialDataContainerFormatV01(SpatialDataFormat):
     def spatialdata_format_version(self) -> str:
         return "0.1"
 
-    # no need for attrs_from_dict as we are not saving specific metadata at the root level
-    def attrs_to_dict(self, data: dict[str, Any]) -> dict[str, str | dict[str, Any]]:
+    def attrs_from_dict(self, metadata: dict[str, Any]) -> dict[str, Any]:
         return {}
+
+    def attrs_to_dict(self) -> dict[str, str | dict[str, Any]]:
+        from spatialdata import __version__
+
+        return {"spatialdata_software_version": __version__}
 
 
 class RasterFormatV01(SpatialDataFormat):

--- a/src/spatialdata/_io/io_zarr.py
+++ b/src/spatialdata/_io/io_zarr.py
@@ -145,6 +145,7 @@ def read_zarr(store: Union[str, Path, zarr.Group], selection: Optional[tuple[str
         points=points,
         shapes=shapes,
         tables=tables,
+        attrs=f.attrs.asdict(),
     )
     sdata.path = Path(store)
     return sdata

--- a/src/spatialdata/_io/io_zarr.py
+++ b/src/spatialdata/_io/io_zarr.py
@@ -141,8 +141,8 @@ def read_zarr(store: str | Path | zarr.Group, selection: None | tuple[str] = Non
     # read attrs metadata
     attrs = f.attrs.asdict()
     if "spatialdata_attrs" in attrs:
-        # no need to call for SpatialDataContainerFormatV01.attrs_to_dict since currently we do not save any root-level
-        # metadata
+        # when refactoring the read_zarr function into reading componenets separately (and according to the version),
+        # we can move the code below (.pop()) into attrs_from_dict()
         attrs.pop("spatialdata_attrs")
     else:
         attrs = None

--- a/src/spatialdata/_io/io_zarr.py
+++ b/src/spatialdata/_io/io_zarr.py
@@ -138,13 +138,22 @@ def read_zarr(store: str | Path | zarr.Group, selection: None | tuple[str] = Non
 
         logger.debug(f"Found {count} elements in {group}")
 
+    # read attrs metadata
+    attrs = f.attrs.asdict()
+    if "spatialdata_attrs" in attrs:
+        # no need to call for SpatialDataContainerFormatV01.attrs_to_dict since currently we do not save any root-level
+        # metadata
+        attrs.pop("spatialdata_attrs")
+    else:
+        attrs = None
+
     sdata = SpatialData(
         images=images,
         labels=labels,
         points=points,
         shapes=shapes,
         tables=tables,
-        attrs=f.attrs.asdict(),
+        attrs=attrs,
     )
     sdata.path = Path(store)
     return sdata

--- a/tests/core/operations/test_rasterize.py
+++ b/tests/core/operations/test_rasterize.py
@@ -205,7 +205,7 @@ def test_rasterize_shapes():
     )
     adata.obs["cat_values"] = adata.obs["cat_values"].astype("category")
     adata = TableModel.parse(adata, region=element_name, region_key="region", instance_key="instance_id")
-    sdata = SpatialData.init_from_elements({element_name: gdf[["geometry"]]}, table=adata)
+    sdata = SpatialData.init_from_elements({element_name: gdf[["geometry"]], "table": adata})
 
     def _rasterize(element: GeoDataFrame, **kwargs) -> SpatialImage:
         return _rasterize_test_alternative_calls(element=element, sdata=sdata, element_name=element_name, **kwargs)
@@ -320,7 +320,7 @@ def test_rasterize_points():
     )
     adata.obs["gene"] = adata.obs["gene"].astype("category")
     adata = TableModel.parse(adata, region=element_name, region_key="region", instance_key="instance_id")
-    sdata = SpatialData.init_from_elements({element_name: ddf[["x", "y"]]}, table=adata)
+    sdata = SpatialData.init_from_elements({element_name: ddf[["x", "y"]], "table": adata})
 
     def _rasterize(element: DaskDataFrame, **kwargs) -> SpatialImage:
         return _rasterize_test_alternative_calls(element=element, sdata=sdata, element_name=element_name, **kwargs)

--- a/tests/core/operations/test_spatialdata_operations.py
+++ b/tests/core/operations/test_spatialdata_operations.py
@@ -389,9 +389,15 @@ def test_no_shared_transformations() -> None:
 
 
 def test_init_from_elements(full_sdata: SpatialData) -> None:
+    # this first code block needs to be removed when the tables argument is removed from init_from_elements()
     all_elements = {name: el for _, name, el in full_sdata._gen_elements()}
-    sdata = SpatialData.init_from_elements(all_elements, table=full_sdata.table)
-    for element_type in ["images", "labels", "points", "shapes"]:
+    sdata = SpatialData.init_from_elements(all_elements, tables=full_sdata["table"])
+    for element_type in ["images", "labels", "points", "shapes", "tables"]:
+        assert set(getattr(sdata, element_type).keys()) == set(getattr(full_sdata, element_type).keys())
+
+    all_elements = {name: el for _, name, el in full_sdata._gen_elements(include_table=True)}
+    sdata = SpatialData.init_from_elements(all_elements)
+    for element_type in ["images", "labels", "points", "shapes", "tables"]:
         assert set(getattr(sdata, element_type).keys()) == set(getattr(full_sdata, element_type).keys())
 
 

--- a/tests/core/test_deepcopy.py
+++ b/tests/core/test_deepcopy.py
@@ -1,5 +1,6 @@
 from pandas.testing import assert_frame_equal
 
+from spatialdata import SpatialData
 from spatialdata._core._deepcopy import deepcopy as _deepcopy
 from spatialdata.testing import assert_spatial_data_objects_are_identical
 
@@ -45,3 +46,18 @@ def test_deepcopy(full_sdata):
 
     assert_spatial_data_objects_are_identical(full_sdata, copied)
     assert_spatial_data_objects_are_identical(full_sdata, copied_again)
+
+
+def test_deepcopy_attrs(points: SpatialData) -> None:
+    some_attrs = {"a": {"b": 0}}
+    points.attrs = some_attrs
+
+    # before deepcopy
+    sub_points = points.subset(["points_0"])
+    assert sub_points.attrs is some_attrs
+    assert sub_points.attrs["a"] is some_attrs["a"]
+
+    # after deepcopy
+    sub_points_deepcopy = _deepcopy(sub_points)
+    assert sub_points_deepcopy.attrs is not some_attrs
+    assert sub_points_deepcopy.attrs["a"] is not some_attrs["a"]

--- a/tests/io/test_readwrite.py
+++ b/tests/io/test_readwrite.py
@@ -581,6 +581,30 @@ def test_incremental_io_valid_name(points: SpatialData) -> None:
     _check_valid_name(points.delete_element_from_disk)
 
 
+def test_incremental_io_attrs(points: SpatialData) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        f = os.path.join(tmpdir, "data.zarr")
+        my_attrs = {"a": "b", "c": 1}
+        points.attrs = my_attrs
+        points.write(f)
+
+        # test that the attributes are written to disk
+        sdata = SpatialData.read(f)
+        assert sdata.attrs == my_attrs
+
+        # test incremental io attrs (write_attrs())
+        sdata.attrs["c"] = 2
+        sdata.write_attrs()
+        sdata2 = SpatialData.read(f)
+        assert sdata2.attrs["c"] == 2
+
+        # test incremental io attrs (write_metadata())
+        sdata.attrs["c"] = 3
+        sdata.write_metadata()
+        sdata2 = SpatialData.read(f)
+        assert sdata2.attrs["c"] == 3
+
+
 cached_sdata_blobs = blobs()
 
 


### PR DESCRIPTION
As described in issue #404, it is useful to have attributes at the `SpatialData` object level. This will also be useful in Sopa, to simplify the API.

### Example Usage
```python
import spatialdata

from spatialdata.datasets import blobs

sdata = blobs()

sdata.attrs # empty dictionnary
sdata.attrs["test"] = 12

sdata.write("blobs.zarr") # this saves the attributes on disk

sdata = spatialdata.read_zarr("blobs.zarr") # the attributes are read normally

sdata.attrs["test"] # returns 12
```

What do you think @LucaMarconato?

### Check-list

- [x] Add `attrs` attribute to the `SpatialData` object
- [x] Can write the `attrs` on disk when the data is not backed
- [x] Can write the attrs on disk when the data is already backed
- [x] Can read the `attrs` from disk
- [x] Pass the `attrs` to new SpatialData objects
- [x] Merge conflict keys in `attrs` during concatenation
- [x] Update the format version (see Luca's comment)