### PR TITLE
Exclude 1.17.0 for issue anndata 339

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "shapely>=2.0.1",
     "spatial_image>=1.2.3",
     "scikit-image",
-    "scipy",
+    "scipy!=1.7.0",
     "typing_extensions>=4.8.0",
     "universal_pathlib>=0.2.6",
     "xarray>=2024.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "shapely>=2.0.1",
     "spatial_image>=1.2.3",
     "scikit-image",
-    "scipy!=1.7.0",
+    "scipy!=1.17.0",
     "typing_extensions>=4.8.0",
     "universal_pathlib>=0.2.6",
     "xarray>=2024.10.0",


### PR DESCRIPTION
Patch for https://github.com/scverse/anndata/issues/339 so a release is not blocked. It will be relaxed once fixed upstream.