### PR TITLE
Add autodoc_default_options to inherit docstrings

### DIFF
--- a/docs/api/SpatialData.md
+++ b/docs/api/SpatialData.md
@@ -4,5 +4,4 @@
 .. currentmodule:: spatialdata
 
 .. autoclass:: SpatialData
-   :members:
 ```

--- a/docs/api/data_formats.md
+++ b/docs/api/data_formats.md
@@ -7,30 +7,12 @@ These classes are useful to ensure backward compatibility whenever a major versi
 .. currentmodule:: spatialdata._io.format
 
 .. autoclass:: CurrentRasterFormat
-   :members:
-   :undoc-members:
 .. autoclass:: RasterFormatV01
-   :members:
-   :undoc-members:
 .. autoclass:: CurrentShapesFormat
-   :members:
-   :undoc-members:
 .. autoclass:: ShapesFormatV01
-   :members:
-   :undoc-members:
 .. autoclass:: ShapesFormatV02
-   :members:
-   :undoc-members:
 .. autoclass:: CurrentPointsFormat
-   :members:
-   :undoc-members:
 .. autoclass:: PointsFormatV01
-   :members:
-   :undoc-members:
 .. autoclass:: CurrentTablesFormat
-   :members:
-   :undoc-members:
 .. autoclass:: TablesFormatV01
-   :members:
-   :undoc-members:
 ```

--- a/docs/api/dataloader.md
+++ b/docs/api/dataloader.md
@@ -4,5 +4,4 @@
 .. currentmodule:: spatialdata.dataloader
 
 .. autoclass:: ImageTilesDataset
-   :members:
 ```

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -6,24 +6,10 @@ The elements (building-blocks) that constitute `SpatialData`.
 .. currentmodule:: spatialdata.models
 
 .. autoclass:: Image2DModel
-   :members:
-   :undoc-members:
 .. autoclass:: Image3DModel
-   :members:
-   :undoc-members:
 .. autoclass:: Labels2DModel
-   :members:
-   :undoc-members:
 .. autoclass:: Labels3DModel
-   :members:
-   :undoc-members:
 .. autoclass:: ShapesModel
-   :members:
-   :undoc-members:
 .. autoclass:: PointsModel
-   :members:
-   :undoc-members:
 .. autoclass:: TableModel
-   :members:
-   :undoc-members:
 ```

--- a/docs/api/transformations.md
+++ b/docs/api/transformations.md
@@ -6,24 +6,10 @@ The transformations that can be defined between elements and coordinate systems 
 .. currentmodule:: spatialdata.transformations
 
 .. autoclass:: BaseTransformation
-   :members:
-   :undoc-members:
 .. autoclass:: Identity
-   :members:
-   :undoc-members:
 .. autoclass:: MapAxis
-   :members:
-   :undoc-members:
 .. autoclass:: Translation
-   :members:
-   :undoc-members:
 .. autoclass:: Scale
-   :members:
-   :undoc-members:
 .. autoclass:: Affine
-   :members:
-   :undoc-members:
 .. autoclass:: Sequence
-   :members:
-   :undoc-members:
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,12 @@ extensions = [
     *[p.stem for p in (HERE / "extensions").glob("*.py")],
 ]
 
+autodoc_default_options = {
+    'members': True,
+    'inherited-members': True,
+    'show-inheritance': True,
+}
+
 autosummary_generate = True
 autodoc_process_signature = True
 autodoc_member_order = "groupwise"


### PR DESCRIPTION
Closes #828 

I set the following defaults for the autodoc. The first interesting thing is that `'inherited-members': True` fixes #828 because it will now show the inherited docstrings. The second thing is that `'members': True` significantly cleans up the docs because I can remove it everywhere else.
```
autodoc_default_options = {
    'members': True,
    'inherited-members': True,
    'show-inheritance': True,
}
```

Note that I also removed `:undoc-members:`, because I don't think we should show methods that are not documented (it adds a lot of unreadable sections). But feel free to add it in the defaults if you prefer to have it @LucaMarconato 