### PR TITLE
Resolve AnnData FutureWarnings `The dtype argument is deprecated`

### DIFF
--- a/src/spatialdata/_core/operations/aggregate.py
+++ b/src/spatialdata/_core/operations/aggregate.py
@@ -312,7 +312,6 @@ def _aggregate_image_by_labels(
         X,
         obs=pd.DataFrame(index=zones.astype(str)),
         var=pd.DataFrame(index=df.columns),
-        dtype=X.dtype,
     )
 
 
@@ -490,7 +489,6 @@ def _aggregate_shapes(
         X,
         obs=pd.DataFrame(index=rows_categories),
         var=pd.DataFrame(index=columns_categories),
-        dtype=X.dtype,
     )
 
     # cleanup: remove columns previously added

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -454,11 +454,10 @@ def sdata_query_aggregation() -> SpatialData:
 def generate_adata(n_var: int, obs: pd.DataFrame, obsm: dict[Any, Any], uns: dict[Any, Any]) -> AnnData:
     rng = np.random.default_rng(SEED)
     return AnnData(
-        rng.normal(size=(obs.shape[0], n_var)),
+        rng.normal(size=(obs.shape[0], n_var)).astype(np.float64),
         obs=obs,
         obsm=obsm,
         uns=uns,
-        dtype=np.float64,
     )
 
 


### PR DESCRIPTION
Fixes https://github.com/scverse/spatialdata/issues/895

No more

```
site-packages/anndata/_core/anndata.py:401: FutureWarning: The dtype argument is deprecated and will be removed in late 2024.
```
