### PR TITLE
Join with duplicate obs indices

### DIFF
--- a/tests/core/query/test_relational_query.py
+++ b/tests/core/query/test_relational_query.py
@@ -376,6 +376,22 @@ def test_match_rows_inner_join_non_matching_table(sdata_query_aggregation):
     assert all(indices == reversed_instance_id)
 
 
+def test_inner_join_match_rows_duplicate_obs_indices(sdata_query_aggregation):
+    sdata = sdata_query_aggregation
+    sdata["table"].obs.index = ["a"] * sdata["table"].n_obs
+    sdata_query_aggregation["values_polygons"] = sdata_query_aggregation["values_polygons"][:5]
+    sdata_query_aggregation["values_circles"] = sdata_query_aggregation["values_circles"][:5]
+
+    element_dict, table = join_spatialelement_table(
+        sdata=sdata,
+        spatial_element_names=["values_circles", "values_polygons"],
+        table_name="table",
+        how="inner",
+    )
+
+    assert table.n_obs == 10
+
+
 # TODO: there is a lot of dublicate code, simplify with a function that tests both the case sdata=None and sdata=sdata
 def test_match_rows_join(sdata_query_aggregation):
     sdata = sdata_query_aggregation


### PR DESCRIPTION
Closes #815 

The current way the join works on main does not account for duplicate indices in `table.obs.index`. This leads to a problem when performing the join as the indices are used to subset the table. 

The implemented fix here gets the indices of the masked elements and then does a boolean masking on the obs dataframe with the index reset. This retrieves the integer indices which can then be used for subsetting the table. The behaviour of matching rows stays unchanged with this change.

```
from pathlib import Path
import spatialdata as sd
import spatialdata_plot

visium_zarr_path = Path("C:/Users/w-mv/PycharmProjects/spatialdata-notebooks/notebooks/examples/visium_brain.zarr")
visium_sdata = sd.read_zarr(visium_zarr_path)
(
    visium_sdata.pl.render_images(elements="ST8059050_hires_image")
    .pl.render_shapes(elements="ST8059050", color="mt-Co3")
    .pl.show()
)
```
now gives:
![image](https://github.com/user-attachments/assets/4f8465ca-0c73-4d09-b8c1-3d3385283ef5)