### PR TITLE
Docker automatic build

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -85,7 +85,8 @@ jobs:
 
             - uses: docker/build-push-action@v5
               if: ${{ env.skip_build == 'false' }}
-              IMAGE_TAG: ${{ env.REGISTRY }}/scverse/spatialdata:${{ env.IMAGE_TAG_SUFFIX }}
+              env:
+                  IMAGE_TAG: ${{ env.REGISTRY }}/scverse/spatialdata:${{ env.IMAGE_TAG_SUFFIX }}
               with:
                   context: .
                   file: ./Dockerfile

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -7,6 +7,7 @@ on:
         types:
             - completed
     workflow_dispatch:
+    push:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,7 +15,7 @@ concurrency:
 
 jobs:
     build:
-        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
         runs-on: ubuntu-latest
 
         defaults:

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,4 +1,4 @@
-name: build image
+name: Build Docker image
 # adapted from https://github.com/scverse/scvi-tools/blob/main/.github/workflows/build_image_latest.yaml
 
 on:
@@ -7,7 +7,6 @@ on:
         types:
             - completed
     workflow_dispatch:
-    push:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -9,6 +9,10 @@ on:
     workflow_dispatch:
     push:
 
+env:
+    REGISTRY: ghcr.io
+    IMAGE_NAME: ${{ github.repository }}
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
@@ -25,15 +29,19 @@ jobs:
         permissions:
             contents: read
             packages: write
+            attestations: write
+            id-token: write
 
         steps:
-            - uses: actions/checkout@v4
+            - name: Checkout code
+              uses: actions/checkout@v4
 
             - uses: docker/setup-buildx-action@v3
 
-            - uses: docker/login-action@v3
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v3
               with:
-                  registry: ghcr.io
+                  registry: ${{ env.REGISTRY }}
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -53,7 +61,6 @@ jobs:
                   context: .
                   file: ./Dockerfile
                   push: true
-                  cache-from: type=registry,ref=ghcr.io/scverse/spatialdata:buildcache
-                  cache-to: type=inline,ref=ghcr.io/scverse/spatialdata:buildcache
-                  target: build
-                  tags: ghcr.io/scverse/spatialdata:${{ steps.build.outputs.version }}
+                  cache-from: type=registry,ref=${{ env.REGISTRY }}/scverse/spatialdata:buildcache
+                  cache-to: type=inline,ref=${{ env.REGISTRY }}/scverse/spatialdata:buildcache
+                  tags: ${{ env.REGISTRY }}/scverse/spatialdata:${{ steps.build.outputs.version }}

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -52,7 +52,7 @@ jobs:
             - name: Check if image tag exists
               id: check_tag
               env:
-                  IMAGE_TAG: ${{ env.REGISTRY }}/scverse/spatialdata:spatialdata${{ env.SPATIALDATA_VERSION }}_spatialdata-io${{ env.SPATIALDATA_IO_VERSION }}_spatialdata-plot${{ env.SPATIALDATA_PLOT_VERSION }}
+                  IMAGE_TAG_SUFFIX: spatialdata${{ env.SPATIALDATA_VERSION }}_spatialdata-io${{ env.SPATIALDATA_IO_VERSION }}_spatialdata-plot${{ env.SPATIALDATA_PLOT_VERSION }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   # Define the API URL
@@ -66,13 +66,13 @@ jobs:
                   echo "$existing_tags"
 
                   # Check if the constructed tag exists
-                  if echo "$existing_tags" | grep -q "$IMAGE_TAG"; then
-                    echo "Image tag $IMAGE_TAG already exists. Skipping build."
+                  if echo "$existing_tags" | grep -q "$IMAGE_TAG_SUFFIX"; then
+                    echo "Image tag $IMAGE_TAG_SUFFIX already exists. Skipping build."
                     echo "skip_build=true" >> $GITHUB_ENV
                   else
-                    echo "Image tag $IMAGE_TAG does not exist. Proceeding with build."
+                    echo "Image tag $IMAGE_TAG_SUFFIX does not exist. Proceeding with build."
                     echo "skip_build=false" >> $GITHUB_ENV
-                    echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+                    echo "IMAGE_TAG_SUFFIX=${IMAGE_TAG_SUFFIX}" >> $GITHUB_ENV
                   fi
 
             - name: Login to GitHub Container Registry
@@ -85,6 +85,7 @@ jobs:
 
             - uses: docker/build-push-action@v5
               if: ${{ env.skip_build == 'false' }}
+              IMAGE_TAG: ${{ env.REGISTRY }}/scverse/spatialdata:${{ env.IMAGE_TAG_SUFFIX }}
               with:
                   context: .
                   file: ./Dockerfile

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -36,7 +36,7 @@ jobs:
               with:
                   python-version: "3.x"
 
-            - name: Install pip-tools
+            - name: Upgrade pip
               run: pip install pip
 
             - name: Get latest versions

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -24,7 +24,7 @@ jobs:
         permissions:
             contents: read
             packages: write
-            attestation: write
+            attestations: write
             id-token: write
 
         steps:

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -2,7 +2,8 @@ name: Build Docker image
 
 on:
     workflow_dispatch:
-    push:
+#    schedule:
+#        -   cron: '0 0 * * *'  # run daily at midnight UTC
 
 env:
     REGISTRY: ghcr.io
@@ -14,7 +15,6 @@ concurrency:
 
 jobs:
     build:
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
         runs-on: ubuntu-latest
 
         defaults:

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -7,6 +7,7 @@ on:
         types:
             - completed
     workflow_dispatch:
+    push:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
     build:
-        if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
         runs-on: ubuntu-latest
 
         defaults:

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,5 +1,4 @@
 name: Build Docker image
-# adapted from https://github.com/scverse/scvi-tools/blob/main/.github/workflows/build_image_latest.yaml
 
 on:
     workflow_run:
@@ -36,7 +35,23 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
-            - uses: docker/setup-buildx-action@v3
+            - name: Set up Python
+              uses: actions/setup-python@v4
+              with:
+                  python-version: "3.x"
+
+            - name: Install pip-tools
+              run: pip install pip
+
+            - name: Get latest versions
+              id: get_versions
+              run: |
+                  SPATIALDATA_VERSION=$(pip index versions spatialdata | grep "Available versions" | sed 's/Available versions: //' | awk -F', ' '{print $1}')
+                  SPATIALDATA_IO_VERSION=$(pip index versions spatialdata-io | grep "Available versions" | sed 's/Available versions: //' | awk -F', ' '{print $1}')
+                  SPATIALDATA_PLOT_VERSION=$(pip index versions spatialdata-plot | grep "Available versions" | sed 's/Available versions: //' | awk -F', ' '{print $1}')
+                  echo "SPATIALDATA_VERSION=${SPATIALDATA_VERSION}" >> $GITHUB_ENV
+                  echo "SPATIALDATA_IO_VERSION=${SPATIALDATA_IO_VERSION}" >> $GITHUB_ENV
+                  echo "SPATIALDATA_PLOT_VERSION=${SPATIALDATA_PLOT_VERSION}" >> $GITHUB_ENV
 
             - name: Login to GitHub Container Registry
               uses: docker/login-action@v3
@@ -45,17 +60,6 @@ jobs:
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Set build inputs
-              id: build
-              run: |
-                  INPUT_REF=${{ github.ref_name }}
-                  if [[ $INPUT_REF == "main" ]]; then
-                    VERSION="latest"
-                  else
-                    VERSION=${INPUT_REF}
-                  fi
-                  echo "version=${VERSION}" >> $GITHUB_OUTPUT
-
             - uses: docker/build-push-action@v5
               with:
                   context: .
@@ -63,4 +67,8 @@ jobs:
                   push: true
                   cache-from: type=registry,ref=${{ env.REGISTRY }}/scverse/spatialdata:buildcache
                   cache-to: type=inline,ref=${{ env.REGISTRY }}/scverse/spatialdata:buildcache
-                  tags: ${{ env.REGISTRY }}/scverse/spatialdata:${{ steps.build.outputs.version }}
+                  build-args: |
+                      SPATIALDATA_VERSION=${{ env.SPATIALDATA_VERSION }}
+                      SPATIALDATA_IO_VERSION=${{ env.SPATIALDATA_IO_VERSION }}
+                      SPATIALDATA_PLOT_VERSION=${{ env.SPATIALDATA_PLOT_VERSION }}
+                  tags: ${{ env.REGISTRY }}/scverse/spatialdata:spatialdata${{ env.SPATIALDATA_VERSION }}_spatialdata-io${{ env.SPATIALDATA_IO_VERSION }}_spatialdata-plot${{ env.SPATIALDATA_PLOT_VERSION }}

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -2,9 +2,6 @@ name: Build Docker image
 
 on:
     workflow_run:
-        workflows: ["Release"]
-        types:
-            - completed
     workflow_dispatch:
     push:
 
@@ -18,7 +15,7 @@ concurrency:
 
 jobs:
     build:
-        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
         runs-on: ubuntu-latest
 
         defaults:
@@ -28,7 +25,7 @@ jobs:
         permissions:
             contents: read
             packages: write
-            attestations: write
+            attestation: write
             id-token: write
 
         steps:
@@ -53,7 +50,34 @@ jobs:
                   echo "SPATIALDATA_IO_VERSION=${SPATIALDATA_IO_VERSION}" >> $GITHUB_ENV
                   echo "SPATIALDATA_PLOT_VERSION=${SPATIALDATA_PLOT_VERSION}" >> $GITHUB_ENV
 
+            - name: Check if image tag exists
+              id: check_tag
+              env:
+                  IMAGE_TAG: ${{ env.REGISTRY }}/scverse/spatialdata:spatialdata${{ env.SPATIALDATA_VERSION }}_spatialdata-io${{ env.SPATIALDATA_IO_VERSION }}_spatialdata-plot${{ env.SPATIALDATA_PLOT_VERSION }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  # Define the API URL
+                  API_URL="https://api.github.com/orgs/scverse/packages/container/spatialdata/versions"
+
+                  # Fetch all existing versions
+                  existing_tags=$(curl -s -H "Authorization: token $GITHUB_TOKEN" $API_URL | jq -r '.[].metadata.container.tags[]')
+
+                  # Debug: Output all existing tags
+                  echo "Existing tags:"
+                  echo "$existing_tags"
+
+                  # Check if the constructed tag exists
+                  if echo "$existing_tags" | grep -q "$IMAGE_TAG"; then
+                    echo "Image tag $IMAGE_TAG already exists. Skipping build."
+                    echo "skip_build=true" >> $GITHUB_ENV
+                  else
+                    echo "Image tag $IMAGE_TAG does not exist. Proceeding with build."
+                    echo "skip_build=false" >> $GITHUB_ENV
+                    echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+                  fi
+
             - name: Login to GitHub Container Registry
+              if: ${{ env.skip_build == 'false' }}
               uses: docker/login-action@v3
               with:
                   registry: ${{ env.REGISTRY }}
@@ -61,6 +85,7 @@ jobs:
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - uses: docker/build-push-action@v5
+              if: ${{ env.skip_build == 'false' }}
               with:
                   context: .
                   file: ./Dockerfile
@@ -71,4 +96,4 @@ jobs:
                       SPATIALDATA_VERSION=${{ env.SPATIALDATA_VERSION }}
                       SPATIALDATA_IO_VERSION=${{ env.SPATIALDATA_IO_VERSION }}
                       SPATIALDATA_PLOT_VERSION=${{ env.SPATIALDATA_PLOT_VERSION }}
-                  tags: ${{ env.REGISTRY }}/scverse/spatialdata:spatialdata${{ env.SPATIALDATA_VERSION }}_spatialdata-io${{ env.SPATIALDATA_IO_VERSION }}_spatialdata-plot${{ env.SPATIALDATA_PLOT_VERSION }}
+                  tags: ${{ env.IMAGE_TAG }}

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,0 +1,58 @@
+name: build image
+# adapted from https://github.com/scverse/scvi-tools/blob/main/.github/workflows/build_image_latest.yaml
+
+on:
+    workflow_run:
+        workflows: ["Release"]
+        types:
+            - completed
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    build:
+        if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.ref, 'refs/tags/v') }}
+        runs-on: ubuntu-latest
+
+        defaults:
+            run:
+                shell: bash -e {0} # -e to fail on error
+
+        permissions:
+            contents: read
+            packages: write
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: docker/setup-buildx-action@v3
+
+            - uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Set build inputs
+              id: build
+              run: |
+                  INPUT_REF=${{ github.ref_name }}
+                  if [[ $INPUT_REF == "main" ]]; then
+                    VERSION="latest"
+                  else
+                    VERSION=${INPUT_REF}
+                  fi
+                  echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+            - uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  file: ./Dockerfile
+                  push: true
+                  cache-from: type=registry,ref=ghcr.io/scverse/spatialdata:buildcache
+                  cache-to: type=inline,ref=ghcr.io/scverse/spatialdata:buildcache
+                  target: build
+                  tags: ghcr.io/scverse/spatialdata:${{ steps.build.outputs.version }}

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,7 +1,6 @@
 name: Build Docker image
 
 on:
-    workflow_run:
     workflow_dispatch:
     push:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
 ARG TARGETPLATFORM=linux/amd64
 
+# Use the specified platform to pull the correct base image.
+# Override TARGETPLATFORM during build for different architectures, such as linux/arm64 for Apple Silicon.
+# For example, to build for ARM64 architecture (e.g., Apple Silicon),
+# use the following command on the command line:
+#
+#     docker build --build-arg TARGETPLATFORM=linux/arm64 -t my-arm-image .
+#
+# Similarly, to build for the default x86_64 architecture, you can use:
+#
+#     docker build --build-arg TARGETPLATFORM=linux/amd64 -t my-amd64-image .
+#
 FROM --platform=$TARGETPLATFORM ubuntu:latest
 LABEL authors="Luca Marconato"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 ARG TARGETPLATFORM=linux/amd64
 
-ARG SPATIALDATA_VERSION
-ARG SPATIALDATA_IO_VERSION
-ARG SPATIALDATA_PLOT_VERSION
-
 # Use the specified platform to pull the correct base image.
 # Override TARGETPLATFORM during build for different architectures, such as linux/arm64 for Apple Silicon.
 # For example, to build for ARM64 architecture (e.g., Apple Silicon),
@@ -20,6 +16,16 @@ LABEL authors="Luca Marconato"
 
 ENV PYTHONUNBUFFERED=1
 
+ARG SPATIALDATA_VERSION
+ARG SPATIALDATA_IO_VERSION
+ARG SPATIALDATA_PLOT_VERSION
+
+# debugging
+RUN echo "Target Platform: ${TARGETPLATFORM}" && \
+    echo "Spatialdata Version: ${SPATIALDATA_VERSION}" && \
+    echo "Spatialdata IO Version: ${SPATIALDATA_IO_VERSION}" && \
+    echo "Spatialdata Plot Version: ${SPATIALDATA_PLOT_VERSION}"
+
 # Update and install system dependencies.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -27,8 +33,9 @@ RUN apt-get update && \
     python3-venv \
     python3-dev \
     git \
-    && rm -rf /var/lib/apt/lists/*
-#
+    && rm -rf /var/lib/apt/lists/* \
+
+# setup python virtual environment
 RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install --upgrade pip wheel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 ARG TARGETPLATFORM=linux/amd64
 
+ARG SPATIALDATA_VERSION
+ARG SPATIALDATA_IO_VERSION
+ARG SPATIALDATA_PLOT_VERSION
+
 # Use the specified platform to pull the correct base image.
 # Override TARGETPLATFORM during build for different architectures, such as linux/arm64 for Apple Silicon.
 # For example, to build for ARM64 architecture (e.g., Apple Silicon),
@@ -28,7 +32,13 @@ RUN apt-get update && \
 RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install --upgrade pip wheel
+
+# Install the libraries with specific versions
 RUN pip install --no-cache-dir \
-    spatialdata[torch] \
-    spatialdata-io \
-    spatialdata-plot
+    spatialdata[torch]==${SPATIALDATA_VERSION} \
+    spatialdata-io==${SPATIALDATA_IO_VERSION} \
+    spatialdata-plot==${SPATIALDATA_PLOT_VERSION}
+
+LABEL spatialdata_version="${SPATIALDATA_VERSION}" \
+      spatialdata_io_version="${SPATIALDATA_IO_VERSION}" \
+      spatialdata_plot_version="${SPATIALDATA_PLOT_VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && \
     python3-venv \
     python3-dev \
     git \
-    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /var/lib/apt/lists/*
 
 # setup python virtual environment
 RUN python3 -m venv /opt/venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@ ARG SPATIALDATA_PLOT_VERSION
 
 # debugging
 RUN echo "Target Platform: ${TARGETPLATFORM}" && \
-    echo "Spatialdata Version: ${SPATIALDATA_VERSION}" && \
-    echo "Spatialdata IO Version: ${SPATIALDATA_IO_VERSION}" && \
-    echo "Spatialdata Plot Version: ${SPATIALDATA_PLOT_VERSION}"
+    echo "spatialdata version: ${SPATIALDATA_VERSION}" && \
+    echo "spatialdata-io version: ${SPATIALDATA_IO_VERSION}" && \
+    echo "spatialdata-plot version: ${SPATIALDATA_PLOT_VERSION}"
 
 # Update and install system dependencies.
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,23 @@
-FROM condaforge/mambaforge
+ARG TARGETPLATFORM=linux/amd64
 
-RUN mamba install python=3.10
+FROM --platform=$TARGETPLATFORM ubuntu:latest
+LABEL authors="Luca Marconato"
 
-# complex dependencies that needs to be solved with conda
-RUN mamba install -c conda-forge gcc libgdal gxx imagecodecs -y
+ENV PYTHONUNBUFFERED=1
 
-# satellite spatialdata projects
+# Update and install system dependencies.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    python3-venv \
+    python3-dev \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+#
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install --upgrade pip wheel
 RUN pip install --no-cache-dir \
-    spatialdata \
+    spatialdata[torch] \
     spatialdata-io \
     spatialdata-plot

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,6 +60,37 @@ python -c "import spatialdata; print(spatialdata.__path__)"
 
 if you get a path that contains `site-packages`, then your editable installation has been overridden and you need to reinstall the package by rerunning `pip install -e .` in the cloned `spatialdata` repo.
 
+## Conda
+
+You can install the `spatialdata`, `spatialdata-io`, `spatialdata-plot` and `napari-spatialdata` packages from the `conda-forge` channel using
+
+```bash
+mamba install -c conda-forge spatialdata spatialdata-io spatialdata-plot napari-spatialdata
+```
+
+Note: currently (Jan 2025), due to particular versions being unavailable on `conda-forge` for some dependent packages, the latest versions of the packages of the `SpatialData` ecosystem are not available on `conda-forge`. We are working on fixing this issue; please check the latest versions available on the channel.
+
+## Docker
+
+A `Dockerfile` is available in the repository; the image that can be built from it contains `spatialdata` (with `torch`), `spatialdata-io` and `spatialdata-plot` (not `napari-spatialdata`).
+
+To build the image, run:
+
+```bash
+# this is for Apple Silicon machines, if you are not using such machine you can omit the --build-arg
+docker build --build-arg TARGETPLATFORM=linux/arm64 --tag spatialdata .
+docker run -it spatialdata
+```
+
+We also publish images automatically via GitHub Actions; you can see the [list of available images here](https://github.com/scverse/spatialdata/pkgs/container/spatialdata/versions).
+
+Once you have the image name, you can pull and run it with:
+
+```bash
+docker pull ghcr.io/scverse/spatialdata:spatialdata0.3.0_spatialdata-io0.1.7_spatialdata-plot0.2.9
+docker run -it ghcr.io/scverse/spatialdata:spatialdata0.3.0_spatialdata-io0.1.7_spatialdata-plot0.2.9
+```
+
 <!-- Links -->
 
 [napari-spatialdata]: https://github.com/scverse/napari-spatialdata


### PR DESCRIPTION
This PR:
- improves the `Dockerfile`
- Replaces the approach drafted here https://github.com/scverse/spatialdata/pull/326
- introduces a workflow for automatically building a Docker daily, as follows:
	- the container includes the latest available versions of `spatialdata` (with `torch`), `spatialdata-io`, `spatialdata-plot`. Not `napari-spatialdata`
	- to trigger the build of the container you need to manually run the GitHub action. If things work as expected (let's test it for a few releases), we can uncomment the part that runs the workflow everyday
	- the docker container will contain all the 3 spatialdata-xx versions in the tag, and available here: https://github.com/scverse/spatialdata/pkgs/container/spatialdata/versions
	- running the workflow everyday will ensure that the docker container is using up-to-date versions and will not cause unnecessary computation. In fact, the workflow will first check if the container that is going to be built is using a combination of versions for which the container already exists, in that case the build will be skipped. Example of a [workflow run that skips the docker build steps](https://github.com/scverse/spatialdata/actions/runs/12909422601/job/35997051434?pr=841).

To build the Docker container locally:
```bash
# this is for Apple Silicon machines, if you are not using such machine you can omit the --build-arg
docker build --build-arg TARGETPLATFORM=linux/arm64 --tag spatialdata .
docker run -it spatialdata
```

To run one container that was built by the GitHub Actions:
```bash
docker pull ghcr.io/scverse/spatialdata:spatialdata0.3.0_spatialdata-io0.1.7_spatialdata-plot0.2.9
docker run -it ghcr.io/scverse/spatialdata:spatialdata0.3.0_spatialdata-io0.1.7_spatialdata-plot0.2.9
```

CC @FloWuenne @migueLib @melonora 