### PR TITLE
use python>=3.10 typing conventions

### DIFF
--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -24,7 +24,7 @@ import os
 from collections.abc import Sequence
 from functools import lru_cache
 from types import ModuleType
-from typing import Callable, Literal, Optional, Union, overload
+from typing import Callable, Literal, overload
 
 import anndata as ad
 import numpy as np
@@ -98,7 +98,7 @@ def _structure_at_coordinates(
     *,
     multipliers: Sequence = itertools.repeat(1),
     dtype=None,
-    reduce_fn: Callable[[np.ndarray, np.ndarray, Optional[np.ndarray]], np.ndarray],
+    reduce_fn: Callable[[np.ndarray, np.ndarray, np.ndarray | None], np.ndarray],
 ):
     """Update data with structure at given coordinates.
 
@@ -165,9 +165,9 @@ def _smallest_dtype(n: int) -> np.dtype:
 @overload
 def labeled_particles(
     shape: Sequence[int],
-    dtype: Optional[np.dtype] = None,
+    dtype: np.dtype | None = None,
     n: int = 144,
-    seed: Optional[int] = None,
+    seed: int | None = None,
     return_density: Literal[False] = False,
 ) -> np.ndarray: ...
 
@@ -175,9 +175,9 @@ def labeled_particles(
 @overload
 def labeled_particles(
     shape: Sequence[int],
-    dtype: Optional[np.dtype] = None,
+    dtype: np.dtype | None = None,
     n: int = 144,
-    seed: Optional[int] = None,
+    seed: int | None = None,
     return_density: Literal[True] = True,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]: ...
 
@@ -185,22 +185,22 @@ def labeled_particles(
 @lru_cache
 def labeled_particles(
     shape: Sequence[int],
-    dtype: Optional[np.dtype] = None,
+    dtype: np.dtype | None = None,
     n: int = 144,
-    seed: Optional[int] = None,
+    seed: int | None = None,
     return_density: bool = False,
-) -> Union[np.ndarray, tuple[np.ndarray, np.ndarray, np.ndarray]]:
+) -> np.ndarray | tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Generate labeled blobs of given shape and dtype.
 
     Parameters
     ----------
     shape : Sequence[int]
         Shape of the resulting array.
-    dtype : Optional[np.dtype]
+    dtype : np.dtype | None
         Dtype of the resulting array.
     n : int
         Number of blobs to generate.
-    seed : Optional[int]
+    seed : int | None
         Seed for the random number generator.
     return_density : bool
         Whether to return the density array and center coordinates.

--- a/docs/design_doc.md
+++ b/docs/design_doc.md
@@ -268,7 +268,7 @@ In `spatialdata-io` we use a consistent naming scheme for the `region_key` and `
 ### Summary
 
 - Image `type: Image`
-- Regions `type: Union[Labels, Shapes]`
+- Regions `type: Labels | Shapes`
     - Labels `type: Labels`
     - Shapes `type: Shapes`
 - Points `type: Points`

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import dask
 
 dask.config.set({"dataframe.query-planning": False})

--- a/src/spatialdata/_core/_deepcopy.py
+++ b/src/spatialdata/_core/_deepcopy.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from copy import deepcopy as _deepcopy
 from functools import singledispatch
 

--- a/src/spatialdata/_core/_elements.py
+++ b/src/spatialdata/_core/_elements.py
@@ -1,7 +1,5 @@
 """SpatialData elements."""
 
-from __future__ import annotations
-
 from collections import UserDict
 from collections.abc import Iterable, KeysView, ValuesView
 from typing import TypeVar

--- a/src/spatialdata/_core/_utils.py
+++ b/src/spatialdata/_core/_utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Iterable
 
 from anndata import AnnData

--- a/src/spatialdata/_core/centroids.py
+++ b/src/spatialdata/_core/centroids.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections import defaultdict
 from functools import singledispatch
 

--- a/src/spatialdata/_core/concatenate.py
+++ b/src/spatialdata/_core/concatenate.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections import defaultdict
 from collections.abc import Callable, Iterable
 from copy import copy  # Should probably go up at the top

--- a/src/spatialdata/_core/data_extent.py
+++ b/src/spatialdata/_core/data_extent.py
@@ -1,9 +1,6 @@
-from __future__ import annotations
-
 # Functions to compute the bounding box describing the extent of a SpatialElement or SpatialData object
 from collections import defaultdict
 from functools import singledispatch
-from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -107,9 +104,7 @@ def get_extent(
     has_labels: bool = True,
     has_points: bool = True,
     has_shapes: bool = True,
-    elements: Union[  # noqa: UP007 # https://github.com/scverse/spatialdata/pull/318#issuecomment-1755714287
-        list[str], None
-    ] = None,
+    elements: list[str] | None = None,  # noqa: UP007 # https://github.com/scverse/spatialdata/pull/318#issuecomment-1755714287
 ) -> BoundingBoxDescription:
     """
     Get the extent (bounding box) of a SpatialData object or a SpatialElement.
@@ -178,9 +173,7 @@ def _(
     has_labels: bool = True,
     has_points: bool = True,
     has_shapes: bool = True,
-    # python 3.9 tests fail if we don't use Union here, see
-    # https://github.com/scverse/spatialdata/pull/318#issuecomment-1755714287
-    elements: Union[list[str], None] = None,  # noqa: UP007
+    elements: list[str] | None = None,
 ) -> BoundingBoxDescription:
     """
     Get the extent (bounding box) of a SpatialData object.

--- a/src/spatialdata/_core/operations/_utils.py
+++ b/src/spatialdata/_core/operations/_utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import TYPE_CHECKING
 
 from xarray import DataArray, DataTree

--- a/src/spatialdata/_core/operations/aggregate.py
+++ b/src/spatialdata/_core/operations/aggregate.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import warnings
 from typing import Any
 
@@ -21,14 +19,7 @@ from spatialdata._core.operations.transform import transform
 from spatialdata._core.query.relational_query import get_values
 from spatialdata._core.spatialdata import SpatialData
 from spatialdata._types import ArrayLike
-from spatialdata.models import (
-    Image2DModel,
-    Labels2DModel,
-    PointsModel,
-    ShapesModel,
-    TableModel,
-    get_model,
-)
+from spatialdata.models import Image2DModel, Labels2DModel, PointsModel, ShapesModel, TableModel, get_model
 from spatialdata.transformations import BaseTransformation, Identity, get_transformation
 
 __all__ = ["aggregate"]

--- a/src/spatialdata/_core/operations/map.py
+++ b/src/spatialdata/_core/operations/map.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 import operator
 from collections.abc import Callable, Iterable, Mapping

--- a/src/spatialdata/_core/operations/rasterize.py
+++ b/src/spatialdata/_core/operations/rasterize.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import dask_image.ndinterp
 import datashader as ds
 import numpy as np

--- a/src/spatialdata/_core/operations/rasterize_bins.py
+++ b/src/spatialdata/_core/operations/rasterize_bins.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import TYPE_CHECKING
 
 import dask.array as da

--- a/src/spatialdata/_core/operations/transform.py
+++ b/src/spatialdata/_core/operations/transform.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import itertools
 import warnings
 from functools import singledispatch
@@ -21,10 +19,7 @@ from spatialdata.models._utils import DEFAULT_COORDINATE_SYSTEM, get_channel_nam
 from spatialdata.transformations._utils import _get_scale, compute_coordinates, scale_radii
 
 if TYPE_CHECKING:
-    from spatialdata.transformations.transformations import (
-        BaseTransformation,
-        Translation,
-    )
+    from spatialdata.transformations.transformations import BaseTransformation, Translation
 
 DEBUG_WITH_PLOTS = False
 ERROR_MSG_AFTER_0_0_15 = """\
@@ -350,12 +345,7 @@ def _(
         data, transformation, maintain_positioning, to_coordinate_system
     )
     schema = get_model(data)
-    from spatialdata.models import (
-        Image2DModel,
-        Image3DModel,
-        Labels2DModel,
-        Labels3DModel,
-    )
+    from spatialdata.models import Image2DModel, Image3DModel, Labels2DModel, Labels3DModel
     from spatialdata.models._utils import TRANSFORM_KEY
     from spatialdata.transformations import get_transformation, set_transformation
     from spatialdata.transformations.transformations import Identity, Sequence

--- a/src/spatialdata/_core/operations/vectorize.py
+++ b/src/spatialdata/_core/operations/vectorize.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from functools import singledispatch
 from typing import Any
 

--- a/src/spatialdata/_core/query/_utils.py
+++ b/src/spatialdata/_core/query/_utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 import numba as nb
@@ -12,11 +10,7 @@ from spatialdata._core.spatialdata import SpatialData
 from spatialdata._types import ArrayLike
 from spatialdata._utils import Number, _parse_list_into_array
 from spatialdata.transformations._utils import compute_coordinates
-from spatialdata.transformations.transformations import (
-    BaseTransformation,
-    Sequence,
-    Translation,
-)
+from spatialdata.transformations.transformations import BaseTransformation, Sequence, Translation
 
 
 def get_bounding_box_corners(

--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 import warnings
 from collections import defaultdict

--- a/src/spatialdata/_core/query/spatial_query.py
+++ b/src/spatialdata/_core/query/spatial_query.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import warnings
 from abc import abstractmethod
 from collections.abc import Callable, Mapping
@@ -16,10 +14,7 @@ from shapely.geometry import MultiPolygon, Point, Polygon
 from xarray import DataArray, DataTree
 
 from spatialdata import to_polygons
-from spatialdata._core.query._utils import (
-    _get_filtered_or_unfiltered_tables,
-    get_bounding_box_corners,
-)
+from spatialdata._core.query._utils import _get_filtered_or_unfiltered_tables, get_bounding_box_corners
 from spatialdata._core.spatialdata import SpatialData
 from spatialdata._docs import docstring_parameter
 from spatialdata._types import ArrayLike
@@ -35,11 +30,7 @@ from spatialdata.models import (
 from spatialdata.models._utils import ValidAxis_t, get_spatial_axes
 from spatialdata.models.models import ATTRS_KEY
 from spatialdata.transformations.operations import set_transformation
-from spatialdata.transformations.transformations import (
-    Affine,
-    BaseTransformation,
-    _get_affine_for_element,
-)
+from spatialdata.transformations.transformations import Affine, BaseTransformation, _get_affine_for_element
 
 MIN_COORDINATE_DOCS = """\
     The upper left hand corners of the bounding boxes (i.e., minimum coordinates along all dimensions).

--- a/src/spatialdata/_core/validation.py
+++ b/src/spatialdata/_core/validation.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Collection
 from types import TracebackType
 from typing import NamedTuple, cast
@@ -277,7 +275,7 @@ class _ErrorDetailsCollector:
         self,
         location: str | tuple[str, ...] = (),
         expected_exception: type[BaseException] | tuple[type[BaseException], ...] | None = None,
-    ) -> _ErrorDetailsCollector:
+    ) -> "_ErrorDetailsCollector":
         """
         Set or override error details in advance before an exception is raised.
 

--- a/src/spatialdata/_io/_utils.py
+++ b/src/spatialdata/_io/_utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import filecmp
 import logging
 import os.path
@@ -31,10 +29,7 @@ from spatialdata.models._utils import (
     _validate_mapping_to_coordinate_system_type,
 )
 from spatialdata.transformations.ngff.ngff_transformations import NgffBaseTransformation
-from spatialdata.transformations.transformations import (
-    BaseTransformation,
-    _get_current_output_axes,
-)
+from spatialdata.transformations.transformations import BaseTransformation, _get_current_output_axes
 
 
 # suppress logger debug from ome_zarr with context manager

--- a/src/spatialdata/_io/format.py
+++ b/src/spatialdata/_io/format.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Iterator
 from typing import Any
 
@@ -106,9 +104,7 @@ class RasterFormatV01(SpatialDataFormat):
             import json
 
             json0 = [json.dumps(t) for t in transformations]
-            from spatialdata.transformations.ngff.ngff_transformations import (
-                NgffBaseTransformation,
-            )
+            from spatialdata.transformations.ngff.ngff_transformations import NgffBaseTransformation
 
             parsed = [NgffBaseTransformation.from_dict(t) for t in transformations]
             json1 = [json.dumps(p.to_dict()) for p in parsed]

--- a/src/spatialdata/_io/io_table.py
+++ b/src/spatialdata/_io/io_table.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 from json import JSONDecodeError
 from typing import Literal

--- a/src/spatialdata/_utils.py
+++ b/src/spatialdata/_utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import functools
 import re
 import warnings
@@ -15,12 +13,7 @@ from dask.array import Array as DaskArray
 from xarray import DataArray, Dataset, DataTree
 
 from spatialdata._types import ArrayLike
-from spatialdata.transformations import (
-    Sequence,
-    Translation,
-    get_transformation,
-    set_transformation,
-)
+from spatialdata.transformations import Sequence, Translation, get_transformation, set_transformation
 
 # I was using "from numbers import Number" but this led to mypy errors, so I switched to the following:
 Number = int | float

--- a/src/spatialdata/dataloader/datasets.py
+++ b/src/spatialdata/dataloader/datasets.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import warnings
 from collections.abc import Callable, Mapping
 from functools import partial

--- a/src/spatialdata/datasets.py
+++ b/src/spatialdata/datasets.py
@@ -1,7 +1,5 @@
 """SpatialData datasets."""
 
-from __future__ import annotations
-
 from typing import Any, Literal
 
 import dask.dataframe.core
@@ -22,13 +20,7 @@ from spatialdata._core.query.relational_query import get_element_instances
 from spatialdata._core.spatialdata import SpatialData
 from spatialdata._logging import logger
 from spatialdata._types import ArrayLike
-from spatialdata.models import (
-    Image2DModel,
-    Labels2DModel,
-    PointsModel,
-    ShapesModel,
-    TableModel,
-)
+from spatialdata.models import Image2DModel, Labels2DModel, PointsModel, ShapesModel, TableModel
 from spatialdata.transformations import Identity
 
 __all__ = ["blobs", "raccoon"]

--- a/src/spatialdata/models/_utils.py
+++ b/src/spatialdata/models/_utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import warnings
 from functools import singledispatch
 from typing import TYPE_CHECKING, Any, TypeAlias

--- a/src/spatialdata/testing.py
+++ b/src/spatialdata/testing.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from anndata import AnnData
 from anndata.tests.helpers import assert_equal as assert_anndata_equal
 from dask.dataframe import DataFrame as DaskDataFrame

--- a/src/spatialdata/transformations/_utils.py
+++ b/src/spatialdata/transformations/_utils.py
@@ -1,8 +1,6 @@
-from __future__ import annotations
-
 import warnings
 from functools import singledispatch
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from dask.dataframe import DataFrame as DaskDataFrame
@@ -92,7 +90,7 @@ def _(e: DataTree, transformations: MappingToCoordinateSystem_t) -> None:
     dims = get_axes_names(e)
     from spatialdata.transformations.transformations import Scale, Sequence
 
-    old_shape: Optional[ArrayLike] = None
+    old_shape: ArrayLike | None = None
     for i, (scale, node) in enumerate(dict(e).items()):
         # this is to be sure that the pyramid levels are listed here in the correct order
         if scale != f"scale{i}":
@@ -122,7 +120,7 @@ def _(e: DataTree, transformations: MappingToCoordinateSystem_t) -> None:
 
 @_set_transformations.register(GeoDataFrame)
 @_set_transformations.register(DaskDataFrame)
-def _(e: Union[GeoDataFrame, GeoDataFrame], transformations: MappingToCoordinateSystem_t) -> None:
+def _(e: GeoDataFrame | GeoDataFrame, transformations: MappingToCoordinateSystem_t) -> None:
     _set_transformations_to_element(e, transformations)
     # _set_transformations_to_dict_container(e.attrs, transformations)
 
@@ -149,7 +147,7 @@ def _(e: DataTree) -> MappingToCoordinateSystem_t | None:
 
 @_get_transformations.register(GeoDataFrame)
 @_get_transformations.register(DaskDataFrame)
-def _(e: Union[GeoDataFrame, DaskDataFrame]) -> MappingToCoordinateSystem_t | None:
+def _(e: GeoDataFrame | DaskDataFrame) -> MappingToCoordinateSystem_t | None:
     return _get_transformations_from_dict_container(e.attrs)
 
 

--- a/src/spatialdata/transformations/ngff/_utils.py
+++ b/src/spatialdata/transformations/ngff/_utils.py
@@ -1,12 +1,7 @@
-from __future__ import annotations
-
 import copy
 
 from spatialdata.models import C, X, Y, Z
-from spatialdata.transformations.ngff.ngff_coordinate_system import (
-    NgffAxis,
-    NgffCoordinateSystem,
-)
+from spatialdata.transformations.ngff.ngff_coordinate_system import NgffAxis, NgffCoordinateSystem
 
 __all__ = "get_default_coordinate_system"
 

--- a/src/spatialdata/transformations/ngff/ngff_coordinate_system.py
+++ b/src/spatialdata/transformations/ngff/ngff_coordinate_system.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import copy
 import json
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 __all__ = ["NgffCoordinateSystem", "NgffAxis"]
 
 Axis_t = dict[str, str]
-CoordSystem_t = dict[str, Union[str, list[dict[str, str]]]]
+CoordSystem_t = dict[str, str | list[dict[str, str]]]
 AXIS_ORDER = ["t", "c", "z", "y", "x"]
 
 
@@ -62,7 +62,7 @@ class NgffCoordinateSystem:
         names of the axes of the coordinate system
     """
 
-    def __init__(self, name: str, axes: Optional[list[NgffAxis]] = None):
+    def __init__(self, name: str, axes: list[NgffAxis] | None = None):
         self.name = name
         self._axes = axes if axes is not None else []
         if len(self._axes) != len({axis.name for axis in self._axes}):
@@ -106,7 +106,7 @@ class NgffCoordinateSystem:
         return out
 
     @staticmethod
-    def from_json(data: Union[str, bytes]) -> NgffCoordinateSystem:
+    def from_json(data: str | bytes) -> NgffCoordinateSystem:
         """Initialize a coordinate system from it's json representation."""
         coord_sys = json.loads(data)
         return NgffCoordinateSystem.from_dict(coord_sys)

--- a/src/spatialdata/transformations/ngff/ngff_transformations.py
+++ b/src/spatialdata/transformations/ngff/ngff_transformations.py
@@ -1,7 +1,7 @@
 import math
 from abc import ABC, abstractmethod
 from numbers import Number
-from typing import Any, Optional, Union
+from typing import Any
 
 import numpy as np
 from typing_extensions import Self
@@ -28,20 +28,20 @@ __all__ = [
 # link pointing to the latest specs from John Bogovic (from his fork of the repo)
 # TODO: update this link when the specs are finalized
 # http://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/bogovicj/ngff/coord-transforms/latest/index.bs
-# Transformation_t = Dict[str, Union[str, List[int], List[str], List[Dict[str, Any]]]]
+# Transformation_t = dict[str, str | list[int] | list[str] | list[Dict[str, Any]]]
 Transformation_t = dict[str, Any]
 
 
 class NgffBaseTransformation(ABC):
     """Base class for all the transformations defined by the NGFF specification."""
 
-    input_coordinate_system: Optional[NgffCoordinateSystem] = None
-    output_coordinate_system: Optional[NgffCoordinateSystem] = None
+    input_coordinate_system: NgffCoordinateSystem | None = None
+    output_coordinate_system: NgffCoordinateSystem | None = None
 
     def __init__(
         self,
-        input_coordinate_system: Optional[NgffCoordinateSystem] = None,
-        output_coordinate_system: Optional[NgffCoordinateSystem] = None,
+        input_coordinate_system: NgffCoordinateSystem | None = None,
+        output_coordinate_system: NgffCoordinateSystem | None = None,
     ) -> None:
         self.input_coordinate_system = input_coordinate_system
         self.output_coordinate_system = output_coordinate_system
@@ -215,7 +215,7 @@ class NgffBaseTransformation(ABC):
         return input_axes, output_axes
 
     @staticmethod
-    def _parse_list_into_array(array: Union[list[Number], list[list[Number]], ArrayLike]) -> ArrayLike:
+    def _parse_list_into_array(array: list[Number] | list[list[Number]] | ArrayLike) -> ArrayLike:
         """Parse a list or numbers, or a list of lists of numbers, into a float numpy array."""
         if isinstance(array, list):
             array = np.array(array)
@@ -284,9 +284,9 @@ class NgffAffine(NgffBaseTransformation):
 
     def __init__(
         self,
-        affine: Union[ArrayLike, list[list[Number]]],
-        input_coordinate_system: Optional[NgffCoordinateSystem] = None,
-        output_coordinate_system: Optional[NgffCoordinateSystem] = None,
+        affine: ArrayLike | list[list[Number]],
+        input_coordinate_system: NgffCoordinateSystem | None = None,
+        output_coordinate_system: NgffCoordinateSystem | None = None,
     ) -> None:
         """
         Init the NgffAffine object.
@@ -394,8 +394,8 @@ class NgffIdentity(NgffBaseTransformation):
 
     def __init__(
         self,
-        input_coordinate_system: Optional[NgffCoordinateSystem] = None,
-        output_coordinate_system: Optional[NgffCoordinateSystem] = None,
+        input_coordinate_system: NgffCoordinateSystem | None = None,
+        output_coordinate_system: NgffCoordinateSystem | None = None,
     ) -> None:
         """
         Init the NgffIdentity object.
@@ -460,8 +460,8 @@ class NgffMapAxis(NgffBaseTransformation):
     def __init__(
         self,
         map_axis: dict[str, str],
-        input_coordinate_system: Optional[NgffCoordinateSystem] = None,
-        output_coordinate_system: Optional[NgffCoordinateSystem] = None,
+        input_coordinate_system: NgffCoordinateSystem | None = None,
+        output_coordinate_system: NgffCoordinateSystem | None = None,
     ) -> None:
         """
         Init the NgffMapAxis object.
@@ -550,9 +550,9 @@ class NgffTranslation(NgffBaseTransformation):
 
     def __init__(
         self,
-        translation: Union[ArrayLike, list[Number]],
-        input_coordinate_system: Optional[NgffCoordinateSystem] = None,
-        output_coordinate_system: Optional[NgffCoordinateSystem] = None,
+        translation: ArrayLike | list[Number],
+        input_coordinate_system: NgffCoordinateSystem | None = None,
+        output_coordinate_system: NgffCoordinateSystem | None = None,
     ) -> None:
         """
         Init the NgffTranslation object.
@@ -601,7 +601,7 @@ class NgffTranslation(NgffBaseTransformation):
         self._validate_transform_points_shapes(len(input_axes), points.shape)
         return points + self.translation
 
-    def to_affine(self, ndims_input: Optional[int] = None, ndims_output: Optional[int] = None) -> NgffAffine:
+    def to_affine(self, ndims_input: int | None = None, ndims_output: int | None = None) -> NgffAffine:
         input_axes, _ = self._get_and_validate_axes()
         matrix = np.eye(len(input_axes) + 1)
         matrix[:-1, -1] = self.translation
@@ -617,9 +617,9 @@ class NgffScale(NgffBaseTransformation):
 
     def __init__(
         self,
-        scale: Union[ArrayLike, list[Number]],
-        input_coordinate_system: Optional[NgffCoordinateSystem] = None,
-        output_coordinate_system: Optional[NgffCoordinateSystem] = None,
+        scale: ArrayLike | list[Number],
+        input_coordinate_system: NgffCoordinateSystem | None = None,
+        output_coordinate_system: NgffCoordinateSystem | None = None,
     ) -> None:
         """
         Init the NgffScale object.
@@ -686,9 +686,9 @@ class NgffRotation(NgffBaseTransformation):
 
     def __init__(
         self,
-        rotation: Union[ArrayLike, list[Number]],
-        input_coordinate_system: Optional[NgffCoordinateSystem] = None,
-        output_coordinate_system: Optional[NgffCoordinateSystem] = None,
+        rotation: ArrayLike | list[Number],
+        input_coordinate_system: NgffCoordinateSystem | None = None,
+        output_coordinate_system: NgffCoordinateSystem | None = None,
     ) -> None:
         """
         Init the NgffRotation object.
@@ -762,8 +762,8 @@ class NgffSequence(NgffBaseTransformation):
     def __init__(
         self,
         transformations: list[NgffBaseTransformation],
-        input_coordinate_system: Optional[NgffCoordinateSystem] = None,
-        output_coordinate_system: Optional[NgffCoordinateSystem] = None,
+        input_coordinate_system: NgffCoordinateSystem | None = None,
+        output_coordinate_system: NgffCoordinateSystem | None = None,
     ) -> None:
         """
         Init the NgffSequence object.
@@ -834,7 +834,7 @@ class NgffSequence(NgffBaseTransformation):
     @staticmethod
     def _inferring_cs_infer_output_coordinate_system(
         t: NgffBaseTransformation,
-    ) -> Optional[NgffCoordinateSystem]:
+    ) -> NgffCoordinateSystem | None:
         """
         One of a series of helper functions to infer the input and output axes of the transformations composing a Sequence NGFF transformation.
 
@@ -865,7 +865,7 @@ class NgffSequence(NgffBaseTransformation):
     @staticmethod
     def _inferring_cs_pre_action(
         t: NgffBaseTransformation, latest_output_cs: NgffCoordinateSystem
-    ) -> tuple[NgffCoordinateSystem, Optional[NgffCoordinateSystem], Optional[NgffCoordinateSystem]]:
+    ) -> tuple[NgffCoordinateSystem, NgffCoordinateSystem | None, NgffCoordinateSystem | None]:
         """See _inferring_cs_infer_output_coordinate_system()"""
         input_cs = t.input_coordinate_system
         if input_cs is None:
@@ -896,8 +896,8 @@ class NgffSequence(NgffBaseTransformation):
     @staticmethod
     def _inferring_cs_post_action(
         t: NgffBaseTransformation,
-        input_cs: Optional[NgffCoordinateSystem],
-        output_cs: Optional[NgffCoordinateSystem],
+        input_cs: NgffCoordinateSystem | None,
+        output_cs: NgffCoordinateSystem | None,
     ) -> None:
         """See _inferring_cs_infer_output_coordinate_system()"""
         # if the transformation t was passed without input or output coordinate systems (and so we had to infer
@@ -960,7 +960,7 @@ class NgffSequence(NgffBaseTransformation):
 #         raise NotImplementedError()
 #
 #     # @property
-#     # def ndim(self) -> Optional[int]:
+#     # def ndim(self) -> int | None:
 #     #     return self._ndim
 #
 #
@@ -969,12 +969,12 @@ class NgffSequence(NgffBaseTransformation):
 #         raise NotImplementedError()
 #
 #     # @property
-#     # def ndim(self) -> Optional[int]:
+#     # def ndim(self) -> int | None:
 #     #     return self._ndim
 #
 #
 # class InverseOf(NgffBaseTransformation):
-#     def __init__(self, transformation: Union[Dict[str, Any], NgffBaseTransformation]) -> None:
+#     def __init__(self, transformation: dict[str, Any] | NgffBaseTransformation) -> None:
 #         if isinstance(transformation, NgffBaseTransformation):
 #             self.transformation = transformation
 #         else:
@@ -982,15 +982,15 @@ class NgffSequence(NgffBaseTransformation):
 #         self._ndim = self.transformation.ndim
 #
 #     @property
-#     def src_dim(self) -> Optional[int]:
+#     def src_dim(self) -> int | None:
 #         return self._ndim
 #
 #     @property
-#     def des_dim(self) -> Optional[int]:
+#     def des_dim(self) -> int | None:
 #         return self._ndim
 #
 #     @property
-#     def ndim(self) -> Optional[int]:
+#     def ndim(self) -> int | None:
 #         # support mixed ndim and remove this property
 #         return self._ndim
 #
@@ -1009,7 +1009,7 @@ class NgffSequence(NgffBaseTransformation):
 #
 # class Bijection(NgffBaseTransformation):
 #     def __init__(
-#         self, forward: Union[Dict[str, Any], NgffBaseTransformation], inverse: Union[Dict[str, Any], NgffBaseTransformation]
+#         self, forward: dict[str, Any] | NgffBaseTransformation, inverse: dict[str, Any] | NgffBaseTransformation
 #     ) -> None:
 #         if isinstance(forward, NgffBaseTransformation):
 #             self.forward = forward
@@ -1024,15 +1024,15 @@ class NgffSequence(NgffBaseTransformation):
 #         self._ndim = self.forward.ndim
 #
 #     @property
-#     def src_dim(self) -> Optional[int]:
+#     def src_dim(self) -> int | None:
 #         return self._ndim
 #
 #     @property
-#     def des_dim(self) -> Optional[int]:
+#     def des_dim(self) -> int | None:
 #         return self._ndim
 #
 #     @property
-#     def ndim(self) -> Optional[int]:
+#     def ndim(self) -> int | None:
 #         return self._ndim
 #
 #     def to_dict(self) -> Transformation_t:
@@ -1053,8 +1053,8 @@ class NgffByDimension(NgffBaseTransformation):
     def __init__(
         self,
         transformations: list[NgffBaseTransformation],
-        input_coordinate_system: Optional[NgffCoordinateSystem] = None,
-        output_coordinate_system: Optional[NgffCoordinateSystem] = None,
+        input_coordinate_system: NgffCoordinateSystem | None = None,
+        output_coordinate_system: NgffCoordinateSystem | None = None,
     ) -> None:
         """
         Init the ByDimension object.

--- a/src/spatialdata/transformations/operations.py
+++ b/src/spatialdata/transformations/operations.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
 import contextlib
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 import networkx as nx
 import numpy as np
@@ -20,10 +18,10 @@ if TYPE_CHECKING:
 
 def set_transformation(
     element: SpatialElement,
-    transformation: Union[BaseTransformation, dict[str, BaseTransformation]],
+    transformation: BaseTransformation | dict[str, BaseTransformation],
     to_coordinate_system: str | None = None,
     set_all: bool = False,
-    write_to_sdata: Optional[SpatialData] = None,
+    write_to_sdata: SpatialData | None = None,
 ) -> None:
     """
     Set a transformation/s to an element, in-memory or to disk.
@@ -90,7 +88,7 @@ def set_transformation(
 
 def get_transformation(
     element: SpatialElement, to_coordinate_system: str | None = None, get_all: bool = False
-) -> Union[BaseTransformation, dict[str, BaseTransformation]]:
+) -> BaseTransformation | dict[str, BaseTransformation]:
     """
     Get the transformation/s of an element.
 
@@ -211,9 +209,9 @@ def _build_transformations_graph(sdata: SpatialData) -> nx.Graph:
 
 def get_transformation_between_coordinate_systems(
     sdata: SpatialData,
-    source_coordinate_system: Union[SpatialElement, str],
-    target_coordinate_system: Union[SpatialElement, str],
-    intermediate_coordinate_systems: Optional[Union[SpatialElement, str]] = None,
+    source_coordinate_system: SpatialElement | str,
+    target_coordinate_system: SpatialElement | str,
+    intermediate_coordinate_systems: SpatialElement | str | None = None,
     shortest_path: bool = True,
 ) -> BaseTransformation:
     """
@@ -247,7 +245,7 @@ def get_transformation_between_coordinate_systems(
     ):
         return Identity()
 
-    def _describe_paths(paths: list[list[Union[int, str]]]) -> str:
+    def _describe_paths(paths: list[list[int | str]]) -> str:
         paths_str = ""
         for p in paths:
             components = []
@@ -266,13 +264,13 @@ def get_transformation_between_coordinate_systems(
         return paths_str
 
     g = _build_transformations_graph(sdata)
-    src_node: Union[int, str]
+    src_node: int | str
     if has_type_spatial_element(source_coordinate_system):
         src_node = id(source_coordinate_system)
     else:
         assert isinstance(source_coordinate_system, str)
         src_node = source_coordinate_system
-    tgt_node: Union[int, str]
+    tgt_node: int | str
     if has_type_spatial_element(target_coordinate_system):
         tgt_node = id(target_coordinate_system)
     else:
@@ -341,8 +339,8 @@ def get_transformation_between_coordinate_systems(
 
 
 def get_transformation_between_landmarks(
-    references_coords: Union[GeoDataFrame, DaskDataFrame],
-    moving_coords: Union[GeoDataFrame, DaskDataFrame],
+    references_coords: GeoDataFrame | DaskDataFrame,
+    moving_coords: GeoDataFrame | DaskDataFrame,
 ) -> Affine:
     """
     Get a similarity transformation between two lists of (n >= 3) landmarks.
@@ -438,14 +436,14 @@ def get_transformation_between_landmarks(
 
 
 def align_elements_using_landmarks(
-    references_coords: Union[GeoDataFrame | DaskDataFrame],
-    moving_coords: Union[GeoDataFrame | DaskDataFrame],
+    references_coords: GeoDataFrame | DaskDataFrame,
+    moving_coords: GeoDataFrame | DaskDataFrame,
     reference_element: SpatialElement,
     moving_element: SpatialElement,
     reference_coordinate_system: str = "global",
     moving_coordinate_system: str = "global",
     new_coordinate_system: str | None = None,
-    write_to_sdata: Optional[SpatialData] = None,
+    write_to_sdata: SpatialData | None = None,
 ) -> BaseTransformation:
     """
     Maps a moving object into a reference object using two lists of (n >= 3) landmarks.

--- a/src/spatialdata/transformations/transformations.py
+++ b/src/spatialdata/transformations/transformations.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 from warnings import warn
 
 import numpy as np
@@ -10,10 +10,7 @@ import xarray as xr
 from xarray import DataArray
 
 from spatialdata._types import ArrayLike
-from spatialdata.transformations.ngff.ngff_coordinate_system import (
-    NgffCoordinateSystem,
-    _get_spatial_axes,
-)
+from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem, _get_spatial_axes
 from spatialdata.transformations.ngff.ngff_transformations import (
     NgffAffine,
     NgffBaseTransformation,
@@ -96,9 +93,7 @@ class BaseTransformation(ABC):
         name: str | None = None,
         default_to_global: bool = False,
     ) -> NgffCoordinateSystem:
-        from spatialdata.transformations.ngff._utils import (
-            get_default_coordinate_system,
-        )
+        from spatialdata.transformations.ngff._utils import get_default_coordinate_system
 
         cs = get_default_coordinate_system(axes)
         if unit is not None:
@@ -130,7 +125,7 @@ class BaseTransformation(ABC):
         return Affine(affine_matrix, input_axes, output_axes)
 
     # order of the composition: self is applied first, then the transformation passed as argument
-    def compose_with(self, transformations: Union[BaseTransformation, list[BaseTransformation]]) -> BaseTransformation:
+    def compose_with(self, transformations: BaseTransformation | list[BaseTransformation]) -> BaseTransformation:
         if isinstance(transformations, BaseTransformation):
             return Sequence([self, transformations])
         else:
@@ -169,7 +164,7 @@ class BaseTransformation(ABC):
             raise ValueError(f"Invalid axes: {axes}")
 
     @staticmethod
-    def _xarray_coords_filter_axes(data: DataArray, axes: Optional[tuple[ValidAxis_t, ...]] = None) -> DataArray:
+    def _xarray_coords_filter_axes(data: DataArray, axes: tuple[ValidAxis_t, ...] | None = None) -> DataArray:
         if axes is None:
             axes = ("x", "y", "z")
         return data[:, data["dim"].isin(axes)]
@@ -346,7 +341,7 @@ class MapAxis(BaseTransformation):
 
 
 class Translation(BaseTransformation):
-    def __init__(self, translation: Union[list[Number], ArrayLike], axes: tuple[ValidAxis_t, ...]) -> None:
+    def __init__(self, translation: list[Number] | ArrayLike, axes: tuple[ValidAxis_t, ...]) -> None:
         from spatialdata._utils import _parse_list_into_array
 
         self.translation = _parse_list_into_array(translation)
@@ -433,7 +428,7 @@ class Translation(BaseTransformation):
 
 
 class Scale(BaseTransformation):
-    def __init__(self, scale: Union[list[Number], ArrayLike], axes: tuple[ValidAxis_t, ...]) -> None:
+    def __init__(self, scale: list[Number] | ArrayLike, axes: tuple[ValidAxis_t, ...]) -> None:
         from spatialdata._utils import _parse_list_into_array
 
         self.scale = _parse_list_into_array(scale)
@@ -514,7 +509,7 @@ class Scale(BaseTransformation):
 class Affine(BaseTransformation):
     def __init__(
         self,
-        matrix: Union[list[Number], ArrayLike],
+        matrix: list[Number] | ArrayLike,
         input_axes: tuple[ValidAxis_t, ...],
         output_axes: tuple[ValidAxis_t, ...],
     ) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import dask
 
 dask.config.set({"dataframe.query-planning": False})

--- a/tests/core/operations/test_rasterize.py
+++ b/tests/core/operations/test_rasterize.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd

--- a/tests/core/operations/test_rasterize_bins.py
+++ b/tests/core/operations/test_rasterize_bins.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import re
 

--- a/tests/core/operations/test_spatialdata_operations.py
+++ b/tests/core/operations/test_spatialdata_operations.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 
 import numpy as np
@@ -13,22 +11,9 @@ from spatialdata._core.operations._utils import transform_to_data_extent
 from spatialdata._core.spatialdata import SpatialData
 from spatialdata._types import ArrayLike
 from spatialdata.datasets import blobs
-from spatialdata.models import (
-    Image2DModel,
-    Labels2DModel,
-    PointsModel,
-    ShapesModel,
-    TableModel,
-    get_table_keys,
-)
-from spatialdata.testing import (
-    assert_elements_dict_are_identical,
-    assert_spatial_data_objects_are_identical,
-)
-from spatialdata.transformations.operations import (
-    get_transformation,
-    set_transformation,
-)
+from spatialdata.models import Image2DModel, Labels2DModel, PointsModel, ShapesModel, TableModel, get_table_keys
+from spatialdata.testing import assert_elements_dict_are_identical, assert_spatial_data_objects_are_identical
+from spatialdata.transformations.operations import get_transformation, set_transformation
 from spatialdata.transformations.transformations import (
     Affine,
     BaseTransformation,

--- a/tests/dataloader/__init__.py
+++ b/tests/dataloader/__init__.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 try:
     from spatialdata.dataloader.datasets import ImageTilesDataset
 except ImportError as e:

--- a/tests/io/test_partial_read.py
+++ b/tests/io/test_partial_read.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import os
 import re

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import re
 import tempfile
@@ -49,13 +47,8 @@ from spatialdata.models.models import (
     get_model,
 )
 from spatialdata.testing import assert_elements_are_identical
-from spatialdata.transformations._utils import (
-    _set_transformations,
-)
-from spatialdata.transformations.operations import (
-    get_transformation,
-    set_transformation,
-)
+from spatialdata.transformations._utils import _set_transformations
+from spatialdata.transformations.operations import get_transformation, set_transformation
 from spatialdata.transformations.transformations import Identity, Scale
 from tests.conftest import (
     MULTIPOLYGON_PATH,

--- a/tests/utils/test_sanitize.py
+++ b/tests/utils/test_sanitize.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import numpy as np
 import pandas as pd
 import pytest


### PR DESCRIPTION
Since `spatialdata` requires `python>=3.10`, we can remove most of the `from __future__ import annotations`, and also remove all the old typings such as `Union` or `Optional`

This PR is low priority, as it's just a cleanup