### PR TITLE
Lazy load torch

### DIFF
--- a/src/spatialdata/dataloader/__init__.py
+++ b/src/spatialdata/dataloader/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 import spatialdata


### PR DESCRIPTION
If `torch` is installed, importing spatialdata will also import `torch` because of `ImageTilesDataset`.

This PR aims to speed up the import by making the import of torch lazy.

It's a little bit tricky to keep all the dosctrings + auto-completion. For now, it seems the auto-completion is working fine for the instances, but not the `__init__` docstrings.

If you think this PR seems interesting, I can work on fixing the docstrings, else we can just close it