### PR TITLE
Use numba jit instead of njit to remove warning

### DIFF
--- a/src/spatialdata/_core/query/_utils.py
+++ b/src/spatialdata/_core/query/_utils.py
@@ -96,7 +96,7 @@ def get_bounding_box_corners(
     return output.squeeze().drop_vars("box")
 
 
-@nb.njit(parallel=False, nopython=True)
+@nb.jit(parallel=False, nopython=True)
 def _create_slices_and_translation(
     min_values: nb.types.Array,
     max_values: nb.types.Array,


### PR DESCRIPTION
One-character PR to remove the following warning during the import of spatialdata:
```
RuntimeWarning: nopython is set for njit and is ignored
```
Very minor PR, not urgent.
See [here](https://github.com/numba/numba/blob/0f363d1b2dd19f2aa1a8cec5f0a99c3dd95512f8/numba/core/decorators.py#L239) the difference between `numba.jit` and `numba.njit`.

> I was annoyed about this warning when running segmentation: for instance, with 50 workers, the warning gets duplicated 50 times and breaks the progress bar.