### PR TITLE
Geometry encoding parameter for shapes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ node_modules/
 
 .mypy_cache
 .ruff_cache
+uv.lock

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -40,6 +40,7 @@ __all__ = [
     "deepcopy",
     "sanitize_table",
     "sanitize_name",
+    "settings",
 ]
 
 from spatialdata import dataloader, datasets, models, transformations
@@ -70,3 +71,4 @@ from spatialdata._io._utils import get_dask_backing_files
 from spatialdata._io.format import SpatialDataFormatType
 from spatialdata._io.io_zarr import read_zarr
 from spatialdata._utils import get_pyramid_levels, unpad_raster
+from spatialdata.config import settings

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -1110,7 +1110,7 @@ class SpatialData:
         consolidate_metadata: bool = True,
         update_sdata_path: bool = True,
         sdata_formats: SpatialDataFormatType | list[SpatialDataFormatType] | None = None,
-        shapes_geometry_encoding: Literal["WKB", "geoarrow"] = "WKB",
+        shapes_geometry_encoding: Literal["WKB", "geoarrow"] | None = None,
     ) -> None:
         """
         Write the `SpatialData` object to a Zarr store.
@@ -1157,7 +1157,7 @@ class SpatialData:
             `spatialdata._io.format.py`.
         shapes_geometry_encoding
             Whether to use the WKB or geoarrow encoding for GeoParquet. See :meth:`geopandas.GeoDataFrame.to_parquet`
-            for details.
+            for details. If None, uses the value from :attr:`spatialdata.settings.shapes_geometry_encoding`.
         """
         from spatialdata._io._utils import _resolve_zarr_store
         from spatialdata._io.format import _parse_formats
@@ -1200,7 +1200,7 @@ class SpatialData:
         element_name: str,
         overwrite: bool,
         parsed_formats: dict[str, SpatialDataFormatType] | None = None,
-        shapes_geometry_encoding: Literal["WKB", "geoarrow"] = "WKB",
+        shapes_geometry_encoding: Literal["WKB", "geoarrow"] | None = None,
     ) -> None:
         from spatialdata._io.io_zarr import _get_groups_for_element
 
@@ -1270,7 +1270,7 @@ class SpatialData:
         element_name: str | list[str],
         overwrite: bool = False,
         sdata_formats: SpatialDataFormatType | list[SpatialDataFormatType] | None = None,
-        shapes_geometry_encoding: Literal["WKB", "geoarrow"] = "WKB",
+        shapes_geometry_encoding: Literal["WKB", "geoarrow"] | None = None,
     ) -> None:
         """
         Write a single element, or a list of elements, to the Zarr store used for backing.
@@ -1288,7 +1288,7 @@ class SpatialData:
              `SpatialData.write()`.
         shapes_geometry_encoding
             Whether to use the WKB or geoarrow encoding for GeoParquet. See :meth:`geopandas.GeoDataFrame.to_parquet`
-            for details.
+            for details. If None, uses the value from :attr:`spatialdata.settings.shapes_geometry_encoding`.
 
         Notes
         -----

--- a/src/spatialdata/_io/io_shapes.py
+++ b/src/spatialdata/_io/io_shapes.py
@@ -70,7 +70,7 @@ def write_shapes(
     group: zarr.Group,
     group_type: str = "ngff:shapes",
     element_format: Format = CurrentShapesFormat(),
-    geometry_encoding: Literal["WKB", "geoarrow"] = "WKB",
+    geometry_encoding: Literal["WKB", "geoarrow"] | None = None,
 ) -> None:
     """Write shapes to spatialdata zarr store.
 
@@ -89,8 +89,13 @@ def write_shapes(
         The format of the shapes element used to store it.
     geometry_encoding
         Whether to use the WKB or geoarrow encoding for GeoParquet. See :meth:`geopandas.GeoDataFrame.to_parquet` for
-        details.
+        details. If None, uses the value from :attr:`spatialdata.settings.shapes_geometry_encoding`.
     """
+    from spatialdata.config import settings
+
+    if geometry_encoding is None:
+        geometry_encoding = settings.shapes_geometry_encoding
+
     axes = get_axes_names(shapes)
     transformations = _get_transformations(shapes)
     if transformations is None:

--- a/src/spatialdata/config.py
+++ b/src/spatialdata/config.py
@@ -1,4 +1,28 @@
-# chunk sizes bigger than this value (bytes) can trigger a compression error
-# https://github.com/scverse/spatialdata/issues/812#issuecomment-2559380276
-# so if we detect this during parsing/validation we raise a warning
-LARGE_CHUNK_THRESHOLD_BYTES = 2147483647
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass
+class Settings:
+    """Global settings for spatialdata.
+
+    Attributes
+    ----------
+    shapes_geometry_encoding
+        Default geometry encoding for GeoParquet files when writing shapes.
+        Can be "WKB" (Well-Known Binary) or "geoarrow".
+        See :meth:`geopandas.GeoDataFrame.to_parquet` for details.
+    large_chunk_threshold_bytes
+        Chunk sizes bigger than this value (bytes) can trigger a compression error.
+        See https://github.com/scverse/spatialdata/issues/812#issuecomment-2559380276
+        If detected during parsing/validation, a warning is raised.
+    """
+
+    shapes_geometry_encoding: Literal["WKB", "geoarrow"] = "WKB"
+    large_chunk_threshold_bytes: int = 2147483647
+
+
+settings = Settings()
+
+# Backwards compatibility alias
+LARGE_CHUNK_THRESHOLD_BYTES = settings.large_chunk_threshold_bytes

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -35,7 +35,7 @@ from spatialdata._core.validation import validate_table_attr_keys
 from spatialdata._logging import logger
 from spatialdata._types import ArrayLike
 from spatialdata._utils import _check_match_length_channels_c_dim
-from spatialdata.config import LARGE_CHUNK_THRESHOLD_BYTES
+from spatialdata.config import settings
 from spatialdata.models import C, X, Y, Z, get_axes_names
 from spatialdata.models._utils import (
     DEFAULT_COORDINATE_SYSTEM,
@@ -315,9 +315,9 @@ class RasterSchema(DataArraySchema):
                 return
             n_elems = np.array(list(max_per_dimension.values())).prod().item()
             usage = n_elems * data.dtype.itemsize
-            if usage > LARGE_CHUNK_THRESHOLD_BYTES:
+            if usage > settings.large_chunk_threshold_bytes:
                 warnings.warn(
-                    f"Detected chunks larger than: {usage} > {LARGE_CHUNK_THRESHOLD_BYTES} bytes. "
+                    f"Detected chunks larger than: {usage} > {settings.large_chunk_threshold_bytes} bytes. "
                     "This can lead to low "
                     "performance and memory issues downstream, and sometimes cause compression errors when writing "
                     "(https://github.com/scverse/spatialdata/issues/812#issuecomment-2575983527). Please consider using"
@@ -327,7 +327,7 @@ class RasterSchema(DataArraySchema):
                     "2) Multiscale representations can be achieved by using the `scale_factors` argument in the "
                     "`parse()` function.\n"
                     "You can suppress this warning by increasing the value of "
-                    "`spatialdata.config.LARGE_CHUNK_THRESHOLD_BYTES`.",
+                    "`spatialdata.settings.large_chunk_threshold_bytes`.",
                     UserWarning,
                     stacklevel=2,
                 )


### PR DESCRIPTION
Fixes https://github.com/scverse/spatialdata/issues/799
The [to_parquet](https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoDataFrame.to_parquet.html) function supports a `geometry_encoding` parameter. When [geoarrow](https://geoarrow.org/), it will be more efficient to read/parse the geometries, as the data can stay in its parquet/arrow memory layout during downstream usage. Visualization applications will benefit from this (and other applications such as data processing pipelines should too).

