### PR TITLE
Fix write validation against empty transformations

### DIFF
--- a/docs/api/models_utils.md
+++ b/docs/api/models_utils.md
@@ -4,6 +4,7 @@
 .. currentmodule:: spatialdata.models
 
 .. autofunction:: get_model
+.. autofunction:: validate_element
 .. autodata:: SpatialElement
 .. autofunction:: get_axes_names
 .. autofunction:: get_spatial_axes

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -1225,6 +1225,11 @@ class SpatialData:
         if parsed_formats is None:
             parsed_formats = _parse_formats(formats=parsed_formats)
 
+        if element_type != "tables":
+            from spatialdata.models.models import get_model
+
+            get_model(element)
+
         if element_type == "images":
             write_image(
                 image=element,

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -1226,9 +1226,9 @@ class SpatialData:
             parsed_formats = _parse_formats(formats=parsed_formats)
 
         if element_type != "tables":
-            from spatialdata.models.models import get_model
+            from spatialdata.models import validate_element
 
-            get_model(element)
+            validate_element(element)
 
         if element_type == "images":
             write_image(

--- a/src/spatialdata/_io/io_points.py
+++ b/src/spatialdata/_io/io_points.py
@@ -67,7 +67,7 @@ def write_points(
     """
     axes = get_axes_names(points)
     transformations = _get_transformations(points)
-    assert transformations is not None
+    assert transformations is not None  # mypy: validate_element() in _write_element guarantees this
 
     store_root = group.store_path.store.root
     path = store_root / group.path / "points.parquet"

--- a/src/spatialdata/_io/io_points.py
+++ b/src/spatialdata/_io/io_points.py
@@ -95,6 +95,6 @@ def write_points(
         axes=list(axes),
         attrs=attrs,
     )
-    if transformations is None:
-        raise ValueError(f"No transformations specified for element '{group.basename}'. Cannot write.")
+    if not transformations:
+        raise ValueError(f"{group.basename} does not have any transformations and can therefore not be written.")
     overwrite_coordinate_transformations_non_raster(group=group, axes=axes, transformations=transformations)

--- a/src/spatialdata/_io/io_points.py
+++ b/src/spatialdata/_io/io_points.py
@@ -67,6 +67,7 @@ def write_points(
     """
     axes = get_axes_names(points)
     transformations = _get_transformations(points)
+    assert transformations is not None
 
     store_root = group.store_path.store.root
     path = store_root / group.path / "points.parquet"
@@ -95,6 +96,4 @@ def write_points(
         axes=list(axes),
         attrs=attrs,
     )
-    if not transformations:
-        raise ValueError(f"{group.basename} does not have any transformations and can therefore not be written.")
     overwrite_coordinate_transformations_non_raster(group=group, axes=axes, transformations=transformations)

--- a/src/spatialdata/_io/io_raster.py
+++ b/src/spatialdata/_io/io_raster.py
@@ -369,7 +369,7 @@ def _write_raster_dataarray(
 
     data = raster_data.data
     transformations = _get_transformations(raster_data)
-    assert transformations is not None
+    assert transformations is not None  # mypy: validate_element() in _write_element guarantees this
     input_axes: tuple[str, ...] = tuple(raster_data.dims)
     parsed_axes = _get_valid_axes(axes=list(input_axes), fmt=raster_format)
     storage_options = _prepare_storage_options(storage_options)
@@ -438,7 +438,7 @@ def _write_raster_datatree(
     assert len(d) == 1
     xdata = d.values().__iter__().__next__()
     transformations = _get_transformations_xarray(xdata)
-    assert transformations is not None
+    assert transformations is not None  # mypy: validate_element() in _write_element guarantees this
 
     parsed_axes = _get_valid_axes(axes=list(input_axes), fmt=raster_format)
     storage_options = _prepare_storage_options(storage_options)

--- a/src/spatialdata/_io/io_raster.py
+++ b/src/spatialdata/_io/io_raster.py
@@ -369,7 +369,7 @@ def _write_raster_dataarray(
 
     data = raster_data.data
     transformations = _get_transformations(raster_data)
-    if transformations is None:
+    if not transformations:
         raise ValueError(f"{element_name} does not have any transformations and can therefore not be written.")
     input_axes: tuple[str, ...] = tuple(raster_data.dims)
     parsed_axes = _get_valid_axes(axes=list(input_axes), fmt=raster_format)
@@ -439,7 +439,7 @@ def _write_raster_datatree(
     assert len(d) == 1
     xdata = d.values().__iter__().__next__()
     transformations = _get_transformations_xarray(xdata)
-    if transformations is None:
+    if not transformations:
         raise ValueError(f"{element_name} does not have any transformations and can therefore not be written.")
 
     parsed_axes = _get_valid_axes(axes=list(input_axes), fmt=raster_format)

--- a/src/spatialdata/_io/io_raster.py
+++ b/src/spatialdata/_io/io_raster.py
@@ -369,8 +369,7 @@ def _write_raster_dataarray(
 
     data = raster_data.data
     transformations = _get_transformations(raster_data)
-    if not transformations:
-        raise ValueError(f"{element_name} does not have any transformations and can therefore not be written.")
+    assert transformations is not None
     input_axes: tuple[str, ...] = tuple(raster_data.dims)
     parsed_axes = _get_valid_axes(axes=list(input_axes), fmt=raster_format)
     storage_options = _prepare_storage_options(storage_options)
@@ -439,8 +438,7 @@ def _write_raster_datatree(
     assert len(d) == 1
     xdata = d.values().__iter__().__next__()
     transformations = _get_transformations_xarray(xdata)
-    if not transformations:
-        raise ValueError(f"{element_name} does not have any transformations and can therefore not be written.")
+    assert transformations is not None
 
     parsed_axes = _get_valid_axes(axes=list(input_axes), fmt=raster_format)
     storage_options = _prepare_storage_options(storage_options)

--- a/src/spatialdata/_io/io_shapes.py
+++ b/src/spatialdata/_io/io_shapes.py
@@ -100,7 +100,7 @@ def write_shapes(
 
     axes = get_axes_names(shapes)
     transformations = _get_transformations(shapes)
-    assert transformations is not None
+    assert transformations is not None  # mypy: validate_element() in _write_element guarantees this
     if isinstance(element_format, ShapesFormatV01):
         attrs = _write_shapes_v01(shapes, group, element_format)
     elif isinstance(element_format, ShapesFormatV02 | ShapesFormatV03):

--- a/src/spatialdata/_io/io_shapes.py
+++ b/src/spatialdata/_io/io_shapes.py
@@ -100,7 +100,7 @@ def write_shapes(
 
     axes = get_axes_names(shapes)
     transformations = _get_transformations(shapes)
-    if transformations is None:
+    if not transformations:
         raise ValueError(f"{group.basename} does not have any transformations and can therefore not be written.")
     if isinstance(element_format, ShapesFormatV01):
         attrs = _write_shapes_v01(shapes, group, element_format)

--- a/src/spatialdata/_io/io_shapes.py
+++ b/src/spatialdata/_io/io_shapes.py
@@ -100,8 +100,7 @@ def write_shapes(
 
     axes = get_axes_names(shapes)
     transformations = _get_transformations(shapes)
-    if not transformations:
-        raise ValueError(f"{group.basename} does not have any transformations and can therefore not be written.")
+    assert transformations is not None
     if isinstance(element_format, ShapesFormatV01):
         attrs = _write_shapes_v01(shapes, group, element_format)
     elif isinstance(element_format, ShapesFormatV02 | ShapesFormatV03):

--- a/src/spatialdata/models/__init__.py
+++ b/src/spatialdata/models/__init__.py
@@ -27,6 +27,7 @@ from spatialdata.models.models import (
     TableModel,
     get_model,
     get_table_keys,
+    validate_element,
 )
 
 __all__ = [
@@ -51,6 +52,7 @@ __all__ = [
     "points_dask_dataframe_to_geopandas",
     "check_target_region_column_symmetry",
     "get_table_keys",
+    "validate_element",
     "get_channel_names",
     "set_channel_names",
     "force_2d",

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -342,7 +342,7 @@ class RasterSchema:
     @classmethod
     def _check_transforms_present(cls, data: DataArray | DataTree) -> None:
         parsed_transform = _get_transformations(data)
-        if parsed_transform is None:
+        if not parsed_transform:
             raise ValueError(
                 f"No transformation found for `{data}`. At least one transformation is required for "
                 f"raster elements, e.g. images, labels."
@@ -477,7 +477,7 @@ class ShapesModel:
                     "please see https://github.com/scverse/spatialdata/discussions/657 for a solution. Otherwise, "
                     "please correct the radii of the circles before calling the parser function.",
                 )
-        if cls.TRANSFORM_KEY not in data.attrs:
+        if not data.attrs.get(cls.TRANSFORM_KEY):
             raise ValueError(f":class:`geopandas.GeoDataFrame` does not contain `{TRANSFORM_KEY}`." + SUGGESTION)
         if len(data) > 0:
             n = data.geometry.iloc[0]._ndim
@@ -668,7 +668,7 @@ class PointsModel:
                 np.int64,
             ]:
                 raise ValueError(f"Column `{ax}` must be of type `int` or `float`.")
-        if cls.TRANSFORM_KEY not in data.attrs:
+        if not data.attrs.get(cls.TRANSFORM_KEY):
             raise ValueError(
                 f":attr:`dask.dataframe.core.DataFrame.attrs` does not contain `{cls.TRANSFORM_KEY}`." + SUGGESTION
             )

--- a/src/spatialdata/models/models.py
+++ b/src/spatialdata/models/models.py
@@ -342,9 +342,14 @@ class RasterSchema:
     @classmethod
     def _check_transforms_present(cls, data: DataArray | DataTree) -> None:
         parsed_transform = _get_transformations(data)
-        if not parsed_transform:
+        if parsed_transform is None:
             raise ValueError(
                 f"No transformation found for `{data}`. At least one transformation is required for "
+                f"raster elements, e.g. images, labels."
+            )
+        if len(parsed_transform) == 0:
+            raise ValueError(
+                f"The transformations dict for `{data}` is empty. At least one transformation is required for "
                 f"raster elements, e.g. images, labels."
             )
 
@@ -477,8 +482,13 @@ class ShapesModel:
                     "please see https://github.com/scverse/spatialdata/discussions/657 for a solution. Otherwise, "
                     "please correct the radii of the circles before calling the parser function.",
                 )
-        if not data.attrs.get(cls.TRANSFORM_KEY):
+        if cls.TRANSFORM_KEY not in data.attrs:
             raise ValueError(f":class:`geopandas.GeoDataFrame` does not contain `{TRANSFORM_KEY}`." + SUGGESTION)
+        if not data.attrs[cls.TRANSFORM_KEY]:
+            raise ValueError(
+                f":class:`geopandas.GeoDataFrame` has an empty `{TRANSFORM_KEY}` dict. "
+                f"At least one transformation is required." + SUGGESTION
+            )
         if len(data) > 0:
             n = data.geometry.iloc[0]._ndim
             if n != 2:
@@ -668,9 +678,14 @@ class PointsModel:
                 np.int64,
             ]:
                 raise ValueError(f"Column `{ax}` must be of type `int` or `float`.")
-        if not data.attrs.get(cls.TRANSFORM_KEY):
+        if cls.TRANSFORM_KEY not in data.attrs:
             raise ValueError(
                 f":attr:`dask.dataframe.core.DataFrame.attrs` does not contain `{cls.TRANSFORM_KEY}`." + SUGGESTION
+            )
+        if not data.attrs[cls.TRANSFORM_KEY]:
+            raise ValueError(
+                f":attr:`dask.dataframe.core.DataFrame.attrs` has an empty `{cls.TRANSFORM_KEY}` dict. "
+                f"At least one transformation is required." + SUGGESTION
             )
         if ATTRS_KEY in data.attrs and "feature_key" in data.attrs[ATTRS_KEY]:
             feature_key = data.attrs[ATTRS_KEY][cls.FEATURE_KEY]
@@ -1291,6 +1306,23 @@ def get_model(
     if isinstance(e, AnnData):
         return _validate_and_return(TableModel, e)
     raise TypeError(f"Unsupported type {type(e)}")
+
+
+def validate_element(e: SpatialElement) -> None:
+    """
+    Validate a spatial element against its model schema.
+
+    Parameters
+    ----------
+    e
+        The spatial element to validate.
+
+    Raises
+    ------
+    ValueError
+        If the element is invalid (e.g. missing or empty transformations, wrong dtypes).
+    """
+    get_model(e, validate=True)
 
 
 def get_table_keys(table: AnnData) -> tuple[str | list[str], str, str]:

--- a/tests/core/operations/test_transform.py
+++ b/tests/core/operations/test_transform.py
@@ -812,14 +812,13 @@ def test_transform_until_0_0_15(points):
 def test_write_fails_after_removing_all_transformations(
     full_sdata: SpatialData, tmp_path: Path, element_fixture: str, kwargs: dict
 ) -> None:
-    """Writing an element whose transformations have all been removed should raise a ValueError."""
-    element = full_sdata[element_fixture]
-    remove_transformation(element, remove_all=True)
-
-    # Build a minimal SpatialData with only this element and write it to a fresh location
+    """Writing should fail when all transformations are removed from an element already in a SpatialData."""
+    # Build a valid SpatialData first (passes __setitem__ validation)
     container_key = next(iter(kwargs))
-    sdata = SpatialData(**{container_key: {element_fixture: element}})
-    tmpdir = tmp_path / "sdata.zarr"
+    sdata = SpatialData(**{container_key: {element_fixture: full_sdata[element_fixture]}})
 
-    with pytest.raises(ValueError, match="does not have any transformations"):
-        sdata.write(tmpdir)
+    # Mutate in-place after construction, bypassing __setitem__ validation
+    remove_transformation(sdata[element_fixture], remove_all=True)
+
+    with pytest.raises(ValueError, match="transform"):
+        sdata.write(tmp_path / "sdata.zarr")

--- a/tests/core/operations/test_transform.py
+++ b/tests/core/operations/test_transform.py
@@ -796,3 +796,30 @@ def test_transform_until_0_0_15(points):
 
     transform(points, transformation=t0, maintain_positioning=True)
     transform(points, to_coordinate_system="global", maintain_positioning=True)
+
+
+@pytest.mark.parametrize(
+    "element_fixture,kwargs",
+    [
+        ("image2d", {"images": {}}),
+        ("image2d_multiscale", {"images": {}}),
+        ("labels2d", {"labels": {}}),
+        ("labels2d_multiscale", {"labels": {}}),
+        ("circles", {"shapes": {}}),
+        ("points_0", {"points": {}}),
+    ],
+)
+def test_write_fails_after_removing_all_transformations(
+    full_sdata: SpatialData, tmp_path: Path, element_fixture: str, kwargs: dict
+) -> None:
+    """Writing an element whose transformations have all been removed should raise a ValueError."""
+    element = full_sdata[element_fixture]
+    remove_transformation(element, remove_all=True)
+
+    # Build a minimal SpatialData with only this element and write it to a fresh location
+    container_key = next(iter(kwargs))
+    sdata = SpatialData(**{container_key: {element_fixture: element}})
+    tmpdir = tmp_path / "sdata.zarr"
+
+    with pytest.raises(ValueError, match="does not have any transformations"):
+        sdata.write(tmpdir)


### PR DESCRIPTION
The parsers add transformations to empty elements, but after parsing, if a user calls `remove_transformation(element, remove_all=True)`, the transformations dict is set to {} rather than None, bypassing the is-None guard in all three IO writers.

The fix is general: we now call the validators before writing, and we check the presence of transformations in the validator.