### PR TITLE
Added `filter_table_by_query`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ license = {file = "LICENSE"}
 readme = "README.md"
 dependencies = [
     "anndata>=0.9.1",
+    "annsel>=0.0.10",
     "click",
     "dask-image",
     "dask>=2024.4.1,<=2024.11.2",

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -41,6 +41,7 @@ __all__ = [
     "match_element_to_table",
     "match_table_to_element",
     "match_sdata_to_table",
+    "filter_by_table_query",
     "SpatialData",
     "get_extent",
     "get_centroids",
@@ -68,6 +69,7 @@ from spatialdata._core.operations.transform import transform
 from spatialdata._core.operations.vectorize import to_circles, to_polygons
 from spatialdata._core.query._utils import get_bounding_box_corners
 from spatialdata._core.query.relational_query import (
+    filter_by_table_query,
     get_element_annotators,
     get_element_instances,
     get_values,

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import pandas as pd
 import zarr
 from anndata import AnnData
+from annsel.core.typing import Predicates
 from dask.dataframe import DataFrame as DaskDataFrame
 from dask.dataframe import read_parquet
 from dask.delayed import Delayed
@@ -2454,6 +2455,76 @@ class SpatialData:
             self._attrs = value
         else:
             self._attrs = dict(value)
+
+    def filter_by_table_query(
+        self,
+        table_name: str,
+        filter_tables: bool = True,
+        include_orphan_tables: bool = False,
+        elements: list[str] | None = None,
+        obs_expr: Predicates | None = None,
+        var_expr: Predicates | None = None,
+        x_expr: Predicates | None = None,
+        obs_names_expr: Predicates | None = None,
+        var_names_expr: Predicates | None = None,
+        layer: str | None = None,
+        how: Literal["left", "left_exclusive", "inner", "right", "right_exclusive"] = "right",
+    ) -> SpatialData:
+        """Filter the SpatialData object based on a set of table queries. (:class:`anndata.AnnData`.
+
+        Parameters
+        ----------
+        table_name
+            The name of the table to filter the SpatialData object by.
+        filter_tables, optional
+            If True (default), the table is filtered to only contain rows that are annotating regions
+            contained within the element_names.
+        include_orphan_tables, optional
+            If True (not default), include tables that do not annotate SpatialElement(s). Only has an effect if
+            `filter_tables` is also set to True.
+        elements, optional
+            The names of the elements to filter the SpatialData object by.
+        obs_expr, optional
+            A Predicate or an iterable of Predicates to filter :attr:`anndata.AnnData.obs` by.
+        var_expr, optional
+            A Predicate or an iterable of Predicates to filter :attr:`anndata.AnnData.var` by.
+        x_expr, optional
+            A Predicate or an iterable of Predicates to filter :attr:`anndata.AnnData.X` by.
+        obs_names_expr, optional
+            A Predicate or an iterable of Predicates to filter :attr:`anndata.AnnData.obs_names` by.
+        var_names_expr, optional
+            A Predicate or an iterable of Predicates to filter :attr:`anndata.AnnData.var_names` by.
+        layer, optional
+            The layer of the :class:`anndata.AnnData` to filter the SpatialData object by, only used with `x_expr`.
+        how, optional
+            The type of join to perform. See :func:`spatialdata.join_spatialelement_table`. Default is "right".
+
+        Returns
+        -------
+            The filtered SpatialData object.
+
+        Notes
+        -----
+        This function calls :func:`spatialdata.filter_by_table_query` with the convenience that `sdata` is the current
+        SpatialData object.
+
+        """
+        from spatialdata._core.query.relational_query import filter_by_table_query
+
+        return filter_by_table_query(
+            self,
+            table_name,
+            filter_tables,
+            include_orphan_tables,
+            elements,
+            obs_expr,
+            var_expr,
+            x_expr,
+            obs_names_expr,
+            var_names_expr,
+            layer,
+            how,
+        )
 
 
 class QueryManager:


### PR DESCRIPTION
Added filtering by a table query as discussed in #626. Added both a standalone function `sd.filter_table_by_query` and a method `sd.SpatialData.filter_table_by_query`.


TODO: 
- [ ] Add Tests
- [ ] More Docs? An example notebook?

Function signature
```python
class SpatialData:
	...

    def filter_by_table_query(
        self,
        table_name: str,
        filter_tables: bool = True,
        include_orphan_tables: bool = False,
        elements: list[str] | None = None,
        obs_expr: Predicates | None = None,
        var_expr: Predicates | None = None,
        x_expr: Predicates | None = None,
        obs_names_expr: Predicates | None = None,
        var_names_expr: Predicates | None = None,
        layer: str | None = None,
        how: Literal["left", "left_exclusive", "inner", "right", "right_exclusive"] = "right",
    ) -> SpatialData:

```

`sd.filter_by_table_query` is the same, but instead of `self`, you have to provide the `SpatialData` object of interest.
----

What expressions can you use?

- Several methods are supported by [`narwhals`][nw-expr-api]. As long as the method doesn't aggregate.
  - I know that the following work: `>,>=,<,<=`, `==`, `is_in`,
  - And from [Expr.str][nw-expr-str-api] `contains`, `starts_with` works.

What parts can I filter on?

You can filter on the `obs` and `var` DataFrame attributes of `AnnData`. 

You can filter on `obs_names` and `var_names`. (uses `an.obs_names`, and `an.var_names` instead of `an.col`)

You can filter on the expression matrix `X` w.r.t layers as well.


----

## Some Examples

```python
# Using the mibitof dataset cause it's small and has a table which covers multiple spatialdata elements.

import spatialdata as sd
import annsel as an
from upath import UPath

mibitof_path = UPath("~/Downloads/mibitof-dataset.zarr")

sdata = sd.read_zarr(mibitof_path)

sdata
```

<details>
<summary>SpatialData Repr</summary>


```sh
SpatialData object, with associated Zarr store: [/Users/srivarra/Downloads/mibitof-dataset.zarr](https://file+.vscode-resource.vscode-cdn.net/Users/srivarra/Downloads/mibitof-dataset.zarr)
├── Images
│     ├── 'point8_image': DataArray[cyx] (3, 1024, 1024)
│     ├── 'point16_image': DataArray[cyx] (3, 1024, 1024)
│     └── 'point23_image': DataArray[cyx] (3, 1024, 1024)
├── Labels
│     ├── 'point8_labels': DataArray[yx] (1024, 1024)
│     ├── 'point16_labels': DataArray[yx] (1024, 1024)
│     └── 'point23_labels': DataArray[yx] (1024, 1024)
└── Tables
      └── 'table': AnnData (3309, 36)
with coordinate systems:
    ▸ 'point8', with elements:
        point8_image (Images), point8_labels (Labels)
    ▸ 'point16', with elements:
        point16_image (Images), point16_labels (Labels)
    ▸ 'point23', with elements:
        point23_image (Images), point23_labels (Labels)
```


</details>


For context here is what the table looks like:

```shell
AnnData object with n_obs × n_vars = 3309 × 36
    obs: 'row_num', 'point', 'cell_id', 'X1', 'center_rowcoord', 'center_colcoord', 'cell_size', 'category', 'donor', 'Cluster', 'batch', 'library_id'
    uns: 'spatialdata_attrs'
    obsm: 'X_scanorama', 'X_umap', 'spatial'
```

1. Filter with respect the donor `"21d7"`, and filter `var_names` where we have `"ASCT2"`, `"ATP5A"` and any marker that starts with "CD".
```python
sd.filter_by_table_query(
    sdata,
    table_name="table",
    obs_expr=an.col("donor") == "21d7",
    var_names_expr=(
        an.var_names.is_in(["ASCT2", "ATP5A"])
        | an.var_names.str.starts_with("CD")
    ),
    x_expr=None,
)

```

<details><summary>Output</summary>
<p>

```shell
SpatialData object
├── Labels
│     └── 'point23_labels': DataArray[yx] (1024, 1024)
└── Tables
      └── 'table': AnnData (1241, 14)
with coordinate systems:
    ▸ 'point23', with elements:
        point23_labels (Labels)
```

</p>
</details> 

2. Filter by batches `"0"` and `"1"`.


```python

sdata.filter_by_table_query(
    table_name="table",
    obs_expr=an.col("batch").is_in(["1", "0"]),
)

```
<details><summary>Output</summary>
<p>

```shell
SpatialData object
├── Labels
│     ├── 'point8_labels': DataArray[yx] (1024, 1024)
│     └── 'point23_labels': DataArray[yx] (1024, 1024)
└── Tables
      └── 'table': AnnData (2286, 36)
with coordinate systems:
    ▸ 'point8', with elements:
        point8_labels (Labels)
    ▸ 'point23', with elements:
        point23_labels (Labels)
```

</p>
</details> 

3. Filter by `obs_names` which start with `"9"`

```python
sd.filter_by_table_query(
    sdata,
    table_name="table",
    obs_names_expr=an.obs_names.str.starts_with("9")
)
```
<details><summary>Output</summary>
<p>

```shell
SpatialData object
├── Labels
│     └── 'point8_labels': DataArray[yx] (1024, 1024)
└── Tables
      └── 'table': AnnData (624, 36)
with coordinate systems:
    ▸ 'point8', with elements:
        point8_labels (Labels)
```
</p>
</details> 

4. Note that tuples of Expressions applies an `&` operator


```python

sd.filter_by_table_query(
    sdata,
    table_name="table",
    var_names_expr=(an.var_names.str.contains("CD"), an.var_names == "CD8"),
    x_expr=None,
)
```
<details><summary>Output</summary>
<p>

```shell
SpatialData object
├── Labels
│     ├── 'point8_labels': DataArray[yx] (1024, 1024)
│     ├── 'point16_labels': DataArray[yx] (1024, 1024)
│     └── 'point23_labels': DataArray[yx] (1024, 1024)
└── Tables
      └── 'table': AnnData (3309, 1)
with coordinate systems:
    ▸ 'point8', with elements:
        point8_labels (Labels)
    ▸ 'point16', with elements:
        point16_labels (Labels)
    ▸ 'point23', with elements:
        point23_labels (Labels)
```

</p>
</details> 

5. Whatever this does

```python
sd.filter_by_table_query(
    sdata,
    table_name="table",
    # Filter observations (rows) based on multiple conditions
    obs_expr=(
        # Cells from donor 21d7 OR 90de
        an.col("donor").is_in(["21d7", "90de"])
        # AND cells with size greater than 400
        & (an.col("cell_size") > 400)
        # AND cells that are either Epithelial or contain "CD" in their cluster name
        & (an.col("Cluster") == "Epithelial")
        | (an.col("Cluster").str.contains("CD"))
    ),
    # Filter variables (columns) based on multiple conditions
    var_names_expr=(
        # Select columns that start with CD
        an.var_names.str.starts_with("CD")
        # OR columns that contain "ATP"
        | an.var_names.str.contains("ATP")
        # OR specific columns
        | an.var_names.is_in(["ASCT2", "PKM2", "SMA"])
    ),
    # Filter based on expression values
    x_expr=(
        # Keep cells where ASCT2 expression is greater than 0.1
        (an.col("ASCT2") > 0.1)
        # AND less than 2 for all ASCT2
        & (an.col("ASCT2") < 2)
    ),
    # Additional parameters
    how="right",
    elements=["point23_labels", "point8_labels"],
)
```
<details><summary>Output</summary>
<p>

```shell
SpatialData object
├── Labels
│     ├── 'point8_labels': DataArray[yx] (1024, 1024)
│     └── 'point23_labels': DataArray[yx] (1024, 1024)
└── Tables
      └── 'table': AnnData (324, 17)
with coordinate systems:
    ▸ 'point8', with elements:
        point8_labels (Labels)
    ▸ 'point23', with elements:
        point23_labels (Labels)
```

</p>
</details> 

[nw-expr-api]: https://narwhals-dev.github.io/narwhals/api-reference/expr/

[nw-expr-str-api]: https://narwhals-dev.github.io/narwhals/api-reference/expr_str/



Thoughts? I'll add some tests soon.