### PR TITLE
update multiscale-spatial-image dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "dask>=2024.4.1",
     "fsspec<=2023.6",
     "geopandas>=0.14",
-    "multiscale_spatial_image>=2.0.1",
+    "multiscale_spatial_image>=2.0.2",
     "networkx",
     "numba",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "xarray>=2024.10.0",
     "xarray-schema",
     "xarray-spatial>=0.3.5",
-    "zarr",
+    "zarr<3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The newest release of multiscale-spatial-image now includes methods such as `transpose` and `reindex` that are used in other spatialdata libraries. For this the dependency here must be updated.