### PR TITLE
Preserve points feature_key in queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning][].
 ### Fixed
 
 -   Updated deprecated default stages of `pre-commit` #771
--   Preserve points `feature_key` during queries
+-   Preserve points `feature_key` during queries #794
 
 ## [0.2.5] - 2024-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning][].
 ### Fixed
 
 -   Updated deprecated default stages of `pre-commit` #771
+-   Preserve points `feature_key` during queries
 
 ## [0.2.5] - 2024-06-11
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
 ]
 docs = [
     "sphinx>=4.5",
+	"sphinx-autobuild",
     "sphinx-book-theme>=1.0.0",
     "myst-nb",
     "sphinxcontrib-bibtex>=1.0.0",

--- a/src/spatialdata/models/_utils.py
+++ b/src/spatialdata/models/_utils.py
@@ -417,8 +417,7 @@ def set_channel_names(element: DataArray | DataTree, channel_names: str | list[s
 
     Returns
     -------
-    element
-        The image `SpatialElement` or parsed `ImageModel` with the channel names set to the `c` dimension.
+    The image `SpatialElement` or parsed `ImageModel` with the channel names set to the `c` dimension.
     """
     from spatialdata.models import Image2DModel, Image3DModel, get_model
 

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -736,8 +736,11 @@ class PointsModel:
         elif isinstance(data, dd.DataFrame):  # type: ignore[attr-defined]
             table = data[[coordinates[ax] for ax in axes]]
             table.columns = axes
-            if feature_key is not None and data[feature_key].dtype.name != "category":
-                table[feature_key] = data[feature_key].astype(str).astype("category")
+            if feature_key is not None:
+                if data[feature_key].dtype.name == "category":
+                    table[feature_key] = data[feature_key]
+                else:
+                    table[feature_key] = data[feature_key].astype(str).astype("category")
         if instance_key is not None:
             table[instance_key] = data[instance_key]
         for c in [X, Y, Z]:

--- a/tests/core/query/test_spatial_query.py
+++ b/tests/core/query/test_spatial_query.py
@@ -29,6 +29,7 @@ from spatialdata.models import (
     ShapesModel,
     TableModel,
 )
+from spatialdata.models.models import ATTRS_KEY
 from spatialdata.testing import assert_spatial_data_objects_are_identical
 from spatialdata.transformations import Identity, MapAxis, set_transformation
 from tests.conftest import _make_points, _make_squares
@@ -204,6 +205,21 @@ def test_query_points(is_3d: bool, is_bb_3d: bool, with_polygon_query: bool, mul
     np.testing.assert_allclose(points_element["y"].compute(), original_y)
     if is_3d:
         np.testing.assert_allclose(points_element["z"].compute(), original_z)
+
+    # the feature_key should be preserved
+    if not multiple_boxes:
+        assert (
+            points_result.attrs[ATTRS_KEY][PointsModel.FEATURE_KEY]
+            == points_element.attrs[ATTRS_KEY][PointsModel.FEATURE_KEY]
+        )
+    else:
+        for result in points_result:
+            if result is None:
+                continue
+            assert (
+                result.attrs[ATTRS_KEY][PointsModel.FEATURE_KEY]
+                == points_element.attrs[ATTRS_KEY][PointsModel.FEATURE_KEY]
+            )
 
 
 def test_query_points_no_points():


### PR DESCRIPTION
In bounding_box/polygon queries, the `"feature_key"` of points was not preserved.

- [x] preserve feature_key in bounding_box
- [x] preserve feature_key in polygon
- [x] tests added

While fixing that, I also found (and fixed) a minor issue in the `PointsModel.parse` method when passing `feature_key`. Indeed, if corresponding column is already a category, it is dropped from the dataframe, see the line below:
```python
if feature_key is not None and data[feature_key].dtype.name != "category":
    table[feature_key] = data[feature_key].astype(str).astype("category")
```