### PR TITLE
Fix compatibility pre-0.1 spatialdata store

### DIFF
--- a/src/spatialdata/_io/io_zarr.py
+++ b/src/spatialdata/_io/io_zarr.py
@@ -157,7 +157,7 @@ def read_zarr(
     # the following is the SpatialDataContainerFormat version
     if "spatialdata_attrs" not in root_group.metadata.attributes:
         # backward compatibility for pre-versioned SpatialData zarr stores
-        sdata_version = "0.1"
+        sdata_version = cast(Literal["0.1", "0.2"], "0.1")
     else:
         sdata_version = root_group.metadata.attributes["spatialdata_attrs"]["version"]
     if sdata_version == "0.1":


### PR DESCRIPTION
Old `spatialdata` stores (e.g. the `mouse_liver` dataset [from spatialdata-sandbox](https://github.com/giovp/spatialdata-sandbox/tree/main/mouse_liver)), didn't use versioning for the spatialdata container. Still, the reading is equivalent to `SpatialDataContainerFormatV01`. 

This PR fixes this.