### PR TITLE
When transforming DataTree elements, discard scales resulting in zero shape

### DIFF
--- a/src/spatialdata/_core/operations/transform.py
+++ b/src/spatialdata/_core/operations/transform.py
@@ -383,7 +383,7 @@ def _(
         )
 
         # if a scale in the transformed data has zero shape, we skip it
-        if not np.min(transformed_dask.shape):
+        if 0 in transformed_dask.shape:
             if k == "scale0":
                 raise ValueError(
                     "The transformation leads to zero shaped data even at the highest resolution level. "

--- a/tests/core/operations/test_transform.py
+++ b/tests/core/operations/test_transform.py
@@ -253,7 +253,10 @@ def test_transform_datatree_scale_handling():
 
     # check that a ValueError is raised when no resolution level
     # is left after the transformation
-    with pytest.raises(ValueError, match="The transformation leads to zero shaped data."):
+    with pytest.raises(
+        ValueError,
+        match="The transformation leads to zero shaped data even at the highest resolution level",
+    ):
         transform(test_image, to_coordinate_system="cs2")
 
 


### PR DESCRIPTION
This PR implements a fix for https://github.com/scverse/spatialdata/issues/947.

**Problem summary**: `spatialdata.transform` transforms each of the scales of a multi-scale image and it can happen that (especially lower resolution) scales result in shape 0. One one hand it doesn't make sense to keep zero shape scales, on the other this leads to an error later on when the scale factors of the resulting image are extracted.

**Fix proposed in this PR**: scales resulting in zero shape are discarded, similarly to the postprocessing of `bounding_box_query`:

https://github.com/scverse/spatialdata/blob/7604a3d2325079293ff523c5dff4483dffc890cb/src/spatialdata/_core/query/_utils.py#L116-L126

In the case of 'scale0' resulting in zero shape, the PR proposes to raise an error.

Happy to work on any review points!

