### PR TITLE
Preserve attrs on Dask DataFrame sample()

### DIFF
--- a/src/spatialdata/models/_accessor.py
+++ b/src/spatialdata/models/_accessor.py
@@ -124,6 +124,7 @@ for method_name in [
     "copy",
     "drop",
     "map_partitions",
+    "sample",
     "set_index",
 ]:
     wrap_method_with_attrs(method_name=method_name, dask_class=DaskDataFrame)

--- a/tests/models/test_accessor.py
+++ b/tests/models/test_accessor.py
@@ -130,6 +130,15 @@ def test_dataframe_set_index_preserves_attrs():
     assert isinstance(result.attrs, AttrsAccessor)
 
 
+def test_dataframe_sample_preserves_attrs():
+    """Test that DataFrame.sample preserves attrs."""
+    df = dd.from_pandas(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}), npartitions=2)
+    df.attrs["key"] = "value"
+    result = df.sample(frac=0.5)
+    assert result.attrs["key"] == "value"
+    assert isinstance(result.attrs, AttrsAccessor)
+
+
 # ============================================================================
 # Series wrapped methods tests
 # ============================================================================


### PR DESCRIPTION
## Description

`DaskDataFrame.sample()` does not preserve `.attrs` metadata, unlike other wrapped methods (`__getitem__`, `compute`, `copy`, `drop`, `map_partitions`, `set_index`).

This adds `"sample"` to the list of methods wrapped by `wrap_method_with_attrs` in `_accessor.py`, so that `.attrs` is carried through after calling `.sample()`.

## Changes

- Add `"sample"` to the wrapped methods list for `DaskDataFrame` in `src/spatialdata/models/_accessor.py`
- Add `test_dataframe_sample_preserves_attrs` test following the existing test pattern

## Test plan

- [x] `pytest tests/models/test_accessor.py` — all 20 tests pass (including new test)