### PR TITLE
relaxed fsspec version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "click",
     "dask-image",
     "dask>=2024.4.1",
-    "fsspec<=2023.6",
+    "fsspec",
     "geopandas>=0.14",
     "multiscale_spatial_image>=2.0.2",
     "networkx",


### PR DESCRIPTION
Before the installation was not working due to this bug: https://github.com/ome/ome-zarr-py/issues/302.