### PR TITLE
ci: bump codecov-action to v6 and fail CI on upload error

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,9 +61,10 @@ jobs:
               run: |
                   uv run pytest --cov --color=yes --cov-report=xml -n auto --dist worksteal
             - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@v6
               with:
                   name: coverage
                   verbose: true
+                  fail_ci_if_error: true
               env:
                   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Two changes to the coverage upload step:

1. **`codecov-action@v5` -> `@v6`.** v5 verifies the codecov CLI binary against Codecov's old Keybase key, which they bricked after migrating accounts, so uploads now fail with `Could not verify signature`. `@v6` (= 6.0.2) ships the updated key.

2. **Restore `fail_ci_if_error: true`.** This matches the `cookiecutter-scverse` template default, so a broken coverage upload surfaces as a CI failure instead of silently passing (which is what masked this issue here until now).

Ref: https://github.com/codecov/codecov-action/issues/1956