### PR TITLE
Pins `distributed`; better categorical handing for points parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "click",
     "dask-image",
     "dask>=2025.2.0,<2026.1.2",
+    "distributed<2026.1.2",
     "datashader",
     "fsspec[s3,http]",
     "geopandas>=0.14",


### PR DESCRIPTION
## Minor change
The latest `dask` `distributed` cannot be used with the second latest `dask` (the latest `dask` is not supported because it's not supported in `ome-zarr-py`). This PR adds an upper bound.

## Main change
Improves performance of points parsing by eliminating superfluous conversions to `categorical` for columns that are not the `feature_key` column. Also warns the user that converting a column to categorical prior to parsing (by preserving the known status of the categories), improves performance. 

Tested with Xenium data (performance of point parsing improves ~20x for ~100 million transcripts): [<link to spatialdata-io PR to be added>](https://github.com/scverse/spatialdata-io/pull/363).