### PR TITLE
migrated pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,8 @@ fail_fast: false
 default_language_version:
     python: python3
 default_stages:
-    - commit
-    - push
+    - pre-commit
+    - pre-push
 minimum_pre_commit_version: 2.16.0
 ci:
     skip: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [0.2.6] - TBD
+
+### Fixed
+
+-   Updated deprecated default stages of `pre-commit` #771
+
 ## [0.2.5] - 2024-06-11
 
 ### Fixed


### PR DESCRIPTION
Some of the default stage names have been deprecated for `pre-commit`. This PR introduces the update as suggested by pre-commit to migrate the config: `pre-commit migrate-config`.