### PR TITLE
Revert "Update pyproject.toml"

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: ["3.10", "3.12", "3.13"]
+                python: ["3.10", "3.12"]
                 os: [ubuntu-latest]
                 include:
                     - os: macos-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
 urls.Documentation = "https://spatialdata.scverse.org/en/latest"
 urls.Source = "https://github.com/scverse/spatialdata.git"
 urls.Home-page = "https://github.com/scverse/spatialdata.git"
-requires-python = ">=3.10"
+requires-python = ">=3.10, <3.13" # include 3.13 once multiscale-spatial-image conflicts are resolved
 dynamic= [
   "version" # allow version to be set by git tags
 ]


### PR DESCRIPTION
This reverts commit 1f8a01cf97dee96a3fa957234b2f5e8a0732d7e0. (i.e. removes Python 3.13 support). The latest release doesn't support 3.13, so this will not impact users.