### PR TITLE
Update README.md: conda not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Check out the docs for more complete [installation instructions](https://spatial
 pip install "spatialdata[extra]"
 ```
 
-~~or via conda:~~ 
+~~or via conda:~~
 Update Feb 2025: `spatialdata` cannot be currently be installed via `conda` because some dependencies of our dependencies are not updated in `conda-forge` and we are still waiting for an update. Please install from `pip`; the latest versions of the `spatialdata` libraries are always available via `PyPI`.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Check out the docs for more complete [installation instructions](https://spatial
 pip install "spatialdata[extra]"
 ```
 
-or via conda:
+~~or via conda:~~ 
+Update Feb 2025: `spatialdata` cannot be currently be installed via `conda` because some dependencies of our dependencies are not updated in `conda-forge` and we are still waiting for an update. Please install from `pip`; the latest versions of the `spatialdata` libraries are always available via `PyPI`.
 
 ```bash
 mamba install -c conda-forge spatialdata napari-spatialdata spatialdata-io spatialdata-plot

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,9 +69,11 @@ mamba install -c conda-forge spatialdata spatialdata-io spatialdata-plot napari-
 ```
 
 Update: currently (Feb 2025), due to particular versions being unavailable on `conda-forge` for some (dependencies of our) dependencies, the latest versions of the packages of the `SpatialData` ecosystem are not available on `conda-forge`. We are waiting for the availability to be unlocked. The latest versions are always available via PyPI.
+
 ## Docker
 
 ## Docker
+
 A `Dockerfile` is available in the repository; the image that can be built from it contains `spatialdata` (with `torch`), `spatialdata-io` and `spatialdata-plot` (not `napari-spatialdata`)'; the libaries are installed from PyPI.
 
 To build the image, run:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -68,11 +68,11 @@ You can install the `spatialdata`, `spatialdata-io`, `spatialdata-plot` and `nap
 mamba install -c conda-forge spatialdata spatialdata-io spatialdata-plot napari-spatialdata
 ```
 
-Note: currently (Jan 2025), due to particular versions being unavailable on `conda-forge` for some dependent packages, the latest versions of the packages of the `SpatialData` ecosystem are not available on `conda-forge`. We are working on fixing this issue; please check the latest versions available on the channel.
-
+Update: currently (Feb 2025), due to particular versions being unavailable on `conda-forge` for some (dependencies of our) dependencies, the latest versions of the packages of the `SpatialData` ecosystem are not available on `conda-forge`. We are waiting for the availability to be unlocked. The latest versions are always available via PyPI.
 ## Docker
 
-A `Dockerfile` is available in the repository; the image that can be built from it contains `spatialdata` (with `torch`), `spatialdata-io` and `spatialdata-plot` (not `napari-spatialdata`).
+## Docker
+A `Dockerfile` is available in the repository; the image that can be built from it contains `spatialdata` (with `torch`), `spatialdata-io` and `spatialdata-plot` (not `napari-spatialdata`)'; the libaries are installed from PyPI.
 
 To build the image, run:
 


### PR DESCRIPTION
We cannot offer `spatialdata` in `conda` atm. Details here: https://github.com/conda-forge/spatialdata-feedstock/pull/14. I therefore explain this in the docs and readme.