### PR TITLE
Specify NGFF 0.6-dev in output data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
             additional_dependencies: [numpy, types-requests]
             exclude: tests/|docs/
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.9.2
+      rev: v0.9.3
       hooks:
           - id: ruff
             args: [--fix, --exit-non-zero-on-fix]

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -77,5 +77,6 @@ from spatialdata._core.query.relational_query import (
 from spatialdata._core.query.spatial_query import bounding_box_query, polygon_query
 from spatialdata._core.spatialdata import SpatialData
 from spatialdata._io._utils import get_dask_backing_files, save_transformations
+from spatialdata._io.format import SpatialDataFormat
 from spatialdata._io.io_zarr import read_zarr
 from spatialdata._utils import get_pyramid_levels, unpad_raster

--- a/src/spatialdata/_io/format.py
+++ b/src/spatialdata/_io/format.py
@@ -47,9 +47,7 @@ def _parse_version(group: zarr.Group, expect_attrs_key: bool) -> str | None:
 
 
 class SpatialDataFormat(CurrentFormat):
-    @property
-    def version(self) -> str:
-        return "0.6-dev"
+    pass
 
 
 def format_implementations() -> Iterator[Format]:
@@ -138,6 +136,22 @@ class RasterFormatV01(SpatialDataFormat):
     @property
     def spatialdata_format_version(self) -> str:
         return "0.1"
+
+    @property
+    def version(self) -> str:
+        return "0.4"
+
+
+class RasterFormatV02(RasterFormatV01):
+    @property
+    def spatialdata_format_version(self) -> str:
+        return "0.2"
+
+    @property
+    def version(self) -> str:
+        # 0.1 -> 0.2 changed the version string for the NGFF format, from 0.4 to 0.6-dev-spatialdata as discussed here
+        # https://github.com/scverse/spatialdata/pull/849
+        return "0.6-dev-spatialdata"
 
 
 class ShapesFormatV01(SpatialDataFormat):
@@ -230,7 +244,7 @@ class TablesFormatV01(SpatialDataFormat):
             raise ValueError("`table.obs[instance_key]` must not contain null values, but it does.")
 
 
-CurrentRasterFormat = RasterFormatV01
+CurrentRasterFormat = RasterFormatV02
 CurrentShapesFormat = ShapesFormatV02
 CurrentPointsFormat = PointsFormatV01
 CurrentTablesFormat = TablesFormatV01
@@ -248,6 +262,7 @@ TablesFormats = {
 }
 RasterFormats = {
     "0.1": RasterFormatV01(),
+    "0.2": RasterFormatV02(),
 }
 SpatialDataContainerFormats = {
     "0.1": SpatialDataContainerFormatV01(),

--- a/src/spatialdata/_io/format.py
+++ b/src/spatialdata/_io/format.py
@@ -50,21 +50,6 @@ class SpatialDataFormat(CurrentFormat):
     pass
 
 
-def format_implementations() -> Iterator[Format]:
-    """Return an instance of each format implementation, newest to oldest."""
-    yield SpatialDataFormat()
-    yield FormatV04()
-    yield FormatV03()
-    yield FormatV02()
-    yield FormatV01()
-
-
-# monkeypatch the ome_zarr.format module to include the SpatialDataFormat (we want to use the APIs from ome_zarr to
-# read, but signal that the format we are using is a dev version of NGFF, since it builds on some open PR that are
-# not released yet)
-ome_zarr.format.format_implementations = format_implementations
-
-
 class SpatialDataContainerFormatV01(SpatialDataFormat):
     @property
     def spatialdata_format_version(self) -> str:
@@ -151,7 +136,7 @@ class RasterFormatV02(RasterFormatV01):
     def version(self) -> str:
         # 0.1 -> 0.2 changed the version string for the NGFF format, from 0.4 to 0.6-dev-spatialdata as discussed here
         # https://github.com/scverse/spatialdata/pull/849
-        return "0.6-dev-spatialdata"
+        return "0.4-dev-spatialdata"
 
 
 class ShapesFormatV01(SpatialDataFormat):
@@ -267,6 +252,22 @@ RasterFormats = {
 SpatialDataContainerFormats = {
     "0.1": SpatialDataContainerFormatV01(),
 }
+
+
+def format_implementations() -> Iterator[Format]:
+    """Return an instance of each format implementation, newest to oldest."""
+    yield RasterFormatV02()
+    # yield RasterFormatV01()  # same format string as FormatV04
+    yield FormatV04()
+    yield FormatV03()
+    yield FormatV02()
+    yield FormatV01()
+
+
+# monkeypatch the ome_zarr.format module to include the SpatialDataFormat (we want to use the APIs from ome_zarr to
+# read, but signal that the format we are using is a dev version of NGFF, since it builds on some open PR that are
+# not released yet)
+ome_zarr.format.format_implementations = format_implementations
 
 
 def _parse_formats(formats: SpatialDataFormat | list[SpatialDataFormat] | None) -> dict[str, SpatialDataFormat]:

--- a/tests/io/test_format.py
+++ b/tests/io/test_format.py
@@ -1,9 +1,19 @@
+import json
+import tempfile
+from pathlib import Path
 from typing import Any
 
 import pytest
 from shapely import GeometryType
 
-from spatialdata._io.format import CurrentPointsFormat, CurrentShapesFormat, ShapesFormatV01
+from spatialdata._io.format import (
+    CurrentPointsFormat,
+    CurrentShapesFormat,
+    RasterFormatV01,
+    RasterFormatV02,
+    ShapesFormatV01,
+    SpatialDataFormat,
+)
 from spatialdata.models import PointsModel, ShapesModel
 
 Points_f = CurrentPointsFormat()
@@ -71,3 +81,17 @@ class TestFormat:
         metadata: dict[str, Any] = {attrs_key: {"version": Shapes_f.spatialdata_format_version}}
         metadata[attrs_key].pop("version")
         assert metadata[attrs_key] == Shapes_f.attrs_to_dict({})
+
+    @pytest.mark.parametrize("format", [RasterFormatV01, RasterFormatV02])
+    def test_format_raster_v1_v2(self, images, format: type[SpatialDataFormat]) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            images.write(Path(tmpdir) / "images.zarr", format=format())
+            zattrs_file = Path(tmpdir) / "images.zarr/images/image2d/.zattrs"
+            with open(zattrs_file) as infile:
+                zattrs = json.load(infile)
+                ngff_version = zattrs["multiscales"][0]["version"]
+                if format == RasterFormatV01:
+                    assert ngff_version == "0.4"
+                else:
+                    assert format == RasterFormatV02
+                    assert ngff_version == "0.6-dev-spatialdata"

--- a/tests/io/test_format.py
+++ b/tests/io/test_format.py
@@ -94,4 +94,4 @@ class TestFormat:
                     assert ngff_version == "0.4"
                 else:
                     assert format == RasterFormatV02
-                    assert ngff_version == "0.6-dev-spatialdata"
+                    assert ngff_version == "0.4-dev-spatialdata"


### PR DESCRIPTION
This PR monkeypatches `ome_zarr.format` to make it possible to use the read/write APIs of `ome-zarr-py`, while clarifying which OME-Zarr data version we are building on top.

Precisely, we implement the [NGFF transformations specification](https://github.com/ome/ngff/pull/138), which, as of today, it is not merged to NGFF main yet. The timeline is to have the specification included in NGFF v0.6, hence from this PR we will write `0.6-dev` instead of `0.4` (which was kept for compatibility with `ome-zarr-py`).

All the tests pass, the code for reproducing the documentation and paper notebooks and the data conversions from `spatialdata-sandbox` are currently running.

Practically, the PR will not change APIs or usage of the function of the `spatialdata` package and will only modify, on-disk, the version string for images and labels, as shown here (in this example I used Seqfish v2 data).

```
(ome311) macbook@Lucas-MacBook-Pro-2021 seqfish_v2_io % diff -r data.zarr.v4 data.zarr.v6
diff -r data.zarr.v4/images/Roi1_DAPI/.zattrs data.zarr.v6/images/Roi1_DAPI/.zattrs
91c91
<             "version": "0.4"
---
>             "version": "0.6-dev"
diff -r data.zarr.v4/labels/Roi1_Segmentation/.zattrs data.zarr.v6/labels/Roi1_Segmentation/.zattrs
3c3
<         "version": "0.4"
---
>         "version": "0.6-dev"
71c71
<             "version": "0.4"
---
>             "version": "0.6-dev"
diff -r data.zarr.v4/zmetadata data.zarr.v6/zmetadata
105c105
<                     "version": "0.4"
---
>                     "version": "0.6-dev"
157c157
<                 "version": "0.4"
---
>                 "version": "0.6-dev"
225c225
<                     "version": "0.4"
---
>                     "version": "0.6-dev"
```

CC @joshmoore 