### PR TITLE
Design doc: Add note about on-disk locations of point metadata attributes

### DIFF
--- a/docs/design_doc.md
+++ b/docs/design_doc.md
@@ -234,7 +234,7 @@ The requirements are the following:
 - The dataframe MUST contains axis name to represent the axes.
     - If it's 2D, the axes should be `["x","y"]`.
     - If it's 3D, the axes should be `["x","y","z"]`.
-- It MUST also contain coordinate transformations in `dask.dataframe.DataFrame().attrs["transform"]`. This information will be saved on-disk in JSON under a `"coordinateTransformations"` key in a `.zattrs` file (Zarr v2), or `zarr.json` file (Zarr v3), in a Zarr Group containing the Element. The specific way this information is stored in disk is described by the NGFF specification. Precisely, the NGFF specification dscribes coordinate transformations for images, but we will reuse it also for Points and Shapes.
+- It MUST also contain coordinate transformations in `dask.dataframe.DataFrame().attrs["transform"]`. This information will be saved on-disk in JSON under a `"coordinateTransformations"` key in a `.zattrs` file (Zarr v2), or `zarr.json` file (Zarr v3), in a Zarr Group containing the Element. The specific way this information is stored in disk is described by the NGFF specification (the implementaiton of the latest version of the specs is ongoing). Precisely, the NGFF specification dscribes coordinate transformations for images, but we will reuse it also for Points and Shapes.
 
 Additional information is stored in `dask.dataframe.DataFrame().attrs["spatialdata_attrs"]` (or on-disk in `.attrs["spatialdata_attrs"]` for the Zarr Group containing the Element).
 


### PR DESCRIPTION
This PR clarifies how to access the attributes listed here when accessing the points data from the on-disk format.

Is this correct that the coordinate transformations are in `"transform"` in-memory but `"coordinateTransformations"` on-disk?