### PR TITLE
fix integration CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ test = [
     "pytest",
     "pytest-cov",
     "pytest-mock",
+    "torch",
 ]
 torch = [
     "torch"


### PR DESCRIPTION
The integration CI is failing with spatialdata most likely because torch is not a test dependency (because of the github workflow only installing like this `pip install -e .[test]` the torch dependency is missing when running the dataloader tests.

Here torch is now included in test and the github workflow is adjusted to reflect that.