### PR TITLE
Fix transform graph

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - {os: windows-latest, python: "3.11", dask-version: "2025.2.0", name: "Dask 2025.2.0"}
+                    - {os: windows-latest, python: "3.11", dask-version: "2025.12.0", name: "Dask 2025.12.0"}
                     - {os: windows-latest, python: "3.13", dask-version: "latest", name: "Dask latest"}
                     - {os: ubuntu-latest, python: "3.11", dask-version: "latest", name: "Dask latest"}
                     - {os: ubuntu-latest, python: "3.13", dask-version: "latest", name: "Dask latest"}

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,22 @@ SpatialData is a data framework that comprises a FAIR storage format and a colle
 
 Please see our publication {cite}`marconatoSpatialDataOpenUniversal2024` for citation and to learn more.
 
+:::{note}
+With dask >= 2025.2.0, users can get an error as described in [#1077](https://github.com/scverse/spatialdata/issues/1064). While we tried implementing fixes in SpatialData, it can be that
+users perform operations on the `Points` data themselves and get this error. In order to prevent it, users can use a context manager we created.
+
+```python
+from spatialdata import disable_dask_tune_optimization
+import contextlib
+...
+
+with disable_dask_tune_optimization() if data.npartitions > 1 else contextlib.nullcontext():
+    <your operation on points dask dataframe>
+```
+
+This will disable dask graph optimization if the dataframe has more than 1 partition and otherwise keep it enabled.
+:::
+
 [//]: # "numfocus-fiscal-sponsor-attribution"
 
 spatialdata is part of the scverse® project ([website](https://scverse.org), [governance](https://scverse.org/about/roles)) and is fiscally sponsored by [NumFOCUS](https://numfocus.org/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,8 @@ with disable_dask_tune_optimization() if data.npartitions > 1 else contextlib.nu
     <your operation on points dask dataframe>
 ```
 
-This will disable dask graph optimization if the dataframe has more than 1 partition and otherwise keep it enabled.
+This will disable dask graph optimization if the dataframe has more than 1 partition and otherwise keep it enabled. This solves
+the problem discussed in this [dask issue](https://github.com/dask/dask/issues/12193). We are looking into an upstream fix.
 :::
 
 [//]: # "numfocus-fiscal-sponsor-attribution"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "annsel>=0.1.2",
     "click",
     "dask-image",
-    "dask>=2025.2.0,<2026.1.2",
+    "dask>=2025.12.0,<2026.1.2",
     "distributed<2026.1.2",
     "datashader",
     "fsspec[s3,http]",

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "transformations",
     "datasets",
     "dataloader",
+    "disable_dask_tune_optimization",
     "concatenate",
     "rasterize",
     "rasterize_bins",
@@ -72,5 +73,5 @@ from spatialdata._core.spatialdata import SpatialData
 from spatialdata._io._utils import get_dask_backing_files
 from spatialdata._io.format import SpatialDataFormatType
 from spatialdata._io.io_zarr import read_zarr
-from spatialdata._utils import get_pyramid_levels, unpad_raster
+from spatialdata._utils import disable_dask_tune_optimization, get_pyramid_levels, unpad_raster
 from spatialdata.config import settings

--- a/tests/core/operations/test_transform.py
+++ b/tests/core/operations/test_transform.py
@@ -586,6 +586,21 @@ def test_transform_elements_and_entire_spatial_data_object(full_sdata: SpatialDa
     _ = full_sdata.transform_to_coordinate_system("my_space", maintain_positioning=maintain_positioning)
 
 
+def test_transform_points_with_multiple_partitions(full_sdata: SpatialData, tmp_path: str):
+    tmpdir = Path(tmp_path) / "tmp.zarr"
+    full_sdata["points_0"] = PointsModel.parse(
+        full_sdata["points_0"].repartition(npartitions=4),
+        transformations={"global": get_transformation(full_sdata["points_0"])},
+    )
+
+    full_sdata.write(tmpdir)
+
+    full_sdata = SpatialData.read(tmpdir)
+
+    # This just needs to run without error
+    transform(full_sdata["points_0"], to_coordinate_system="global")
+
+
 @pytest.mark.parametrize("maintain_positioning", [True, False])
 def test_transform_elements_and_entire_spatial_data_object_multi_hop(
     full_sdata: SpatialData, maintain_positioning: bool

--- a/tests/core/operations/test_transform.py
+++ b/tests/core/operations/test_transform.py
@@ -590,17 +590,22 @@ def test_transform_elements_and_entire_spatial_data_object(full_sdata: SpatialDa
 
 def test_transform_points_with_multiple_partitions(full_sdata: SpatialData, tmp_path: str):
     tmpdir = Path(tmp_path) / "tmp.zarr"
+    points_memory = full_sdata["points_0"].compute()
     full_sdata["points_0"] = PointsModel.parse(
         full_sdata["points_0"].repartition(npartitions=4),
         transformations={"global": get_transformation(full_sdata["points_0"])},
     )
+    assert points_memory.equals(full_sdata["points_0"].compute())
 
     full_sdata.write(tmpdir)
 
     full_sdata = SpatialData.read(tmpdir)
 
     # This just needs to run without error
-    transform(full_sdata["points_0"], to_coordinate_system="global")
+    data = transform(full_sdata["points_0"], to_coordinate_system="global")
+
+    # test that data still can be computed
+    data.compute()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1064 
Closes https://github.com/scverse/napari-spatialdata/issues/388

This PR fixes the problem of transforming points data where the dask dataframe has multiple partitions. This particular problem occured when writing a multipartition dataframe to parquet, reading it back in with SpatialData and then transforming the data. 
The problem occured due to a partition collaps when dask expr (dask >2025.0.0) optimizes the dask graph. This specific problem is prevented in transforms by explicitly passing the current partition lengths. However, this leads to a missing dependency problem in the dask graph that is prevented by setting the dask optimization to False when performing specific operations. 