### PR TITLE
Fix for `FutureWarning: functools.partial ...`

### DIFF
--- a/src/spatialdata/_core/query/relational_query.py
+++ b/src/spatialdata/_core/query/relational_query.py
@@ -2,7 +2,7 @@ import math
 import warnings
 from collections import defaultdict
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, member
 from functools import partial, singledispatch
 from typing import Any, Literal
 
@@ -528,11 +528,11 @@ def _match_rows(
 class JoinTypes(Enum):
     """Available join types for matching elements to tables and vice versa."""
 
-    left = partial(_left_join_spatialelement_table)
-    left_exclusive = partial(_left_exclusive_join_spatialelement_table)
-    inner = partial(_inner_join_spatialelement_table)
-    right = partial(_right_join_spatialelement_table)
-    right_exclusive = partial(_right_exclusive_join_spatialelement_table)
+    left = member(partial(_left_join_spatialelement_table))
+    left_exclusive = member(partial(_left_exclusive_join_spatialelement_table))
+    inner = member(partial(_inner_join_spatialelement_table))
+    right = member(partial(_right_join_spatialelement_table))
+    right_exclusive = member(partial(_right_exclusive_join_spatialelement_table))
 
     def __call__(self, *args: Any) -> tuple[dict[str, Any], AnnData]:
         return self.value(*args)


### PR DESCRIPTION
This is a minimal fix doing exactly what the warnings says and is backward compat. Here is an example of how the warnings look:
```
.venv/lib/python3.13/site-packages/spatialdata/_core/query/relational_query.py:532
  /Users/selman/projects/squidpy/.venv/lib/python3.13/site-packages/spatialdata/_core/query/relational_query.py:532: FutureWarning: functools.partial will be a method descriptor in future Python versions; wrap it in enum.member() if you want to preserve the old behavior
    left_exclusive = partial(_left_exclusive_join_spatialelement_table)

.venv/lib/python3.13/site-packages/spatialdata/_core/query/relational_query.py:533
  /Users/selman/projects/squidpy/.venv/lib/python3.13/site-packages/spatialdata/_core/query/relational_query.py:533: FutureWarning: functools.partial will be a method descriptor in future Python versions; wrap it in enum.member() if you want to preserve the old behavior
    inner = partial(_inner_join_spatialelement_table)

.venv/lib/python3.13/site-packages/spatialdata/_core/query/relational_query.py:534
  /Users/selman/projects/squidpy/.venv/lib/python3.13/site-packages/spatialdata/_core/query/relational_query.py:534: FutureWarning: functools.partial will be a method descriptor in future Python versions; wrap it in enum.member() if you want to preserve the old behavior
    right = partial(_right_join_spatialelement_table)

.venv/lib/python3.13/site-packages/spatialdata/_core/query/relational_query.py:535
  /Users/selman/projects/squidpy/.venv/lib/python3.13/site-packages/spatialdata/_core/query/relational_query.py:535: FutureWarning: functools.partial will be a method descriptor in future Python versions; wrap it in enum.member() if you want to preserve the old behavior
    right_exclusive = partial(_right_exclusive_join_spatialelement_table)

```
ping: @LucaMarconato 