### PR TITLE
Fix `transform_to_data_extent` converting labels to images

### DIFF
--- a/src/spatialdata/_core/operations/_utils.py
+++ b/src/spatialdata/_core/operations/_utils.py
@@ -125,6 +125,7 @@ def transform_to_data_extent(
                 target_width=target_width,
                 target_height=None,
                 target_depth=None,
+                return_regions_as_labels=True,
             )
             sdata_to_return_elements[element_name] = rasterized
         else:

--- a/tests/core/operations/test_spatialdata_operations.py
+++ b/tests/core/operations/test_spatialdata_operations.py
@@ -17,6 +17,7 @@ from spatialdata.models import (
     PointsModel,
     ShapesModel,
     TableModel,
+    get_model,
     get_table_keys,
 )
 from spatialdata.testing import assert_elements_dict_are_identical, assert_spatial_data_objects_are_identical
@@ -468,6 +469,7 @@ def test_transform_to_data_extent(full_sdata: SpatialData, maintain_positioning:
         for element in elements:
             before = full_sdata[element]
             after = sdata[element]
+            assert get_model(after) == get_model(before)
             data_extent_before = get_extent(before, coordinate_system="global")
             data_extent_after = get_extent(after, coordinate_system="global")
             # huge tolerance because of the bug with pixel perfectness


### PR DESCRIPTION
This PR ensures `transform_to_data_extent` preserves the data type of labels and does not convert them to images. Here, I chose the most minimal solution to pass the (missing) parameter `return_regions_as_labels=True` and override its default of `False`.

Meanwhile, @quentinblampey has already documented the parameter `return_regions_as_labels` in `rasterize`.

Closes #783