### PR TITLE
Fix validation and scale accessor multiscale image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning][].
 ### Minor
 
 -   Added `shortest_path` parameter to `get_transformation_between_coordinate_systems`
+-   Added `get_pyramid_levels()` utils API
 
 ## [0.2.3] - 2024-09-25
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -52,6 +52,7 @@ Operations on `SpatialData` objects.
     unpad_raster
     are_extents_equal
     deepcopy
+    get_pyramid_levels
 ```
 
 ## Models

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -44,6 +44,7 @@ __all__ = [
     "get_centroids",
     "read_zarr",
     "unpad_raster",
+    "get_pyramid_levels",
     "save_transformations",
     "get_dask_backing_files",
     "are_extents_equal",
@@ -75,4 +76,4 @@ from spatialdata._core.query.spatial_query import bounding_box_query, polygon_qu
 from spatialdata._core.spatialdata import SpatialData
 from spatialdata._io._utils import get_dask_backing_files, save_transformations
 from spatialdata._io.io_zarr import read_zarr
-from spatialdata._utils import unpad_raster
+from spatialdata._utils import get_pyramid_levels, unpad_raster

--- a/src/spatialdata/_io/io_raster.py
+++ b/src/spatialdata/_io/io_raster.py
@@ -17,7 +17,6 @@ from xarray import DataArray
 
 from spatialdata._io._utils import (
     _get_transformations_from_ngff_dict,
-    _iter_multiscale,
     overwrite_coordinate_transformations_raster,
 )
 from spatialdata._io.format import (
@@ -26,6 +25,7 @@ from spatialdata._io.format import (
     RasterFormatV01,
     _parse_version,
 )
+from spatialdata._utils import get_pyramid_levels
 from spatialdata.models._utils import get_channels
 from spatialdata.models.models import ATTRS_KEY
 from spatialdata.transformations._utils import (
@@ -180,8 +180,8 @@ def _write_raster(
             group=_get_group_for_writing_transformations(), transformations=transformations, axes=input_axes
         )
     elif isinstance(raster_data, DataTree):
-        data = _iter_multiscale(raster_data, "data")
-        list_of_input_axes: list[Any] = _iter_multiscale(raster_data, "dims")
+        data = get_pyramid_levels(raster_data, attr="data")
+        list_of_input_axes: list[Any] = get_pyramid_levels(raster_data, attr="dims")
         assert len(set(list_of_input_axes)) == 1
         input_axes = list_of_input_axes[0]
         # saving only the transformations of the first scale
@@ -191,8 +191,8 @@ def _write_raster(
         transformations = _get_transformations_xarray(xdata)
         assert transformations is not None
         assert len(transformations) > 0
-        chunks = _iter_multiscale(raster_data, "chunks")
-        # coords = _iter_multiscale(raster_data, "coords")
+        chunks = get_pyramid_levels(raster_data, "chunks")
+        # coords = iterate_pyramid_levels(raster_data, "coords")
         parsed_axes = _get_valid_axes(axes=list(input_axes), fmt=format)
         storage_options = [{"chunks": chunk} for chunk in chunks]
         write_multi_scale_ngff(

--- a/src/spatialdata/_utils.py
+++ b/src/spatialdata/_utils.py
@@ -4,6 +4,7 @@ import functools
 import re
 import warnings
 from collections.abc import Generator
+from itertools import islice
 from typing import Any, Callable, TypeVar, Union
 
 import numpy as np
@@ -150,28 +151,53 @@ def unpad_raster(raster: DataArray | DataTree) -> DataArray | DataTree:
     return compute_coordinates(unpadded)
 
 
-# TODO: this functions is similar to _iter_multiscale(), the latter is more powerful but not exposed to the user.
-#  Use only one and expose it to the user in this file
-def iterate_pyramid_levels(image: DataTree) -> Generator[DataArray, None, None]:
+def get_pyramid_levels(image: DataTree, attr: str | None = None, n: int | None = None) -> list[Any] | Any:
     """
-    Iterate over the pyramid levels of a multiscale spatial image.
+    Access the data/attribute of the pyramid levels of a multiscale spatial image.
 
     Parameters
     ----------
     image
         The multiscale spatial image.
+    attr
+        If `None`, return the data of the pyramid level as a `DataArray`, if not None, return the specified attribute
+        within the `DataArray` data.
+    n
+        If not None, return only the `n` pyramid level.
 
     Returns
     -------
-    A generator that yields the pyramid levels.
+    The pyramid levels data (or an attribute of it) as a list or a generator.
     """
-    for k in range(len(image)):
-        scale_name = f"scale{k}"
-        dt = image[scale_name]
-        v = dt.values()
-        assert len(v) == 1
-        xdata = next(iter(v))
-        yield xdata
+    generator = iterate_pyramid_levels(image, attr)
+    if n is not None:
+        return next(iter(islice(generator, n, None)))
+    return list(generator)
+
+
+def iterate_pyramid_levels(
+    data: DataTree,
+    attr: str | None,
+) -> Generator[Any, None, None]:
+    """
+    Iterate over the pyramid levels of a multiscale spatial image.
+
+    Parameters
+    ----------
+    data
+        The multiscale spatial image
+    attr
+        If `None`, return the data of the pyramid level as a `DataArray`, if not None, return the specified attribute
+        within the `DataArray` data.
+
+    Returns
+    -------
+    A generator to iterate over the pyramid levels.
+    """
+    names = data["scale0"].ds.keys()
+    name: str = next(iter(names))
+    for scale in data:
+        yield data[scale][name] if attr is None else getattr(data[scale][name], attr)
 
 
 def _inplace_fix_subset_categorical_obs(subset_adata: AnnData, original_adata: AnnData) -> None:

--- a/src/spatialdata/_utils.py
+++ b/src/spatialdata/_utils.py
@@ -150,23 +150,6 @@ def unpad_raster(raster: DataArray | DataTree) -> DataArray | DataTree:
     return compute_coordinates(unpadded)
 
 
-# TODO: probably we want this method to live in multiscale_spatial_image
-def multiscale_spatial_image_from_data_tree(data_tree: DataTree) -> DataTree:
-    warnings.warn(
-        f"{multiscale_spatial_image_from_data_tree} is deprecated and will be removed in version 0.2.0.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    d = {}
-    for k, dt in data_tree.items():
-        v = dt.values()
-        assert len(v) == 1
-        xdata = v.__iter__().__next__()
-        d[k] = xdata
-
-    return DataTree.from_dict(d)
-
-
 # TODO: this functions is similar to _iter_multiscale(), the latter is more powerful but not exposed to the user.
 #  Use only one and expose it to the user in this file
 def iterate_pyramid_levels(image: DataTree) -> Generator[DataArray, None, None]:

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -251,8 +251,8 @@ class RasterSchema(DataArraySchema):
             if j != k:
                 raise ValueError(f"Wrong key for multiscale data, found: `{j}`, expected: `{k}`.")
         name = {list(data[i].data_vars.keys())[0] for i in data}
-        if len(name) > 1:
-            raise ValueError(f"Wrong name for datatree: `{name}`.")
+        if len(name) != 1:
+            raise ValueError(f"Expected exactly one data variable for the datatree: found `{name}`.")
         name = list(name)[0]
         for d in data:
             super().validate(data[d][name])

--- a/tests/core/operations/test_rasterize.py
+++ b/tests/core/operations/test_rasterize.py
@@ -16,7 +16,7 @@ from xarray import DataArray
 from spatialdata import SpatialData, get_extent
 from spatialdata._core.operations.rasterize import rasterize
 from spatialdata._core.query.relational_query import get_element_instances
-from spatialdata._io._utils import _iter_multiscale
+from spatialdata._utils import get_pyramid_levels
 from spatialdata.models import PointsModel, ShapesModel, TableModel, get_axes_names
 from spatialdata.models._utils import get_spatial_axes
 from spatialdata.transformations import MapAxis
@@ -57,7 +57,7 @@ def test_rasterize_raster(_get_raster):
         if isinstance(raster, DataArray):
             return raster.data.compute()
 
-        xdata = next(iter(_iter_multiscale(raster, None)))
+        xdata = get_pyramid_levels(raster, n=0)
         return xdata.data.compute()
 
     for element_name, raster in rasters.items():


### PR DESCRIPTION
Small PR adding the `spatialdata.get_pyramid_levels()` util function.

closes #106 (was mostly implemented already)
closes #355 