### PR TITLE
hotfix multiscale spatial image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "dask>=2024.4.1",
     "fsspec<=2023.6",
     "geopandas>=0.14",
-    "multiscale_spatial_image>=1.0.0",
+    "multiscale_spatial_image>=1.0.0,<2.0.0",
     "networkx",
     "numba",
     "numpy",


### PR DESCRIPTION
Due to new release of `multiscale-spatial-image` it can lead to problems as it uses the version of xarray that already directly imports datatree.