### PR TITLE
fix: don't lower bound `anndata` so high

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic= [
 license = {file = "LICENSE"}
 readme = "README.md"
 dependencies = [
-    "anndata>=0.12.10",
+    "anndata>=0.9.1",
     "annsel>=0.1.2",
     "click",
     "dask-image",


### PR DESCRIPTION
Why was this done in #1083 when the outcome of https://github.com/conda-forge/spatialdata-io-feedstock/issues/14 was "this is an issue with conda dependency resolution"?

For example, releasing this change would immediately make you incompatible with anyone upper bounding anndata, of which there may be a few: https://github.com/search?q=%22anndata%3C0%22&type=code

Is there some other reason to lower bound this?