### PR TITLE
Fix rechunk bug after spatial query

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ exclude = [
     "docs/_build",
     "dist",
     "setup.py",
-    
+
 ]
 line-length = 120
 target-version = "py310"

--- a/tests/io/test_pyramids_performance.py
+++ b/tests/io/test_pyramids_performance.py
@@ -82,5 +82,5 @@ def test_write_image_multiscale_performance(sdata_with_image: SpatialData, tmp_p
 
     actual_num_chunk_writes = zarr_chunk_write_spy.call_count
     actual_num_chunk_reads = zarr_chunk_read_spy.call_count
-    assert actual_num_chunk_writes == num_chunks_all_scales
-    assert actual_num_chunk_reads == num_chunks_scale0
+    assert actual_num_chunk_writes == num_chunks_all_scales.item()
+    assert actual_num_chunk_reads == num_chunks_scale0.item()


### PR DESCRIPTION
Closes https://github.com/scverse/spatialdata/issues/821 until the root of the problem (https://github.com/dask/dask/issues/11713) is addressed, and until we can update to the latest dask (https://github.com/dask/dask/issues/11146).