### PR TITLE
spatialdata.io.io_shapes: fix support for remote shapes

### DIFF
--- a/src/spatialdata/_io/io_shapes.py
+++ b/src/spatialdata/_io/io_shapes.py
@@ -40,8 +40,7 @@ def _read_shapes(
             geometry = from_ragged_array(typ, coords, offsets)
             geo_df = GeoDataFrame({"geometry": geometry}, index=index)
     elif isinstance(format, ShapesFormatV02):
-        path = Path(f._store.path) / f.path / "shapes.parquet"
-        geo_df = read_parquet(path)
+        geo_df = read_parquet(f.store.path, filesystem=f.store.fs)
     else:
         raise ValueError(
             f"Unsupported shapes format {format} from version {version}. Please update the spatialdata library."

--- a/tests/io/test_remote_mock.py
+++ b/tests/io/test_remote_mock.py
@@ -135,8 +135,7 @@ class TestRemoteMock:
             "labels",
             # TODO: fix remote reading support points
             # "points",
-            # TODO: fix remote reading support shapes
-            # "shapes",
+            "shapes",
         ],
     )
     def test_reading_mocked_elements(self, upath: UPath, sdata_type: str, request) -> None:


### PR DESCRIPTION
This PR adds remote filesystem support for shapes.