### PR TITLE
Fix adata layers None after anndata X unification

### DIFF
--- a/src/spatialdata/_core/validation.py
+++ b/src/spatialdata/_core/validation.py
@@ -150,6 +150,8 @@ def check_all_keys_case_insensitively_unique(keys: Collection[str], location: tu
         exc_type=ValueError,
     ) as collect_error:
         for key in keys:
+            if key is None:
+                continue
             normalized_key = key.lower()
             with collect_error(location=location + (key,)):
                 check_key_is_case_insensitively_unique(key, seen)
@@ -247,6 +249,8 @@ def validate_table_attr_keys(data: AnnData, location: tuple[str, ...] = ()) -> N
             with collect_error(location=attr_path):
                 check_all_keys_case_insensitively_unique(getattr(data, attr).keys(), location=attr_path)
             for key in getattr(data, attr):
+                if key is None:
+                    continue
                 key_path = attr_path + (key,)
                 with collect_error(location=key_path):
                     if attr in ("obs", "var"):

--- a/tests/io/test_multi_table.py
+++ b/tests/io/test_multi_table.py
@@ -47,7 +47,7 @@ class TestMultiTable:
         n_obs = full_sdata["table"].n_obs
         full_sdata["table"].obs["instance_id"] = range(n_obs)
         # introduce null values
-        full_sdata["table"].obs.loc[0, "instance_id"] = None
+        full_sdata["table"].obs.at[full_sdata["table"].obs_names[0], "instance_id"] = None
         with pytest.raises(ValueError, match="must not contain null values, but it does."):
             full_sdata.validate_table_in_spatialdata(table=full_sdata["table"])
 


### PR DESCRIPTION
Failing due to `adata` allowing finding `None` among the keys of `layers`, full discussion here https://github.com/scverse/spatialdata/issues/1119.