### PR TITLE
Add encoding type and version to write_zarr

### DIFF
--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -1215,6 +1215,13 @@ class SpatialData:
         self.write_attrs(zarr_group=zarr_group)
         store.close()
 
+        from spatialdata._io.format import SpatialDataContainerFormats
+
+        zarr_group.attrs["encoding-type"] = "spatialdata"
+        zarr_group.attrs["encoding-version"] = max(
+            SpatialDataContainerFormats.keys(), key=lambda version: float(version)
+        )
+
         for element_type, element_name, element in self.gen_elements():
             self._write_element(
                 element=element,

--- a/tests/core/test_write.py
+++ b/tests/core/test_write.py
@@ -1,0 +1,94 @@
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+import zarr
+
+
+@pytest.fixture
+def temp_zarr_path():
+    """Create a temporary directory for testing, clean up afterwards."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+        zarr_path = Path(temp_dir) / "test.zarr"
+        yield zarr_path
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+def test_write_encoding_metadata(full_sdata, temp_zarr_path):
+    """Test that encoding metadata is written to the root group."""
+    # Write the SpatialData object
+    full_sdata.write(temp_zarr_path)
+
+    # Open the Zarr store and check for encoding metadata
+    store = zarr.open(temp_zarr_path)
+    assert "encoding-type" in store.attrs
+    assert store.attrs["encoding-type"] == "spatialdata"
+    assert "encoding-version" in store.attrs
+    assert store.attrs["encoding-version"] == "0.1"
+
+
+def test_write_read_roundtrip(full_sdata, temp_zarr_path):
+    """Test writing and reading back preserves data and metadata."""
+    full_sdata.write(temp_zarr_path)
+
+    from spatialdata import SpatialData
+
+    read_sdata = SpatialData.read(temp_zarr_path)
+
+    # Check that encoding metadata is preserved
+    store = zarr.open(temp_zarr_path)
+    assert "encoding-type" in store.attrs
+    assert "encoding-version" in store.attrs
+
+    # Check that element counts match
+    assert len(read_sdata.images) == len(full_sdata.images)
+    assert len(read_sdata.labels) == len(full_sdata.labels)
+    assert len(read_sdata.shapes) == len(full_sdata.shapes)
+    assert len(read_sdata.points) == len(full_sdata.points)
+    assert len(read_sdata.tables) == len(full_sdata.tables)
+
+
+def test_write_consolidated_metadata(full_sdata):
+    """Test that consolidated metadata includes encoding information."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+        zarr_path = Path(temp_dir) / "test_consolidated.zarr"
+
+        # Write with consolidated metadata
+        full_sdata.write(zarr_path, consolidate_metadata=True)
+
+        # Check for both possible metadata filenames
+        # (.zmetadata is the standard, zmetadata is referenced in the comments)
+        standard_path = os.path.join(zarr_path, ".zmetadata")
+        alt_path = os.path.join(zarr_path, "zmetadata")
+
+        assert os.path.exists(standard_path) or os.path.exists(alt_path), "Neither .zmetadata nor zmetadata file found"
+
+        # Check encoding metadata in the store
+        store = zarr.open(zarr_path)
+        assert "encoding-type" in store.attrs
+        assert store.attrs["encoding-type"] == "spatialdata"
+        assert "encoding-version" in store.attrs
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+def test_write_empty_sdata(temp_zarr_path):
+    """Test writing an empty SpatialData object."""
+    # Create an empty SpatialData object
+    from spatialdata import SpatialData
+
+    empty_sdata = SpatialData()
+
+    # Write the empty SpatialData object
+    empty_sdata.write(temp_zarr_path)
+
+    # Open the Zarr store and check for encoding metadata
+    store = zarr.open(temp_zarr_path)
+    assert "encoding-type" in store.attrs
+    assert store.attrs["encoding-type"] == "spatialdata"
+    assert "encoding-version" in store.attrs

--- a/tests/io/test_readwrite.py
+++ b/tests/io/test_readwrite.py
@@ -611,7 +611,7 @@ def test_incremental_io_valid_name(full_sdata: SpatialData) -> None:
 def test_incremental_io_attrs(points: SpatialData) -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         f = os.path.join(tmpdir, "data.zarr")
-        my_attrs = {"a": "b", "c": 1}
+        my_attrs = {"a": "b", "c": 1, "encoding-type": "spatialdata", "encoding-version": "0.1"}
         points.attrs = my_attrs
         points.write(f)
 


### PR DESCRIPTION
Fixes #890 

I added a new test script because I am not sure whether these tests should live in `io/test_readwrite.py` because the original writing code is in core.