### PR TITLE
Move c_coords out of kwargs

### DIFF
--- a/src/spatialdata/datasets.py
+++ b/src/spatialdata/datasets.py
@@ -40,7 +40,7 @@ def blobs(
     n_shapes: int = 5,
     extra_coord_system: str | None = None,
     n_channels: int = 3,
-    c_coords: ArrayLike | None = None,
+    c_coords: str | list[str] | None = None,
 ) -> SpatialData:
     """
     Blobs dataset.
@@ -108,7 +108,7 @@ class BlobsDataset:
         n_shapes: int = 5,
         extra_coord_system: str | None = None,
         n_channels: int = 3,
-        c_coords: ArrayLike | None = None,
+        c_coords: str | list[str] | None = None,
     ) -> None:
         """
         Blobs dataset.
@@ -176,7 +176,7 @@ class BlobsDataset:
         transformations: dict[str, Any] | None = None,
         length: int = 512,
         n_channels: int = 3,
-        c_coords: ArrayLike | None = None,
+        c_coords: str | list[str] | None = None,
         multiscale: bool = False,
     ) -> DataArray | DataTree:
         masks = []

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -111,8 +111,7 @@ class RasterSchema(DataArraySchema):
             Dimensions of the data (e.g. ['c', 'y', 'x'] for 2D image data). If the data is a :class:`xarray.DataArray`,
             the dimensions can also be inferred from the data. If the dimensions are not in the order (c)(z)yx, the data
             will be transposed to match the order.
-        {("c_coords : str | list[str] | None\n            Set channel coordinates for image data. This is only"
-        "applicable for image data; labels data do not have channels.\n" if cls.INCLUDE_C_COORDS else "")}
+        {("c_coords : str | list[str] | None\n           Channel names of image data." if cls.INCLUDE_C_COORDS else "")}
         transformations
             Dictionary of transformations to apply to the data. The key is the name of the target coordinate system,
             the value is the transformation to apply. By default, a single `Identity` transformation mapping to the

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -111,7 +111,9 @@ class RasterSchema(DataArraySchema):
             Dimensions of the data (e.g. ['c', 'y', 'x'] for 2D image data). If the data is a :class:`xarray.DataArray`,
             the dimensions can also be inferred from the data. If the dimensions are not in the order (c)(z)yx, the data
             will be transposed to match the order.
-        {("c_coords : str | list[str] | None\n           Channel names of image data." if cls.INCLUDE_C_COORDS else "")}
+        c_coords : str | list[str] | None
+            Channel names of image data. Must be equal to the length of dimension 'c'. Only supported for `Image`
+            models.
         transformations
             Dictionary of transformations to apply to the data. The key is the name of the target coordinate system,
             the value is the transformation to apply. By default, a single `Identity` transformation mapping to the
@@ -318,7 +320,6 @@ class Image2DModel(RasterSchema):
     attrs = AttrsSchema({"transform": Transform_s})
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.INCLUDE_C_COORDS = True
         super().__init__(
             dims=self.dims,
             array_type=self.array_type,
@@ -334,7 +335,6 @@ class Image3DModel(RasterSchema):
     attrs = AttrsSchema({"transform": Transform_s})
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.INCLUDE_C_COORDS = True
         super().__init__(
             dims=self.dims,
             array_type=self.array_type,

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -98,7 +98,7 @@ class RasterSchema(DataArraySchema):
         chunks: Chunks_t | None = None,
         **kwargs: Any,
     ) -> DataArray | DataTree:
-        """
+        r"""
         Validate (or parse) raster data.
 
         Parameters
@@ -111,6 +111,8 @@ class RasterSchema(DataArraySchema):
             Dimensions of the data (e.g. ['c', 'y', 'x'] for 2D image data). If the data is a :class:`xarray.DataArray`,
             the dimensions can also be inferred from the data. If the dimensions are not in the order (c)(z)yx, the data
             will be transposed to match the order.
+        {("c_coords : str | list[str] | None\n            Set channel coordinates for image data. This is only"
+        "applicable for image data; labels data do not have channels.\n" if cls.INCLUDE_C_COORDS else "")}
         transformations
             Dictionary of transformations to apply to the data. The key is the name of the target coordinate system,
             the value is the transformation to apply. By default, a single `Identity` transformation mapping to the
@@ -317,6 +319,7 @@ class Image2DModel(RasterSchema):
     attrs = AttrsSchema({"transform": Transform_s})
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.INCLUDE_C_COORDS = True
         super().__init__(
             dims=self.dims,
             array_type=self.array_type,
@@ -332,6 +335,7 @@ class Image3DModel(RasterSchema):
     attrs = AttrsSchema({"transform": Transform_s})
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.INCLUDE_C_COORDS = True
         super().__init__(
             dims=self.dims,
             array_type=self.array_type,


### PR DESCRIPTION
This PR implements one of the tasks in #750 to improve the handling of channel names. It moves the `c_coords` parameter out of kwargs and also adds a validation for a mismatch in length between `c_coords` and the length of the `c` dimension.