### PR TITLE
Transformation manager foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ node_modules/
 uv.lock
 pixi.lock
 
+# local hatch config
+hatch.toml
+

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ hatch.toml
 .kilo/
 plans/
 
+# test coverage
+.coverage
+htmlcov/
+

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ pixi.lock
 # local hatch config
 hatch.toml
 
+# Kilo and plans
+.kilo/
+plans/
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ extra  = [
 [dependency-groups]
 dev = [
     "bump2version",
+    "pandas-stubs>=3.0.3.260530",
 ]
 test = [
     "pytest",

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -57,8 +57,6 @@ _LAZY_IMPORTS: dict[str, str] = {
     # _core.query.spatial_query
     "bounding_box_query": "spatialdata._core.query.spatial_query",
     "polygon_query": "spatialdata._core.query.spatial_query",
-    # _core.transformation_manager
-    "TransformationManager": "spatialdata._core.transformation_manager",
     # _core.spatialdata
     "SpatialData": "spatialdata._core.spatialdata",
     # _io._utils
@@ -118,8 +116,6 @@ __all__ = [
     "bounding_box_query",
     "polygon_query",
     # _core.transformation_manager
-    "TransformationManager",
-    # _core.spatialdata
     "SpatialData",
     # _io._utils
     "get_dask_backing_files",
@@ -211,9 +207,6 @@ if TYPE_CHECKING:
 
     # _core.spatialdata
     from spatialdata._core.spatialdata import SpatialData
-
-    # _core.transformation_manager
-    from spatialdata._core.transformation_manager import TransformationManager
 
     # _io._utils
     from spatialdata._io._utils import get_dask_backing_files

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -57,9 +57,8 @@ _LAZY_IMPORTS: dict[str, str] = {
     # _core.query.spatial_query
     "bounding_box_query": "spatialdata._core.query.spatial_query",
     "polygon_query": "spatialdata._core.query.spatial_query",
-    # _core.transformation_manager
-    # "TransformationManager": "spatialdata._core.transformation_manager",
-    # _io._utils
+    # _core.spatialdata
+    "SpatialData": "spatialdata._core.spatialdata",
     "get_dask_backing_files": "spatialdata._io._utils",
     # _io.format
     "SpatialDataFormatType": "spatialdata._io.format",
@@ -210,7 +209,8 @@ if TYPE_CHECKING:
     from spatialdata._core.spatialdata import SpatialData
 
     # _core.transformation_manager
-    # from spatialdata._core.transformation_manager import TransformationManager
+    from spatialdata._core.transformation_manager import TransformationManager
+
     # _io._utils
     from spatialdata._io._utils import get_dask_backing_files
 

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -57,6 +57,8 @@ _LAZY_IMPORTS: dict[str, str] = {
     # _core.query.spatial_query
     "bounding_box_query": "spatialdata._core.query.spatial_query",
     "polygon_query": "spatialdata._core.query.spatial_query",
+    # _core.transformation_manager
+    "TransformationManager": "spatialdata._core.transformation_manager",
     # _core.spatialdata
     "SpatialData": "spatialdata._core.spatialdata",
     # _io._utils
@@ -115,6 +117,8 @@ __all__ = [
     # _core.query.spatial_query
     "bounding_box_query",
     "polygon_query",
+    # _core.transformation_manager
+    "TransformationManager",
     # _core.spatialdata
     "SpatialData",
     # _io._utils
@@ -207,6 +211,9 @@ if TYPE_CHECKING:
 
     # _core.spatialdata
     from spatialdata._core.spatialdata import SpatialData
+
+    # _core.transformation_manager
+    from spatialdata._core.transformation_manager import TransformationManager
 
     # _io._utils
     from spatialdata._io._utils import get_dask_backing_files

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -58,7 +58,7 @@ _LAZY_IMPORTS: dict[str, str] = {
     "bounding_box_query": "spatialdata._core.query.spatial_query",
     "polygon_query": "spatialdata._core.query.spatial_query",
     # _core.transformation_manager
-    "TransformationManager": "spatialdata._core.transformation_manager",
+    # "TransformationManager": "spatialdata._core.transformation_manager",
     # _io._utils
     "get_dask_backing_files": "spatialdata._io._utils",
     # _io.format
@@ -116,7 +116,6 @@ __all__ = [
     "bounding_box_query",
     "polygon_query",
     # _core.transformation_manager
-    "TransformationManager",
     # _core.spatialdata
     "SpatialData",
     # _io._utils
@@ -211,8 +210,7 @@ if TYPE_CHECKING:
     from spatialdata._core.spatialdata import SpatialData
 
     # _core.transformation_manager
-    from spatialdata._core.transformation_manager import TransformationManager
-
+    # from spatialdata._core.transformation_manager import TransformationManager
     # _io._utils
     from spatialdata._io._utils import get_dask_backing_files
 

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -57,8 +57,8 @@ _LAZY_IMPORTS: dict[str, str] = {
     # _core.query.spatial_query
     "bounding_box_query": "spatialdata._core.query.spatial_query",
     "polygon_query": "spatialdata._core.query.spatial_query",
-    # _core.spatialdata
-    "SpatialData": "spatialdata._core.spatialdata",
+    # _core.transformation_manager
+    "TransformationManager": "spatialdata._core.transformation_manager",
     # _io._utils
     "get_dask_backing_files": "spatialdata._io._utils",
     # _io.format
@@ -116,6 +116,8 @@ __all__ = [
     "bounding_box_query",
     "polygon_query",
     # _core.transformation_manager
+    "TransformationManager",
+    # _core.spatialdata
     "SpatialData",
     # _io._utils
     "get_dask_backing_files",
@@ -207,6 +209,9 @@ if TYPE_CHECKING:
 
     # _core.spatialdata
     from spatialdata._core.spatialdata import SpatialData
+
+    # _core.transformation_manager
+    from spatialdata._core.transformation_manager import TransformationManager
 
     # _io._utils
     from spatialdata._io._utils import get_dask_backing_files

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -114,7 +114,6 @@ __all__ = [
     # _core.query.spatial_query
     "bounding_box_query",
     "polygon_query",
-    # _core.transformation_manager
     # _core.spatialdata
     "SpatialData",
     # _io._utils

--- a/src/spatialdata/__init__.py
+++ b/src/spatialdata/__init__.py
@@ -207,9 +207,6 @@ if TYPE_CHECKING:
     # _core.spatialdata
     from spatialdata._core.spatialdata import SpatialData
 
-    # _core.transformation_manager
-    from spatialdata._core.transformation_manager import TransformationManager
-
     # _io._utils
     from spatialdata._io._utils import get_dask_backing_files
 

--- a/src/spatialdata/_core/spatialdata.py
+++ b/src/spatialdata/_core/spatialdata.py
@@ -22,6 +22,7 @@ from xarray import DataArray, DataTree
 from zarr.errors import GroupNotFoundError
 
 from spatialdata._core._elements import Images, Labels, Points, Shapes, Tables
+from spatialdata._core.transformation_manager import TransformationManager
 from spatialdata._core.validation import (
     check_all_keys_case_insensitively_unique,
     check_target_region_column_symmetry,
@@ -130,6 +131,7 @@ class SpatialData:
         self._shapes: Shapes = Shapes(shared_keys=self._shared_keys)
         self._tables: Tables = Tables(shared_keys=self._shared_keys)
         self.attrs = attrs if attrs else {}  # type: ignore[assignment]
+        self.transformation_manager = TransformationManager()  # Initialize the TransformationManager
 
         element_names = list(chain.from_iterable([e.keys() for e in [images, labels, points, shapes] if e is not None]))
 

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -290,7 +290,8 @@ class TransformationManager:
             If the element does not exist.
         """
         self.check_if_element_exists_else_raise_error(element_name)
-        return self.element_to_cs_mapping[element_name]
+        with suppress_direct_internal_attribute_access_warning():
+            return self.element_to_cs_mapping[element_name]
 
     def unset_element(self, element_name: str) -> None:
         """
@@ -525,7 +526,7 @@ class TransformationManager:
             return (
                 f"TransformationManager("
                 f"  coordinate_systems={list(self.graph.nodes())}, "
-                f"  coordinate_transforms={list(self.graph.edges())}, "
+                f"  coordinate_transforms={[x[TRANSFORM_KEY] for *_, x in self.graph.edges(data=True)]}, "
                 f"  elements={list(self.element_to_cs_mapping.keys())}"
                 f")"
             )

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -131,7 +131,7 @@ class TransformationManager:
 
         self._graph.add_edge(input_cs, output_cs, **{TRANSFORM_KEY: transformation})
 
-    def get_transformation(
+    def get_existing_transformation(
         self, input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem
     ) -> BaseTransformation | None:
         """
@@ -210,7 +210,7 @@ class TransformationManager:
         if element_cs is None:
             raise KeyError(f"Element '{element_name}' does not belong to any coordinate system.")
 
-        return self.get_transformation(element_cs, target_cs)
+        return self.get_existing_transformation(element_cs, target_cs)
 
     def build_nx_graph(self) -> nx.MultiDiGraph:
         """
@@ -289,6 +289,86 @@ class TransformationManager:
                 sequence.append(edge_data[0][TRANSFORM_KEY])
             all_sequences.append(sequence)
         return all_sequences
+
+    def _get_transformations_associated_with_cs(
+        self, cs: NgffCoordinateSystem
+    ) -> list[tuple[NgffCoordinateSystem, NgffCoordinateSystem]]:
+        """
+        Get all transformations associated with a coordinate system.
+
+        Parameters
+        ----------
+        cs
+            The coordinate system to check.
+
+        Returns
+        -------
+        List of tuples representing transformations (input_cs, output_cs).
+        """
+        self.check_if_coordinate_system_exists(cs)
+
+        transformations = []
+        # Check outgoing edges (cs -> other)
+        for successor in self._graph.successors(cs):
+            transformations.append((cs, successor))
+        # Check incoming edges (other -> cs)
+        for predecessor in self._graph.predecessors(cs):
+            transformations.append((predecessor, cs))
+
+        return transformations
+
+    def _get_elements_belonging_to_cs(self, cs: NgffCoordinateSystem) -> list[str]:
+        """
+        Get all elements belonging to a coordinate system.
+
+        Parameters
+        ----------
+        cs
+            The coordinate system to check.
+
+        Returns
+        -------
+        List of element names belonging to the coordinate system.
+        """
+        self.check_if_coordinate_system_exists(cs)
+
+        elements = []
+        for element_name, element_cs in self._element_to_cs_mapping.items():
+            if element_cs == cs:
+                elements.append(element_name)
+
+        return elements
+
+    def remove_coordinate_system(self, cs: NgffCoordinateSystem) -> None:
+        """
+        Remove a coordinate system from the transformation manager.
+
+        Parameters
+        ----------
+        cs
+            The coordinate system to remove.
+
+        Raises
+        ------
+        ValueError
+            If the coordinate system has associated transformations or elements.
+        KeyError
+            If the coordinate system does not exist.
+        """
+        self.check_if_coordinate_system_exists(cs)
+
+        # Check if coordinate system has any transformations
+        if len(list(self._graph.edges(cs))) > 0:
+            raise ValueError(f"Cannot remove coordinate system '{cs.name}' as it has associated transformations")
+
+        # Check if coordinate system has any associated elements
+        associated_elements = self._get_elements_belonging_to_cs(cs)
+        if associated_elements:
+            raise ValueError(
+                f"Cannot remove coordinate system '{cs.name}' as it has associated elements: {associated_elements}"
+            )
+
+        self._graph.remove_node(cs)
 
     def __repr__(self) -> str:
         return (

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -375,8 +375,8 @@ class TransformationManager:
         with suppress_direct_internal_attribute_access_warning():
             transforms = []
             assert target_cs in self.graph[source_cs], TransformationNotFoundError(source_cs.name, target_cs.name)
-            for _edge_key, edge in self.graph[source_cs][target_cs]:
-                transform: BaseTransformation = edge[TRANSFORM_KEY]
+            for edge_data in self.graph[source_cs][target_cs].values():
+                transform: BaseTransformation = edge_data[TRANSFORM_KEY]
                 transforms.append(transform)
             return transforms
 
@@ -415,7 +415,7 @@ class TransformationManager:
             )
             self.graph.remove_edge(source_cs, target_cs, key=expected_edge_key)
 
-    def remove_all_transformations(
+    def remove_all_transformations_between_coordinate_systems(
         self,
         source_cs: NgffCoordinateSystem,
         target_cs: NgffCoordinateSystem,
@@ -441,12 +441,13 @@ class TransformationManager:
         # also checks if source_cs and target_cs exist
         with suppress_direct_internal_attribute_access_warning():
             assert len(self.graph[source_cs][target_cs]), TransformationNotFoundError(source_cs.name, target_cs.name)
-            for edge_key, _edge in self.graph[source_cs][target_cs]:
+            for edge_key in list(self.graph[source_cs][target_cs].keys()):
+                # need to covert keys() to list to freeze it, else it will change during the following removal
                 self.graph.remove_edge(source_cs, target_cs, key=edge_key)
 
     def _get_transformation_sequences_from_path_after_disambiguation(
         self,
-        paths: Sequence[list[NgffCoordinateSystem]],
+        paths: list[list[NgffCoordinateSystem]],
         expected_intermediate_transformations: list[BaseTransformation] | None,
     ) -> list[list[BaseTransformation]]:
         """
@@ -471,11 +472,12 @@ class TransformationManager:
                 self._get_edge_key_from_transform(it) for it in expected_intermediate_transformations
             }
         all_sequences = []
-        for path in paths:
+        deduplicated_paths = list({repr(x): x for x in paths}.values())
+        for path in deduplicated_paths:
             sequence = []
             for i in range(len(path) - 1):
                 edge_data = self.graph[path[i]][path[i + 1]]
-                if len(edge_data) >= 1:
+                if len(edge_data) > 1:
                     # when there are multiple edges between a pair of coordinate systems in the path
                     intermediate_transformation_key_here = intermediate_transformation_edge_keys & set(edge_data.keys())
                     if len(intermediate_transformation_key_here) == 0:
@@ -486,7 +488,9 @@ class TransformationManager:
                     # choosing the first one arbitrarily
                     sequence.append(edge_data[edge_key_to_use][TRANSFORM_KEY])
                 else:
-                    sequence.append(edge_data[0][TRANSFORM_KEY])
+                    # Only one edge, no ambiguity
+                    edge_key = next(iter(edge_data.keys()))
+                    sequence.append(edge_data[edge_key][TRANSFORM_KEY])
             all_sequences.append(sequence)
         return all_sequences
 
@@ -528,7 +532,7 @@ class TransformationManager:
         """
         with suppress_direct_internal_attribute_access_warning():
             try:
-                paths = list(nx.shortest_simple_paths(self.graph, source=source_cs, target=target_cs))
+                paths = list(nx.all_shortest_paths(self.graph, source=source_cs, target=target_cs))
 
             except nx.NetworkXNoPath as nxe:
                 raise TransformationPathNotFoundError(source_cs.name, target_cs.name) from nxe

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -5,9 +5,17 @@ import warnings
 import networkx as nx
 
 from spatialdata._core.transformation_manager.exceptions import (
+    CannotRemoveCoordinateSystemError,
+    CoordinateSystemAlreadyExistsError,
+    CoordinateSystemHasElementsError,
+    CoordinateSystemHasTransformationsError,
     CoordinateSystemNotFoundError,
+    ElementAlreadyExistsError,
     ElementNotFoundError,
+    InternalAttributeAccessWarning,
     TransformationNotFoundError,
+    TransformationPathNotFoundError,
+    suppress_direct_internal_attribute_access_warning,
 )
 from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
 from spatialdata.transformations.transformations import BaseTransformation
@@ -31,7 +39,21 @@ class TransformationManager:
         Returns
         -------
         The MultiDiGraph containing coordinate systems and transformations.
+
+        Note
+        ----
+        Direct manipulation of the graph is discouraged. Please use the
+        TransformationManager methods whenever possible for better maintainability
+        and to ensure proper validation and error handling.
         """
+        warnings.warn(
+            "Direct access to the internal graph is discouraged. "
+            "Please use TransformationManager methods whenever possible for better "
+            "maintainability and to ensure proper validation and error handling.",
+            InternalAttributeAccessWarning,
+            stacklevel=2,
+        )
+
         return self._graph
 
     @property
@@ -42,10 +64,23 @@ class TransformationManager:
         Returns
         -------
         A dictionary mapping element names to their coordinate systems.
+
+        Note
+        ----
+        Direct manipulation of internal element_to_cs_mapping is discouraged. Please use the
+        TransformationManager methods whenever possible for better maintainability
+        and to ensure proper validation and error handling.
         """
+        warnings.warn(
+            "Direct access to the internal element_to_cs_mapping is discouraged. "
+            "Please use TransformationManager methods whenever possible for better "
+            "maintainability and to ensure proper validation and error handling",
+            InternalAttributeAccessWarning,
+            stacklevel=2,
+        )
         return self._element_to_cs_mapping
 
-    def check_if_element_exists(self, element_name: str) -> None:
+    def check_if_element_exists_else_raise_error(self, element_name: str) -> None:
         """
         Check if an element exists in the transformation manager.
 
@@ -59,10 +94,11 @@ class TransformationManager:
         ElementNotFoundError
             If the element does not exist.
         """
-        if element_name not in self.element_to_cs_mapping:
-            raise ElementNotFoundError(element_name)
+        with suppress_direct_internal_attribute_access_warning():
+            if element_name not in self.element_to_cs_mapping:
+                raise ElementNotFoundError(element_name)
 
-    def check_if_coordinate_system_exists(self, cs: NgffCoordinateSystem) -> None:
+    def check_if_coordinate_system_exists_else_raise_error(self, cs: NgffCoordinateSystem) -> None:
         """
         Check if a coordinate system exists in the graph.
 
@@ -76,31 +112,80 @@ class TransformationManager:
         CoordinateSystemNotFoundError
             If the coordinate system does not exist.
         """
-        if cs not in self.graph:
-            raise CoordinateSystemNotFoundError(cs.name)
+        with suppress_direct_internal_attribute_access_warning():
+            if cs not in self.graph:
+                raise CoordinateSystemNotFoundError(cs.name)
 
-    def check_if_edge_exists(self, input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem) -> None:
+    def check_if_edge_exists_else_raise_error(
+        self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
+    ) -> None:
         """
         Check if an edge exists between coordinate systems.
 
         Parameters
         ----------
-        input_cs
+        source_cs
             The input coordinate system.
-        output_cs
+        target_cs
             The output coordinate system.
 
         Raises
         ------
+        CoordinateSystemNotFoundError
+            If either coordinate system does not exist.
         TransformationNotFoundError
             If the edge does not exist.
         """
-        if not self.graph.has_edge(input_cs, output_cs):
-            raise TransformationNotFoundError(input_cs.name, output_cs.name)
+        self.check_if_coordinate_system_exists_else_raise_error(source_cs)
+        self.check_if_coordinate_system_exists_else_raise_error(target_cs)
+        with suppress_direct_internal_attribute_access_warning():
+            if not self.graph.has_edge(source_cs, target_cs):
+                raise TransformationNotFoundError(source_cs.name, target_cs.name)
+
+    def check_if_coordinate_system_has_no_transformations_else_raise_error(self, cs: NgffCoordinateSystem) -> None:
+        """
+        Check if a coordinate system has associated transformations.
+
+        Parameters
+        ----------
+        cs
+            The coordinate system to check.
+
+        Raises
+        ------
+        CoordinateSystemNotFoundError
+            If either coordinate system does not exist.
+        CoordinateSystemHasTransformationsError
+            If the coordinate system has associated transformations.
+
+        """
+        transformations = self._get_transformations_associated_with_cs(cs)
+        # also checks if cs exists
+        if transformations:
+            raise CoordinateSystemHasTransformationsError(cs.name)
+
+    def check_if_coordinate_system_has_no_elements_else_raise_error(self, cs: NgffCoordinateSystem) -> None:
+        """
+        Check if a coordinate system has elements that belong to it.
+
+        Parameters
+        ----------
+        cs
+            The coordinate system to check
+
+        Raises
+        ------
+        Co
+
+        """
+        elements = self._get_elements_belonging_to_cs(cs)
+        # also checks if cs exists
+        if elements:
+            raise CoordinateSystemHasElementsError(cs.name, elements)
 
     def add_coordinate_system(self, cs: NgffCoordinateSystem) -> None:
         """
-        Register a new coordinate system.
+        Add a coordinate system to the transformation manager.
 
         Parameters
         ----------
@@ -109,12 +194,45 @@ class TransformationManager:
 
         Raises
         ------
-        ValueError
+        CoordinateSystemAlreadyExistsError
             If the coordinate system already exists.
         """
-        if cs in self.graph:
-            raise ValueError(f"Coordinate system '{cs.name}' already exists in the transformation manager")
-        self.graph.add_node(cs)
+        try:
+            self.check_if_coordinate_system_exists_else_raise_error(cs)
+        except CoordinateSystemNotFoundError:
+            with suppress_direct_internal_attribute_access_warning():
+                self.graph.add_node(cs)
+                return
+
+        raise CoordinateSystemAlreadyExistsError(cs.name)
+
+    def remove_coordinate_system(self, cs: NgffCoordinateSystem) -> None:
+        """
+        Remove a coordinate system from the transformation manager.
+
+        Parameters
+        ----------
+        cs
+            The coordinate system to remove.
+
+        Raises
+        ------
+        CoordinateSystemHasTransformationsError
+            If the coordinate system has associated transformations.
+        CoordinateSystemHasElementsError
+            If the coordinate system has associated elements.
+        CoordinateSystemNotFoundError
+            If the coordinate system is not found
+        """
+        try:
+            self.check_if_coordinate_system_has_no_transformations_else_raise_error(cs)
+            # also checks if cs exists
+            self.check_if_coordinate_system_has_no_elements_else_raise_error(cs)
+        except (CoordinateSystemHasTransformationsError, CoordinateSystemHasElementsError) as err:
+            raise CannotRemoveCoordinateSystemError(cs.name) from err
+
+        with suppress_direct_internal_attribute_access_warning():
+            self.graph.remove_node(cs)
 
     def list_coordinate_systems(self) -> list[NgffCoordinateSystem]:
         """
@@ -124,7 +242,8 @@ class TransformationManager:
         -------
         A list of coordinate system objects.
         """
-        return list(self.graph.nodes())
+        with suppress_direct_internal_attribute_access_warning():
+            return list(self.graph.nodes())
 
     def add_element(self, element_name: str, coordinate_system: NgffCoordinateSystem) -> None:
         """
@@ -137,33 +256,20 @@ class TransformationManager:
         coordinate_system
             The coordinate system to which the element belongs.
 
-        Warnings
-        --------
-        UserWarning
-            If the coordinate system does not exist.
+        Raises
+        ------
+        CoordinateSystemNotFoundError
+            If the coordinate system is not found.
         """
         try:
-            self.check_if_element_exists(element_name)
-        except ElementNotFoundError as _enfe:
-            warnings.warn(
-                f"Cannot add element with name '{element_name}') as it already "
-                f"exists in the transformation manager. Skipping",
-                UserWarning,
-                stacklevel=2,
-            )
+            self.check_if_element_exists_else_raise_error(element_name)
+        except ElementNotFoundError:
+            self.check_if_coordinate_system_exists_else_raise_error(coordinate_system)
+            with suppress_direct_internal_attribute_access_warning():
+                self.element_to_cs_mapping[element_name] = coordinate_system
+                return
 
-        try:
-            self.check_if_coordinate_system_exists(coordinate_system)
-        except CoordinateSystemNotFoundError as _csnfe:
-            warnings.warn(
-                f"Cannot set coordinate system ('{coordinate_system.name}') to element as the "
-                f"coordinate system does not exist.",
-                UserWarning,
-                stacklevel=2,
-            )
-            return
-
-        self.element_to_cs_mapping[element_name] = coordinate_system
+        raise ElementAlreadyExistsError(element_name)
 
     def get_element_coordinate_system(self, element_name: str) -> NgffCoordinateSystem:
         """
@@ -176,14 +282,14 @@ class TransformationManager:
 
         Returns
         -------
-        The coordinate system or None if not found
+        The coordinate system
 
         Raises
         ------
         ElementNotFoundError
             If the element does not exist.
         """
-        self.check_if_element_exists(element_name)
+        self.check_if_element_exists_else_raise_error(element_name)
         return self.element_to_cs_mapping[element_name]
 
     def unset_element(self, element_name: str) -> None:
@@ -200,20 +306,21 @@ class TransformationManager:
         ElementNotFoundError
             If the element has not been registered to any coordinate system.
         """
-        self.check_if_element_exists(element_name)
-        del self.element_to_cs_mapping[element_name]
+        self.check_if_element_exists_else_raise_error(element_name)
+        with suppress_direct_internal_attribute_access_warning():
+            del self.element_to_cs_mapping[element_name]
 
     def add_transformation(
-        self, input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem, transformation: BaseTransformation
+        self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem, transformation: BaseTransformation
     ) -> None:
         """
         Add a transformation between coordinate systems.
 
         Parameters
         ----------
-        input_cs
+        source_cs
             The input coordinate system.
-        output_cs
+        target_cs
             The output coordinate system.
         transformation
             The transformation to add.
@@ -223,22 +330,23 @@ class TransformationManager:
         CoordinateSystemNotFoundError
             If either coordinate system does not exist.
         """
-        self.check_if_coordinate_system_exists(input_cs)
-        self.check_if_coordinate_system_exists(output_cs)
+        self.check_if_coordinate_system_exists_else_raise_error(source_cs)
+        self.check_if_coordinate_system_exists_else_raise_error(target_cs)
 
-        self.graph.add_edge(input_cs, output_cs, **{TRANSFORM_KEY: transformation})
+        with suppress_direct_internal_attribute_access_warning():
+            self.graph.add_edge(source_cs, target_cs, **{TRANSFORM_KEY: transformation})
 
     def get_existing_transformation(
-        self, input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem
+        self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
     ) -> BaseTransformation:
         """
         Retrieve a transformation defined between coordinate systems.
 
         Parameters
         ----------
-        input_cs
+        source_cs
             The input coordinate system.
-        output_cs
+        target_cs
             The output coordinate system.
 
         Returns
@@ -252,23 +360,21 @@ class TransformationManager:
         TransformationNotFoundError
             If the transformation does not exist.
         """
-        self.check_if_coordinate_system_exists(input_cs)
-        self.check_if_coordinate_system_exists(output_cs)
+        self.check_if_edge_exists_else_raise_error(source_cs, target_cs)
+        # also checks if source_cs and target_cs exist
+        with suppress_direct_internal_attribute_access_warning():
+            transform: BaseTransformation = self.graph[source_cs][target_cs][0][TRANSFORM_KEY]
+            return transform
 
-        self.check_if_edge_exists(input_cs, output_cs)
-
-        transform: BaseTransformation = self.graph[input_cs][output_cs][0][TRANSFORM_KEY]
-        return transform
-
-    def remove_transformation(self, input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem) -> None:
+    def remove_transformation(self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem) -> None:
         """
         Remove a transformation between coordinate systems.
 
         Parameters
         ----------
-        input_cs
+        source_cs
             The input coordinate system.
-        output_cs
+        target_cs
             The output coordinate system.
 
         Raises
@@ -278,11 +384,10 @@ class TransformationManager:
         TransformationNotFoundError
             If the transformation does not exist.
         """
-        self.check_if_coordinate_system_exists(input_cs)
-        self.check_if_coordinate_system_exists(output_cs)
-
-        self.check_if_edge_exists(input_cs, output_cs)
-        self.graph.remove_edge(input_cs, output_cs)
+        self.check_if_edge_exists_else_raise_error(source_cs, target_cs)
+        # also checks if source_cs and target_cs exist
+        with suppress_direct_internal_attribute_access_warning():
+            self.graph.remove_edge(source_cs, target_cs)
 
     def get_shortest_transformation_sequence(
         self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
@@ -304,23 +409,28 @@ class TransformationManager:
 
         Raises
         ------
-        ValueError
+        CoordinateSystemNotFoundError
+            If either coordinate system does not exist.
+        TransformationPathNotFoundError
             If no path exists between the source and target coordinate systems.
         """
-        if self.graph.has_edge(source_cs, target_cs):
-            return [self.graph[source_cs][target_cs][0][TRANSFORM_KEY]]
+        with suppress_direct_internal_attribute_access_warning():
+            try:
+                return [self.get_existing_transformation(source_cs=source_cs, target_cs=target_cs)]
+            except TransformationNotFoundError as _tnfe:
+                pass
 
-        try:
-            path = nx.shortest_path(self.graph, source=source_cs, target=target_cs)
+            try:
+                path = nx.shortest_path(self.graph, source=source_cs, target=target_cs)
 
-        except nx.NetworkXNoPath as nxe:
-            raise ValueError(f"No path found from {source_cs.name} to {target_cs.name}") from nxe
+            except nx.NetworkXNoPath as nxe:
+                raise TransformationPathNotFoundError(source_cs.name, target_cs.name) from nxe
 
-        transformations = []
-        for i in range(len(path) - 1):
-            edge_data = self.graph[path[i]][path[i + 1]]
-            transformations.append(edge_data[0][TRANSFORM_KEY])
-        return transformations
+            transformations = []
+            for i in range(len(path) - 1):
+                edge_data = self.graph[path[i]][path[i + 1]]
+                transformations.append(edge_data[0][TRANSFORM_KEY])
+            return transformations
 
     def get_all_transformation_sequences(
         self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
@@ -340,20 +450,19 @@ class TransformationManager:
         list[list[BaseTransformation]]
             All existing sequences of transformations from source_cs to target_cs.
         """
-        paths = list(nx.all_simple_paths(self.graph, source=source_cs, target=target_cs))
+        with suppress_direct_internal_attribute_access_warning():
+            paths = list(nx.all_simple_paths(self.graph, source=source_cs, target=target_cs))
 
-        all_sequences = []
-        for path in paths:
-            sequence = []
-            for i in range(len(path) - 1):
-                edge_data = self.graph[path[i]][path[i + 1]]
-                sequence.append(edge_data[0][TRANSFORM_KEY])
-            all_sequences.append(sequence)
-        return all_sequences
+            all_sequences = []
+            for path in paths:
+                sequence = []
+                for i in range(len(path) - 1):
+                    edge_data = self.graph[path[i]][path[i + 1]]
+                    sequence.append(edge_data[0][TRANSFORM_KEY])
+                all_sequences.append(sequence)
+            return all_sequences
 
-    def _get_transformations_associated_with_cs(
-        self, cs: NgffCoordinateSystem
-    ) -> list[tuple[NgffCoordinateSystem, NgffCoordinateSystem]]:
+    def _get_transformations_associated_with_cs(self, cs: NgffCoordinateSystem) -> list[BaseTransformation]:
         """
         Get all transformations associated with a coordinate system.
 
@@ -364,19 +473,22 @@ class TransformationManager:
 
         Returns
         -------
-        List of tuples representing transformations (input_cs, output_cs).
+        List of transformations
         """
-        self.check_if_coordinate_system_exists(cs)
+        self.check_if_coordinate_system_exists_else_raise_error(cs)
 
-        transformations = []
-        # Check outgoing edges (cs -> other)
-        for successor in self.graph.successors(cs):
-            transformations.append((cs, successor))
-        # Check incoming edges (other -> cs)
-        for predecessor in self.graph.predecessors(cs):
-            transformations.append((predecessor, cs))
+        with suppress_direct_internal_attribute_access_warning():
+            transformations = []
+            # Check outgoing edges (cs -> other)
+            for successor in self.graph.successors(cs):
+                transformation = self.get_existing_transformation(source_cs=cs, target_cs=successor)
+                transformations.append(transformation)
+            # Check incoming edges (other -> cs)
+            for predecessor in self.graph.predecessors(cs):
+                transformation = self.get_existing_transformation(source_cs=predecessor, target_cs=cs)
+                transformations.append(transformation)
 
-        return transformations
+            return transformations
 
     def _get_elements_belonging_to_cs(self, cs: NgffCoordinateSystem) -> list[str]:
         """
@@ -390,52 +502,30 @@ class TransformationManager:
         Returns
         -------
         List of element names belonging to the coordinate system.
-        """
-        self.check_if_coordinate_system_exists(cs)
-
-        elements = []
-        for element_name, element_cs in self.element_to_cs_mapping.items():
-            if element_cs == cs:
-                elements.append(element_name)
-
-        return elements
-
-    def remove_coordinate_system(self, cs: NgffCoordinateSystem) -> None:
-        """
-        Remove a coordinate system from the transformation manager.
-
-        Parameters
-        ----------
-        cs
-            The coordinate system to remove.
 
         Raises
         ------
-        ValueError
-            If the coordinate system has associated transformations or elements.
-        KeyError
+        CoordinateSystemNotFoundError
             If the coordinate system does not exist.
+
         """
-        self.check_if_coordinate_system_exists(cs)
+        self.check_if_coordinate_system_exists_else_raise_error(cs)
 
-        # Check if coordinate system has any transformations
-        if len(list(self.graph.edges(cs))) > 0:
-            raise ValueError(f"Cannot remove coordinate system '{cs.name}' as it has associated transformations")
+        with suppress_direct_internal_attribute_access_warning():
+            elements = []
+            for element_name, element_cs in self.element_to_cs_mapping.items():
+                if element_cs == cs:
+                    elements.append(element_name)
 
-        # Check if coordinate system has any associated elements
-        associated_elements = self._get_elements_belonging_to_cs(cs)
-        if associated_elements:
-            raise ValueError(
-                f"Cannot remove coordinate system '{cs.name}' as it has associated elements: {associated_elements}"
-            )
-
-        self.graph.remove_node(cs)
+            return elements
 
     def __repr__(self) -> str:
-        return (
-            f"TransformationManager("
-            f"  coordinate_systems={list(self.graph.nodes())}, "
-            f"  coordinate_transforms={list(self.graph.edges())}, "
-            f"  elements={list(self.element_to_cs_mapping.keys())}"
-            f")"
-        )
+        """Return a string representation of the TransformationManager."""
+        with suppress_direct_internal_attribute_access_warning():
+            return (
+                f"TransformationManager("
+                f"  coordinate_systems={list(self.graph.nodes())}, "
+                f"  coordinate_transforms={list(self.graph.edges())}, "
+                f"  elements={list(self.element_to_cs_mapping.keys())}"
+                f")"
+            )

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Sequence
 
 import networkx as nx
 
@@ -20,7 +19,7 @@ from spatialdata._core.transformation_manager.exceptions import (
     suppress_direct_internal_attribute_access_warning,
 )
 from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
-from spatialdata.transformations.transformations import BaseTransformation
+from spatialdata.transformations.transformations import BaseTransformation, Sequence
 
 TRANSFORM_KEY = "transformation"
 
@@ -449,7 +448,7 @@ class TransformationManager:
         self,
         paths: list[list[NgffCoordinateSystem]],
         expected_intermediate_transformations: list[BaseTransformation] | None,
-    ) -> list[list[BaseTransformation]]:
+    ) -> list[Sequence]:
         """
         Traverses paths to form sequence of Transformations.
 
@@ -474,7 +473,7 @@ class TransformationManager:
         all_sequences = []
         deduplicated_paths = list({repr(x): x for x in paths}.values())
         for path in deduplicated_paths:
-            sequence = []
+            transformation_list = []
             for i in range(len(path) - 1):
                 edge_data = self.graph[path[i]][path[i + 1]]
                 if len(edge_data) > 1:
@@ -486,12 +485,12 @@ class TransformationManager:
 
                     edge_key_to_use = list(intermediate_transformation_key_here)[0]
                     # choosing the first one arbitrarily
-                    sequence.append(edge_data[edge_key_to_use][TRANSFORM_KEY])
+                    transformation_list.append(edge_data[edge_key_to_use][TRANSFORM_KEY])
                 else:
                     # Only one edge, no ambiguity
                     edge_key = next(iter(edge_data.keys()))
-                    sequence.append(edge_data[edge_key][TRANSFORM_KEY])
-            all_sequences.append(sequence)
+                    transformation_list.append(edge_data[edge_key][TRANSFORM_KEY])
+            all_sequences.append(Sequence(transformation_list))
         return all_sequences
 
     def get_all_shortest_transformation_sequences(
@@ -499,7 +498,7 @@ class TransformationManager:
         source_cs: NgffCoordinateSystem,
         target_cs: NgffCoordinateSystem,
         expected_intermediate_transformations: list[BaseTransformation] | None = None,
-    ) -> list[list[BaseTransformation]]:
+    ) -> list[Sequence]:
         """
         Get all shortest sequences of transformations between two coordinate systems.
 
@@ -515,7 +514,7 @@ class TransformationManager:
 
         Returns
         -------
-        list[list[BaseTransformation]]
+        list[Sequence]
             All shortest sequences of transformations from source_cs to target_cs.
             When multiple transformations are defined between the same coordinate systems, only those containing
             a transformation among intermediate transformations are included.
@@ -549,7 +548,7 @@ class TransformationManager:
         source_cs: NgffCoordinateSystem,
         target_cs: NgffCoordinateSystem,
         expected_intermediate_transformations: list[BaseTransformation] | None = None,
-    ) -> list[list[BaseTransformation]]:
+    ) -> list[Sequence]:
         """
         Get all existing sequences of transformations between two coordinate systems.
 
@@ -565,7 +564,7 @@ class TransformationManager:
 
         Returns
         -------
-        list[list[BaseTransformation]]
+        list[Sequence]
             All existing sequences of transformations from source_cs to target_cs.
             When multiple transformations are defined between the same coordinate systems, only those containing
             a transformation among intermediate transformations are included.

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -35,8 +35,6 @@ class TransformationManager:
         if cs not in self._graph:
             raise ValueError(f"Coordinate system '{cs.name}' does not exist in the transformation manager.")
 
-        self._graph.remove_node(cs)
-
     def list_coordinate_systems(self) -> list[NgffCoordinateSystem]:
         """
         List all registered coordinate systems.

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -23,6 +23,28 @@ class TransformationManager:
         self._element_to_cs_mapping: dict[str, NgffCoordinateSystem] = {}
         # mapping element_name to the coordinate system to which the element belongs
 
+    @property
+    def graph(self) -> nx.MultiDiGraph:
+        """
+        Get the internal transformation graph.
+
+        Returns
+        -------
+        The MultiDiGraph containing coordinate systems and transformations.
+        """
+        return self._graph
+
+    @property
+    def element_to_cs_mapping(self) -> dict[str, NgffCoordinateSystem]:
+        """
+        Get the element to coordinate system mapping.
+
+        Returns
+        -------
+        A dictionary mapping element names to their coordinate systems.
+        """
+        return self._element_to_cs_mapping
+
     def check_if_element_exists(self, element_name: str) -> None:
         """
         Check if an element exists in the transformation manager.
@@ -37,7 +59,7 @@ class TransformationManager:
         ElementNotFoundError
             If the element does not exist.
         """
-        if element_name not in self._element_to_cs_mapping:
+        if element_name not in self.element_to_cs_mapping:
             raise ElementNotFoundError(element_name)
 
     def check_if_coordinate_system_exists(self, cs: NgffCoordinateSystem) -> None:
@@ -54,7 +76,7 @@ class TransformationManager:
         CoordinateSystemNotFoundError
             If the coordinate system does not exist.
         """
-        if cs not in self._graph:
+        if cs not in self.graph:
             raise CoordinateSystemNotFoundError(cs.name)
 
     def check_if_edge_exists(self, input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem) -> None:
@@ -73,8 +95,26 @@ class TransformationManager:
         TransformationNotFoundError
             If the edge does not exist.
         """
-        if not self._graph.has_edge(input_cs, output_cs):
+        if not self.graph.has_edge(input_cs, output_cs):
             raise TransformationNotFoundError(input_cs.name, output_cs.name)
+
+    def add_coordinate_system(self, cs: NgffCoordinateSystem) -> None:
+        """
+        Register a new coordinate system.
+
+        Parameters
+        ----------
+        cs
+            The coordinate system to add.
+
+        Raises
+        ------
+        ValueError
+            If the coordinate system already exists.
+        """
+        if cs in self.graph:
+            raise ValueError(f"Coordinate system '{cs.name}' already exists in the transformation manager")
+        self.graph.add_node(cs)
 
     def list_coordinate_systems(self) -> list[NgffCoordinateSystem]:
         """
@@ -84,7 +124,7 @@ class TransformationManager:
         -------
         A list of coordinate system objects.
         """
-        return list(self._graph.nodes())
+        return list(self.graph.nodes())
 
     def add_element(self, element_name: str, coordinate_system: NgffCoordinateSystem) -> None:
         """
@@ -123,7 +163,7 @@ class TransformationManager:
             )
             return
 
-        self._element_to_cs_mapping[element_name] = coordinate_system
+        self.element_to_cs_mapping[element_name] = coordinate_system
 
     def get_element_coordinate_system(self, element_name: str) -> NgffCoordinateSystem:
         """
@@ -144,7 +184,7 @@ class TransformationManager:
             If the element does not exist.
         """
         self.check_if_element_exists(element_name)
-        return self._element_to_cs_mapping[element_name]
+        return self.element_to_cs_mapping[element_name]
 
     def unset_element(self, element_name: str) -> None:
         """
@@ -161,7 +201,7 @@ class TransformationManager:
             If the element has not been registered to any coordinate system.
         """
         self.check_if_element_exists(element_name)
-        del self._element_to_cs_mapping[element_name]
+        del self.element_to_cs_mapping[element_name]
 
     def add_transformation(
         self, input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem, transformation: BaseTransformation
@@ -186,7 +226,7 @@ class TransformationManager:
         self.check_if_coordinate_system_exists(input_cs)
         self.check_if_coordinate_system_exists(output_cs)
 
-        self._graph.add_edge(input_cs, output_cs, **{TRANSFORM_KEY: transformation})
+        self.graph.add_edge(input_cs, output_cs, **{TRANSFORM_KEY: transformation})
 
     def get_existing_transformation(
         self, input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem
@@ -217,7 +257,7 @@ class TransformationManager:
 
         self.check_if_edge_exists(input_cs, output_cs)
 
-        transform: BaseTransformation = self._graph[input_cs][output_cs][0][TRANSFORM_KEY]
+        transform: BaseTransformation = self.graph[input_cs][output_cs][0][TRANSFORM_KEY]
         return transform
 
     def remove_transformation(self, input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem) -> None:
@@ -242,7 +282,7 @@ class TransformationManager:
         self.check_if_coordinate_system_exists(output_cs)
 
         self.check_if_edge_exists(input_cs, output_cs)
-        self._graph.remove_edge(input_cs, output_cs)
+        self.graph.remove_edge(input_cs, output_cs)
 
     def get_shortest_transformation_sequence(
         self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
@@ -267,18 +307,18 @@ class TransformationManager:
         ValueError
             If no path exists between the source and target coordinate systems.
         """
-        if self._graph.has_edge(source_cs, target_cs):
-            return [self._graph[source_cs][target_cs][0][TRANSFORM_KEY]]
+        if self.graph.has_edge(source_cs, target_cs):
+            return [self.graph[source_cs][target_cs][0][TRANSFORM_KEY]]
 
         try:
-            path = nx.shortest_path(self._graph, source=source_cs, target=target_cs)
+            path = nx.shortest_path(self.graph, source=source_cs, target=target_cs)
 
         except nx.NetworkXNoPath as nxe:
             raise ValueError(f"No path found from {source_cs.name} to {target_cs.name}") from nxe
 
         transformations = []
         for i in range(len(path) - 1):
-            edge_data = self._graph[path[i]][path[i + 1]]
+            edge_data = self.graph[path[i]][path[i + 1]]
             transformations.append(edge_data[0][TRANSFORM_KEY])
         return transformations
 
@@ -300,13 +340,13 @@ class TransformationManager:
         list[list[BaseTransformation]]
             All existing sequences of transformations from source_cs to target_cs.
         """
-        paths = list(nx.all_simple_paths(self._graph, source=source_cs, target=target_cs))
+        paths = list(nx.all_simple_paths(self.graph, source=source_cs, target=target_cs))
 
         all_sequences = []
         for path in paths:
             sequence = []
             for i in range(len(path) - 1):
-                edge_data = self._graph[path[i]][path[i + 1]]
+                edge_data = self.graph[path[i]][path[i + 1]]
                 sequence.append(edge_data[0][TRANSFORM_KEY])
             all_sequences.append(sequence)
         return all_sequences
@@ -330,10 +370,10 @@ class TransformationManager:
 
         transformations = []
         # Check outgoing edges (cs -> other)
-        for successor in self._graph.successors(cs):
+        for successor in self.graph.successors(cs):
             transformations.append((cs, successor))
         # Check incoming edges (other -> cs)
-        for predecessor in self._graph.predecessors(cs):
+        for predecessor in self.graph.predecessors(cs):
             transformations.append((predecessor, cs))
 
         return transformations
@@ -354,7 +394,7 @@ class TransformationManager:
         self.check_if_coordinate_system_exists(cs)
 
         elements = []
-        for element_name, element_cs in self._element_to_cs_mapping.items():
+        for element_name, element_cs in self.element_to_cs_mapping.items():
             if element_cs == cs:
                 elements.append(element_name)
 
@@ -379,7 +419,7 @@ class TransformationManager:
         self.check_if_coordinate_system_exists(cs)
 
         # Check if coordinate system has any transformations
-        if len(list(self._graph.edges(cs))) > 0:
+        if len(list(self.graph.edges(cs))) > 0:
             raise ValueError(f"Cannot remove coordinate system '{cs.name}' as it has associated transformations")
 
         # Check if coordinate system has any associated elements
@@ -389,13 +429,13 @@ class TransformationManager:
                 f"Cannot remove coordinate system '{cs.name}' as it has associated elements: {associated_elements}"
             )
 
-        self._graph.remove_node(cs)
+        self.graph.remove_node(cs)
 
     def __repr__(self) -> str:
         return (
             f"TransformationManager("
-            f"  coordinate_systems={list(self._graph.nodes())}, "
-            f"  coordinate_transforms={list(self._graph.edges())}, "
-            f"  elements={list(self._element_to_cs_mapping.keys())}"
+            f"  coordinate_systems={list(self.graph.nodes())}, "
+            f"  coordinate_transforms={list(self.graph.edges())}, "
+            f"  elements={list(self.element_to_cs_mapping.keys())}"
             f")"
         )

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -1,188 +1,125 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import warnings
 
-from spatialdata._types import ELEMENT_TYPE
+import networkx as nx
+
 from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
 from spatialdata.transformations.transformations import BaseTransformation
 
-if TYPE_CHECKING:
-    import networkx as nx
+TRANSFORM_KEY = "transformation"
 
 
 class TransformationManager:
-    """Centralized storage for managing coordinate systems (cs), transformations and element-cs mapping."""
-
     def __init__(self) -> None:
-        """Initialize a Scene with empty mappings."""
-        self._coordinate_systems: dict[str, NgffCoordinateSystem] = {}
-        # mapping names of coordinate system to coordinate systems
-        self._coordinate_transforms: dict[tuple[str, str], BaseTransformation] = {}
-        # mapping a tuple of coordinate system names, (<source coordinate system name>, <target coordinate system name>)
-        # to a transformation object representing the transformation between them
-        self._element_to_cs_mapping: dict[tuple[ELEMENT_TYPE, str], str] = {}
-        # mapping a tuple, (<element type>, <element key in parent spatialdata object>) to the name of the coordinate
-        # system
+        """Initialize a TransformationManager with empty graph and mappings."""
+        self._graph: nx.MultiDiGraph = nx.MultiDiGraph()
+        # MultiDiGraph with NgffCoordinateSystem objects as nodes and transforms as edge attributes
+        self._element_to_cs_mapping: dict[str, NgffCoordinateSystem] = {}
+        # mapping element_name to the coordinate system to which the element belongs
 
-    def add_coordinate_system(self, cs: NgffCoordinateSystem) -> None:
+    def check_if_coordinate_system_exists(self, cs: NgffCoordinateSystem) -> None:
         """
-        Register a new coordinate system.
+        Check if a coordinate system exists in the graph.
 
         Parameters
         ----------
         cs
-            The coordinate system to register.
+            The coordinate system to check.
 
         Raises
         ------
         ValueError
-            If a coordinate system with the same name already exists.
-        """
-        if cs.name in self._coordinate_systems:
-            raise ValueError(f"Coordinate system with name '{cs.name}' already exists.")
-        self._coordinate_systems[cs.name] = cs
-
-    def _get_transformations_associated_with_cs(self, cs_name: str) -> list[tuple[str, str]]:
-        """
-        Get all transformations associated with a coordinate system.
-
-        Parameters
-        ----------
-        cs_name
-            The name of the coordinate system.
-
-        Returns
-        -------
-        list[tuple[str, str]]
-            A list of tuples representing the transformations associated with the coordinate system.
-        """
-        associated_transformations = []
-        for input_cs, output_cs in self._coordinate_transforms:
-            transformation_key = (input_cs, output_cs)
-            if (input_cs == cs_name or output_cs == cs_name) and transformation_key not in associated_transformations:
-                associated_transformations.append(transformation_key)
-        return associated_transformations
-
-    def _get_elements_belonging_to_cs(self, cs_name: str) -> list[tuple[ELEMENT_TYPE, str]]:
-        """
-        Get all elements belonging to a coordinate system.
-
-        Parameters
-        ----------
-        cs_name
-            The name of the coordinate system.
-
-        Returns
-        -------
-        list[tuple[ELEMENT_TYPE, str]]
-            A list of tuples representing the elements belonging to the coordinate system.
-        """
-        belonging_elements = []
-        for (element_type, element_name), element_cs in self._element_to_cs_mapping.items():
-            if element_cs == cs_name:
-                belonging_elements.append((element_type, element_name))
-        return belonging_elements
-
-    def remove_coordinate_system(self, cs_name: str) -> None:
-        """
-        Remove an existing coordinate system.
-
-        Parameters
-        ----------
-        cs_name
-            The name of the coordinate system to remove.
-
-        Raises
-        ------
-        KeyError
             If the coordinate system does not exist.
-        ValueError
-            If there are transformations associated with the coordinate system or elements belonging to it.
         """
-        if cs_name not in self._coordinate_systems:
-            raise KeyError(f"Coordinate system with name '{cs_name}' not found.")
+        if cs not in self._graph:
+            raise ValueError(f"Coordinate system '{cs.name}' does not exist in the transformation manager.")
 
-        associated_transformations = self._get_transformations_associated_with_cs(cs_name)
-        belonging_elements = self._get_elements_belonging_to_cs(cs_name)
+        self._graph.remove_node(cs)
 
-        # Raise error if there are associated transformations or belonging elements
-        if len(associated_transformations) or len(belonging_elements):
-            raise ValueError(
-                f"Cannot remove coordinate system with name '{cs_name}'. "
-                f"{len(belonging_elements)} elements belong to it and {len(associated_transformations)} transformations"
-                f" are associated with it. "
-                f"Please remove associated transformations and unset elements from the coordinate system first."
-            )
-
-        del self._coordinate_systems[cs_name]
-
-    def list_coordinate_systems(self) -> list[str]:
+    def list_coordinate_systems(self) -> list[NgffCoordinateSystem]:
         """
-        List all registered coordinate system names, ordered as they were added.
+        List all registered coordinate systems.
 
         Returns
         -------
-        A list of coordinate system names.
+        A list of coordinate system objects.
         """
-        return list(self._coordinate_systems.keys())
+        return list(self._graph.nodes())
 
-    def add_element(self, element_type: ELEMENT_TYPE, element_name: str, coordinate_system: str) -> None:
+    def add_element(self, element_name: str, coordinate_system: NgffCoordinateSystem) -> None:
         """
         Register an element and associate it with a coordinate system.
 
         Parameters
         ----------
-        element_type
-            The type of the element (e.g., 'images', 'labels', 'points', 'shapes').
         element_name
             The name of the element.
         coordinate_system
-            The name of the coordinate system to which the element belongs. If None, a new coordinate system
-            will be created with the name "<element_name>_created_at_insert".
+            The coordinate system to which the element belongs.
 
-        Raises
-        ------
-        KeyError
+        Warnings
+        --------
+        UserWarning
             If the coordinate system does not exist.
         """
-        if coordinate_system not in self._coordinate_systems:
-            raise KeyError(
-                f"Cannot set coordinate system ('{coordinate_system}') to element as the "
-                f"coordinate system does not exist."
+        if coordinate_system not in self._graph:
+            warnings.warn(
+                f"Cannot set coordinate system ('{coordinate_system.name}') to element as the "
+                f"coordinate system does not exist.",
+                UserWarning,
+                stacklevel=2,
             )
+            return
 
-        mapping_key = (element_type, element_name)
-        self._element_to_cs_mapping[mapping_key] = coordinate_system
+        self._element_to_cs_mapping[element_name] = coordinate_system
 
-    def get_element_coordinate_system(self, element_type: ELEMENT_TYPE, element_name: str) -> str | None:
+    def get_element_coordinate_system(self, element_name: str) -> NgffCoordinateSystem | None:
         """
-        Get the name of the coordinate system to which an element belongs.
+        Get the coordinate system to which an element belongs.
 
         Parameters
         ----------
-        element_type
-            The type of the element.
         element_name
             The name of the element.
 
         Returns
         -------
-        The name of the coordinate system or None if not found
-
+        The coordinate system or None if not found
         """
-        mapping_key = (element_type, element_name)
-        return self._element_to_cs_mapping.get(mapping_key)
+        return self._element_to_cs_mapping.get(element_name)
 
-    def add_transformation(self, input_cs: str, output_cs: str, transformation: BaseTransformation) -> None:
+    def unset_element(self, element_name: str) -> None:
+        """
+        Unregister an element from the coordinate system to which it belongs.
+
+        Parameters
+        ----------
+        element_name
+            The name of the element.
+
+        Warnings
+        --------
+        UserWarning
+            If the element has not been registered to any coordinate system.
+        """
+        if element_name not in self._element_to_cs_mapping:
+            warnings.warn(f"Element '{element_name}' not found in any coordinate system.", UserWarning, stacklevel=2)
+            return
+        del self._element_to_cs_mapping[element_name]
+
+    def add_transformation(
+        self, input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem, transformation: BaseTransformation
+    ) -> None:
         """
         Add a transformation between coordinate systems.
 
         Parameters
         ----------
         input_cs
-            The name of the input coordinate system.
+            The input coordinate system.
         output_cs
-            The name of the output coordinate system.
+            The output coordinate system.
         transformation
             The transformation to add.
 
@@ -191,92 +128,115 @@ class TransformationManager:
         ValueError
             If either coordinate system does not exist.
         """
-        if input_cs not in self._coordinate_systems:
-            raise ValueError(
-                f"Input coordinate system '{input_cs}' does not exist."
-                f" Please create it before adding a transform associated with it"
-            )
-        if output_cs not in self._coordinate_systems:
-            raise ValueError(
-                f"Output coordinate system '{output_cs}' does not exist."
-                f" Please create it before adding a transform associated with it"
-            )
+        self.check_if_coordinate_system_exists(input_cs)
+        self.check_if_coordinate_system_exists(output_cs)
 
-        key = (input_cs, output_cs)
-        self._coordinate_transforms[key] = transformation
+        self._graph.add_edge(input_cs, output_cs, **{TRANSFORM_KEY: transformation})
 
-    def get_existing_transformation(self, input_cs: str, output_cs: str) -> BaseTransformation | None:
+    def get_transformation(
+        self, input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem
+    ) -> BaseTransformation | None:
         """
         Retrieve a transformation defined between coordinate systems.
 
         Parameters
         ----------
         input_cs
-            The name of the input coordinate system.
+            The input coordinate system.
         output_cs
-            The name of the output coordinate system.
+            The output coordinate system.
 
         Returns
         -------
-        The transformation
-
-        Raises
-        ------
-        KeyError:
-            if no transformation exists from input_cs to output_cs.
+        The transformation or None if not found
         """
-        key = (input_cs, output_cs)
-        return self._coordinate_transforms.get(key)
+        self.check_if_coordinate_system_exists(input_cs)
+        self.check_if_coordinate_system_exists(output_cs)
 
-    def remove_transformation(self, input_cs: str, output_cs: str) -> None:
+        if self._graph.has_edge(input_cs, output_cs):
+            transform: BaseTransformation = self._graph[input_cs][output_cs][0][TRANSFORM_KEY]
+            return transform
+        return None
+
+    def remove_transformation(self, input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem) -> None:
         """
         Remove a transformation between coordinate systems.
 
         Parameters
         ----------
         input_cs
-            The name of the input coordinate system.
+            The input coordinate system.
         output_cs
-            The name of the output coordinate system.
+            The output coordinate system.
+
+        Raises
+        ------
+        ValueError
+            If either coordinate system does not exist.
+        KeyError
+            If the transformation does not exist.
+        """
+        self.check_if_coordinate_system_exists(input_cs)
+        self.check_if_coordinate_system_exists(output_cs)
+
+        if not self._graph.has_edge(input_cs, output_cs):
+            raise KeyError(f"Transformation from '{input_cs.name}' to '{output_cs.name}' not found.")
+        self._graph.remove_edge(input_cs, output_cs)
+
+    def get_element_transformation(
+        self, element_name: str, target_cs: NgffCoordinateSystem
+    ) -> BaseTransformation | None:
+        """
+        Get the transformation from the coordinate system to which the element belongs to a target coordinate system.
+
+        Parameters
+        ----------
+        element_name
+            The name of the element.
+        target_cs
+            The target coordinate system.
+
+        Returns
+        -------
+        The transformation or None if not found
 
         Raises
         ------
         KeyError
-            If the transformation does not exist.
+            If target_cs has not been added or if element_name does not belong to a coordinate system.
         """
-        key = (input_cs, output_cs)
-        if key not in self._coordinate_transforms:
-            raise KeyError(f"Transformation from '{input_cs}' to '{output_cs}' not found.")
-        del self._coordinate_transforms[key]
+        if target_cs not in self._graph:
+            raise KeyError(f"Target coordinate system '{target_cs.name}' not found.")
 
-    def build_nx_graph(self) -> nx.DiGraph:
+        element_cs = self.get_element_coordinate_system(element_name)
+        if element_cs is None:
+            raise KeyError(f"Element '{element_name}' does not belong to any coordinate system.")
+
+        return self.get_transformation(element_cs, target_cs)
+
+    def build_nx_graph(self) -> nx.MultiDiGraph:
         """
         Build a directed graph where nodes are coordinate systems and edges are transformations.
 
         Returns
         -------
-        nx.DiGraph
+        nx.MultiDiGraph
             A directed graph representing the coordinate systems and transformations.
         """
-        import networkx as nx
+        return self._graph.copy()
 
-        g = nx.DiGraph()
-        for cs_name in self._coordinate_systems:
-            g.add_node(cs_name)
-        for (input_cs, output_cs), transformation in self._coordinate_transforms.items():
-            g.add_edge(input_cs, output_cs, transformation=transformation)
-        return g
-
-    def get_shortest_transformation_sequence(self, source_cs: str, target_cs: str) -> list[BaseTransformation]:
+    def get_shortest_transformation_sequence(
+        self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
+    ) -> list[BaseTransformation]:
         """
         Get the shortest sequence of transformations between two coordinate systems.
 
         Parameters
         ----------
         source_cs
-            The name of the source coordinate system.
+            The source coordinate system.
         target_cs
-            The name of the target coordinate system.
+            The target coordinate system.
 
         Returns
         -------
@@ -288,57 +248,55 @@ class TransformationManager:
         ValueError
             If no path exists between the source and target coordinate systems.
         """
-        if (source_cs, target_cs) in self._coordinate_transforms:
-            return [self._coordinate_transforms[(source_cs, target_cs)]]
-
-        g = self.build_nx_graph()
-        import networkx as nx
+        if self._graph.has_edge(source_cs, target_cs):
+            return [self._graph[source_cs][target_cs][0][TRANSFORM_KEY]]
 
         try:
-            path = nx.shortest_path(g, source=source_cs, target=target_cs)
+            path = nx.shortest_path(self._graph, source=source_cs, target=target_cs)
 
         except nx.NetworkXNoPath as nxe:
-            raise ValueError(f"No path found from {source_cs} to {target_cs}") from nxe
+            raise ValueError(f"No path found from {source_cs.name} to {target_cs.name}") from nxe
 
         transformations = []
         for i in range(len(path) - 1):
-            transformations.append(g[path[i]][path[i + 1]]["transformation"])
+            edge_data = self._graph[path[i]][path[i + 1]]
+            transformations.append(edge_data[0][TRANSFORM_KEY])
         return transformations
 
-    def get_all_transformation_sequences(self, source_cs: str, target_cs: str) -> list[list[BaseTransformation]]:
+    def get_all_transformation_sequences(
+        self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
+    ) -> list[list[BaseTransformation]]:
         """
         Get all existing sequences of transformations between two coordinate systems.
 
         Parameters
         ----------
         source_cs
-            The name of the source coordinate system.
+            The source coordinate system.
         target_cs
-            The name of the target coordinate system.
+            The target coordinate system.
 
         Returns
         -------
         list[list[BaseTransformation]]
             All existing sequences of transformations from source_cs to target_cs.
         """
-        g = self.build_nx_graph()
-        import networkx as nx
-
-        paths = list(nx.all_simple_paths(g, source=source_cs, target=target_cs))
+        paths = list(nx.all_simple_paths(self._graph, source=source_cs, target=target_cs))
 
         all_sequences = []
         for path in paths:
             sequence = []
             for i in range(len(path) - 1):
-                sequence.append(g[path[i]][path[i + 1]]["transformation"])
+                edge_data = self._graph[path[i]][path[i + 1]]
+                sequence.append(edge_data[0][TRANSFORM_KEY])
             all_sequences.append(sequence)
         return all_sequences
 
     def __repr__(self) -> str:
         return (
             f"TransformationManager("
-            f"  coordinate_systems={list(self._coordinate_systems.keys())}, "
-            f"  coordinate_transforms={list(self._coordinate_transforms.keys())}, "
+            f"  coordinate_systems={list(self._graph.nodes())}, "
+            f"  coordinate_transforms={list(self._graph.edges())}, "
             f"  elements={list(self._element_to_cs_mapping.keys())}"
             f")"
         )

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from spatialdata._types import ELEMENT_TYPE
 from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
 from spatialdata.transformations.transformations import BaseTransformation
+
+if TYPE_CHECKING:
+    import networkx as nx
 
 
 class TransformationManager:
@@ -60,9 +63,9 @@ class TransformationManager:
                 associated_transformations.append(transformation_key)
         return associated_transformations
 
-    def _get_elements_associated_with_cs(self, cs_name: str) -> list[tuple[ELEMENT_TYPE, str]]:
+    def _get_elements_belonging_to_cs(self, cs_name: str) -> list[tuple[ELEMENT_TYPE, str]]:
         """
-        Get all elements associated with a coordinate system.
+        Get all elements belonging to a coordinate system.
 
         Parameters
         ----------
@@ -72,13 +75,13 @@ class TransformationManager:
         Returns
         -------
         list[tuple[ELEMENT_TYPE, str]]
-            A list of tuples representing the elements associated with the coordinate system.
+            A list of tuples representing the elements belonging to the coordinate system.
         """
-        associated_elements = []
+        belonging_elements = []
         for (element_type, element_name), element_cs in self._element_to_cs_mapping.items():
             if element_cs == cs_name:
-                associated_elements.append((element_type, element_name))
-        return associated_elements
+                belonging_elements.append((element_type, element_name))
+        return belonging_elements
 
     def remove_coordinate_system(self, cs_name: str) -> None:
         """
@@ -94,21 +97,21 @@ class TransformationManager:
         KeyError
             If the coordinate system does not exist.
         ValueError
-            If there are transformations or elements associated with the coordinate system.
+            If there are transformations associated with the coordinate system or elements belonging to it.
         """
         if cs_name not in self._coordinate_systems:
             raise KeyError(f"Coordinate system with name '{cs_name}' not found.")
 
         associated_transformations = self._get_transformations_associated_with_cs(cs_name)
-        associated_elements = self._get_elements_associated_with_cs(cs_name)
+        belonging_elements = self._get_elements_belonging_to_cs(cs_name)
 
-        # Raise error if there are associated transformations or elements
-        if len(associated_transformations) or len(associated_elements):
+        # Raise error if there are associated transformations or belonging elements
+        if len(associated_transformations) or len(belonging_elements):
             raise ValueError(
                 f"Cannot remove coordinate system with name '{cs_name}'. "
-                f"{len(associated_elements)} elements and {len(associated_transformations)} transformations"
+                f"{len(belonging_elements)} elements belong to it and {len(associated_transformations)} transformations"
                 f" are associated with it. "
-                f"Please remove transformations or disassociate elements from the coordinate system first."
+                f"Please remove associated transformations and unset elements from the coordinate system first."
             )
 
         del self._coordinate_systems[cs_name]
@@ -246,8 +249,7 @@ class TransformationManager:
             raise KeyError(f"Transformation from '{input_cs}' to '{output_cs}' not found.")
         del self._coordinate_transforms[key]
 
-    def build_nx_graph(self) -> Any:  # type: ignore[unresolved-reference]  # noqa: F821
-        # nx lazily imported
+    def build_nx_graph(self) -> nx.DiGraph:
         """
         Build a directed graph where nodes are coordinate systems and edges are transformations.
 
@@ -293,9 +295,9 @@ class TransformationManager:
         import networkx as nx
 
         try:
-            path = nx.shortest_path(g, source=source_cs, target=target_cs)  # type: ignore[name-defined, unresolved-reference]  # noqa: F821
-            # nx lazily imported
-        except nx.NetworkXNoPath as nxe:  # type: ignore[name-defined, unresolved-reference]  # noqa: F821
+            path = nx.shortest_path(g, source=source_cs, target=target_cs)
+
+        except nx.NetworkXNoPath as nxe:
             raise ValueError(f"No path found from {source_cs} to {target_cs}") from nxe
 
         transformations = []

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+from typing import Any
+
+from spatialdata._types import ELEMENT_TYPE
+from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
+from spatialdata.transformations.transformations import BaseTransformation
+
+
+class TransformationManager:
+    """Centralized storage for managing coordinate systems (cs), transformations and element-cs mapping."""
+
+    def __init__(self) -> None:
+        """Initialize a Scene with empty mappings."""
+        self._coordinate_systems: dict[str, NgffCoordinateSystem] = {}
+        # mapping names of coordinate system to coordinate systems
+        self._coordinate_transforms: dict[tuple[str, str], BaseTransformation] = {}
+        # mapping a tuple of coordinate system names, (<source coordinate system name>, <target coordinate system name>)
+        # to a transformation object representing the transformation between them
+        self._element_to_cs_mapping: dict[tuple[ELEMENT_TYPE, str], str] = {}
+        # mapping a tuple, (<element type>, <element key in parent spatialdata object>) to the name of the coordinate
+        # system
+
+    def add_coordinate_system(self, cs: NgffCoordinateSystem) -> None:
+        """
+        Register a new coordinate system.
+
+        Parameters
+        ----------
+        cs
+            The coordinate system to register.
+
+        Raises
+        ------
+        ValueError
+            If a coordinate system with the same name already exists.
+        """
+        if cs.name in self._coordinate_systems:
+            raise ValueError(f"Coordinate system with name '{cs.name}' already exists.")
+        self._coordinate_systems[cs.name] = cs
+
+    def _get_transformations_associated_with_cs(self, cs_name: str) -> list[tuple[str, str]]:
+        """
+        Get all transformations associated with a coordinate system.
+
+        Parameters
+        ----------
+        cs_name
+            The name of the coordinate system.
+
+        Returns
+        -------
+        list[tuple[str, str]]
+            A list of tuples representing the transformations associated with the coordinate system.
+        """
+        associated_transformations = []
+        for input_cs, output_cs in self._coordinate_transforms:
+            transformation_key = (input_cs, output_cs)
+            if (input_cs == cs_name or output_cs == cs_name) and transformation_key not in associated_transformations:
+                associated_transformations.append(transformation_key)
+        return associated_transformations
+
+    def _get_elements_associated_with_cs(self, cs_name: str) -> list[tuple[ELEMENT_TYPE, str]]:
+        """
+        Get all elements associated with a coordinate system.
+
+        Parameters
+        ----------
+        cs_name
+            The name of the coordinate system.
+
+        Returns
+        -------
+        list[tuple[ELEMENT_TYPE, str]]
+            A list of tuples representing the elements associated with the coordinate system.
+        """
+        associated_elements = []
+        for (element_type, element_name), element_cs in self._element_to_cs_mapping.items():
+            if element_cs == cs_name:
+                associated_elements.append((element_type, element_name))
+        return associated_elements
+
+    def remove_coordinate_system(self, cs_name: str) -> None:
+        """
+        Remove an existing coordinate system.
+
+        Parameters
+        ----------
+        cs_name
+            The name of the coordinate system to remove.
+
+        Raises
+        ------
+        KeyError
+            If the coordinate system does not exist.
+        ValueError
+            If there are transformations or elements associated with the coordinate system.
+        """
+        if cs_name not in self._coordinate_systems:
+            raise KeyError(f"Coordinate system with name '{cs_name}' not found.")
+
+        associated_transformations = self._get_transformations_associated_with_cs(cs_name)
+        associated_elements = self._get_elements_associated_with_cs(cs_name)
+
+        # Raise error if there are associated transformations or elements
+        if len(associated_transformations) or len(associated_elements):
+            raise ValueError(
+                f"Cannot remove coordinate system with name '{cs_name}'. "
+                f"{len(associated_elements)} elements and {len(associated_transformations)} transformations"
+                f" are associated with it. "
+                f"Please remove transformations or disassociate elements from the coordinate system first."
+            )
+
+        del self._coordinate_systems[cs_name]
+
+    def list_coordinate_systems(self) -> list[str]:
+        """
+        List all registered coordinate system names, ordered as they were added.
+
+        Returns
+        -------
+        A list of coordinate system names.
+        """
+        return list(self._coordinate_systems.keys())
+
+    def add_element(self, element_type: ELEMENT_TYPE, element_name: str, coordinate_system: str) -> None:
+        """
+        Register an element and associate it with a coordinate system.
+
+        Parameters
+        ----------
+        element_type
+            The type of the element (e.g., 'images', 'labels', 'points', 'shapes').
+        element_name
+            The name of the element.
+        coordinate_system
+            The name of the coordinate system to which the element belongs. If None, a new coordinate system
+            will be created with the name "<element_name>_created_at_insert".
+
+        Raises
+        ------
+        KeyError
+            If the coordinate system does not exist.
+        """
+        if coordinate_system not in self._coordinate_systems:
+            raise KeyError(
+                f"Cannot set coordinate system ('{coordinate_system}') to element as the "
+                f"coordinate system does not exist."
+            )
+
+        mapping_key = (element_type, element_name)
+        self._element_to_cs_mapping[mapping_key] = coordinate_system
+
+    def get_element_coordinate_system(self, element_type: ELEMENT_TYPE, element_name: str) -> str | None:
+        """
+        Get the name of the coordinate system to which an element belongs.
+
+        Parameters
+        ----------
+        element_type
+            The type of the element.
+        element_name
+            The name of the element.
+
+        Returns
+        -------
+        The name of the coordinate system or None if not found
+
+        """
+        mapping_key = (element_type, element_name)
+        return self._element_to_cs_mapping.get(mapping_key)
+
+    def add_transformation(self, input_cs: str, output_cs: str, transformation: BaseTransformation) -> None:
+        """
+        Add a transformation between coordinate systems.
+
+        Parameters
+        ----------
+        input_cs
+            The name of the input coordinate system.
+        output_cs
+            The name of the output coordinate system.
+        transformation
+            The transformation to add.
+
+        Raises
+        ------
+        ValueError
+            If either coordinate system does not exist.
+        """
+        if input_cs not in self._coordinate_systems:
+            raise ValueError(
+                f"Input coordinate system '{input_cs}' does not exist."
+                f" Please create it before adding a transform associated with it"
+            )
+        if output_cs not in self._coordinate_systems:
+            raise ValueError(
+                f"Output coordinate system '{output_cs}' does not exist."
+                f" Please create it before adding a transform associated with it"
+            )
+
+        key = (input_cs, output_cs)
+        self._coordinate_transforms[key] = transformation
+
+    def get_existing_transformation(self, input_cs: str, output_cs: str) -> BaseTransformation | None:
+        """
+        Retrieve a transformation defined between coordinate systems.
+
+        Parameters
+        ----------
+        input_cs
+            The name of the input coordinate system.
+        output_cs
+            The name of the output coordinate system.
+
+        Returns
+        -------
+        The transformation
+
+        Raises
+        ------
+        KeyError:
+            if no transformation exists from input_cs to output_cs.
+        """
+        key = (input_cs, output_cs)
+        return self._coordinate_transforms.get(key)
+
+    def remove_transformation(self, input_cs: str, output_cs: str) -> None:
+        """
+        Remove a transformation between coordinate systems.
+
+        Parameters
+        ----------
+        input_cs
+            The name of the input coordinate system.
+        output_cs
+            The name of the output coordinate system.
+
+        Raises
+        ------
+        KeyError
+            If the transformation does not exist.
+        """
+        key = (input_cs, output_cs)
+        if key not in self._coordinate_transforms:
+            raise KeyError(f"Transformation from '{input_cs}' to '{output_cs}' not found.")
+        del self._coordinate_transforms[key]
+
+    def build_nx_graph(self) -> Any:  # type: ignore[unresolved-reference]  # noqa: F821
+        # nx lazily imported
+        """
+        Build a directed graph where nodes are coordinate systems and edges are transformations.
+
+        Returns
+        -------
+        nx.DiGraph
+            A directed graph representing the coordinate systems and transformations.
+        """
+        import networkx as nx
+
+        g = nx.DiGraph()
+        for cs_name in self._coordinate_systems:
+            g.add_node(cs_name)
+        for (input_cs, output_cs), transformation in self._coordinate_transforms.items():
+            g.add_edge(input_cs, output_cs, transformation=transformation)
+        return g
+
+    def get_shortest_transformation_sequence(self, source_cs: str, target_cs: str) -> list[BaseTransformation]:
+        """
+        Get the shortest sequence of transformations between two coordinate systems.
+
+        Parameters
+        ----------
+        source_cs
+            The name of the source coordinate system.
+        target_cs
+            The name of the target coordinate system.
+
+        Returns
+        -------
+        list[BaseTransformation]
+            The shortest sequence of transformations from source_cs to target_cs.
+
+        Raises
+        ------
+        ValueError
+            If no path exists between the source and target coordinate systems.
+        """
+        if (source_cs, target_cs) in self._coordinate_transforms:
+            return [self._coordinate_transforms[(source_cs, target_cs)]]
+
+        g = self.build_nx_graph()
+        import networkx as nx
+
+        try:
+            path = nx.shortest_path(g, source=source_cs, target=target_cs)  # type: ignore[name-defined, unresolved-reference]  # noqa: F821
+            # nx lazily imported
+        except nx.NetworkXNoPath as nxe:  # type: ignore[name-defined, unresolved-reference]  # noqa: F821
+            raise ValueError(f"No path found from {source_cs} to {target_cs}") from nxe
+
+        transformations = []
+        for i in range(len(path) - 1):
+            transformations.append(g[path[i]][path[i + 1]]["transformation"])
+        return transformations
+
+    def get_all_transformation_sequences(self, source_cs: str, target_cs: str) -> list[list[BaseTransformation]]:
+        """
+        Get all existing sequences of transformations between two coordinate systems.
+
+        Parameters
+        ----------
+        source_cs
+            The name of the source coordinate system.
+        target_cs
+            The name of the target coordinate system.
+
+        Returns
+        -------
+        list[list[BaseTransformation]]
+            All existing sequences of transformations from source_cs to target_cs.
+        """
+        g = self.build_nx_graph()
+        import networkx as nx
+
+        paths = list(nx.all_simple_paths(g, source=source_cs, target=target_cs))
+
+        all_sequences = []
+        for path in paths:
+            sequence = []
+            for i in range(len(path) - 1):
+                sequence.append(g[path[i]][path[i + 1]]["transformation"])
+            all_sequences.append(sequence)
+        return all_sequences
+
+    def __repr__(self) -> str:
+        return (
+            f"TransformationManager("
+            f"  coordinate_systems={list(self._coordinate_systems.keys())}, "
+            f"  coordinate_transforms={list(self._coordinate_transforms.keys())}, "
+            f"  elements={list(self._element_to_cs_mapping.keys())}"
+            f")"
+        )

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -4,6 +4,11 @@ import warnings
 
 import networkx as nx
 
+from spatialdata._core.transformation_manager.exceptions import (
+    CoordinateSystemNotFoundError,
+    ElementNotFoundError,
+    TransformationNotFoundError,
+)
 from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
 from spatialdata.transformations.transformations import BaseTransformation
 
@@ -18,6 +23,23 @@ class TransformationManager:
         self._element_to_cs_mapping: dict[str, NgffCoordinateSystem] = {}
         # mapping element_name to the coordinate system to which the element belongs
 
+    def check_if_element_exists(self, element_name: str) -> None:
+        """
+        Check if an element exists in the transformation manager.
+
+        Parameters
+        ----------
+        element_name
+            The name of the element to check.
+
+        Raises
+        ------
+        ElementNotFoundError
+            If the element does not exist.
+        """
+        if element_name not in self._element_to_cs_mapping:
+            raise ElementNotFoundError(element_name)
+
     def check_if_coordinate_system_exists(self, cs: NgffCoordinateSystem) -> None:
         """
         Check if a coordinate system exists in the graph.
@@ -29,11 +51,30 @@ class TransformationManager:
 
         Raises
         ------
-        ValueError
+        CoordinateSystemNotFoundError
             If the coordinate system does not exist.
         """
         if cs not in self._graph:
-            raise ValueError(f"Coordinate system '{cs.name}' does not exist in the transformation manager.")
+            raise CoordinateSystemNotFoundError(cs.name)
+
+    def check_if_edge_exists(self, input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem) -> None:
+        """
+        Check if an edge exists between coordinate systems.
+
+        Parameters
+        ----------
+        input_cs
+            The input coordinate system.
+        output_cs
+            The output coordinate system.
+
+        Raises
+        ------
+        TransformationNotFoundError
+            If the edge does not exist.
+        """
+        if not self._graph.has_edge(input_cs, output_cs):
+            raise TransformationNotFoundError(input_cs.name, output_cs.name)
 
     def list_coordinate_systems(self) -> list[NgffCoordinateSystem]:
         """
@@ -61,7 +102,19 @@ class TransformationManager:
         UserWarning
             If the coordinate system does not exist.
         """
-        if coordinate_system not in self._graph:
+        try:
+            self.check_if_element_exists(element_name)
+        except ElementNotFoundError as _enfe:
+            warnings.warn(
+                f"Cannot add element with name '{element_name}') as it already "
+                f"exists in the transformation manager. Skipping",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        try:
+            self.check_if_coordinate_system_exists(coordinate_system)
+        except CoordinateSystemNotFoundError as _csnfe:
             warnings.warn(
                 f"Cannot set coordinate system ('{coordinate_system.name}') to element as the "
                 f"coordinate system does not exist.",
@@ -72,7 +125,7 @@ class TransformationManager:
 
         self._element_to_cs_mapping[element_name] = coordinate_system
 
-    def get_element_coordinate_system(self, element_name: str) -> NgffCoordinateSystem | None:
+    def get_element_coordinate_system(self, element_name: str) -> NgffCoordinateSystem:
         """
         Get the coordinate system to which an element belongs.
 
@@ -84,8 +137,14 @@ class TransformationManager:
         Returns
         -------
         The coordinate system or None if not found
+
+        Raises
+        ------
+        ElementNotFoundError
+            If the element does not exist.
         """
-        return self._element_to_cs_mapping.get(element_name)
+        self.check_if_element_exists(element_name)
+        return self._element_to_cs_mapping[element_name]
 
     def unset_element(self, element_name: str) -> None:
         """
@@ -96,14 +155,12 @@ class TransformationManager:
         element_name
             The name of the element.
 
-        Warnings
-        --------
-        UserWarning
+        Raises
+        ------
+        ElementNotFoundError
             If the element has not been registered to any coordinate system.
         """
-        if element_name not in self._element_to_cs_mapping:
-            warnings.warn(f"Element '{element_name}' not found in any coordinate system.", UserWarning, stacklevel=2)
-            return
+        self.check_if_element_exists(element_name)
         del self._element_to_cs_mapping[element_name]
 
     def add_transformation(
@@ -123,7 +180,7 @@ class TransformationManager:
 
         Raises
         ------
-        ValueError
+        CoordinateSystemNotFoundError
             If either coordinate system does not exist.
         """
         self.check_if_coordinate_system_exists(input_cs)
@@ -133,7 +190,7 @@ class TransformationManager:
 
     def get_existing_transformation(
         self, input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem
-    ) -> BaseTransformation | None:
+    ) -> BaseTransformation:
         """
         Retrieve a transformation defined between coordinate systems.
 
@@ -147,14 +204,21 @@ class TransformationManager:
         Returns
         -------
         The transformation or None if not found
+
+        Raises
+        ------
+        CoordinateSystemNotFoundError
+            If either coordinate system does not exist.
+        TransformationNotFoundError
+            If the transformation does not exist.
         """
         self.check_if_coordinate_system_exists(input_cs)
         self.check_if_coordinate_system_exists(output_cs)
 
-        if self._graph.has_edge(input_cs, output_cs):
-            transform: BaseTransformation = self._graph[input_cs][output_cs][0][TRANSFORM_KEY]
-            return transform
-        return None
+        self.check_if_edge_exists(input_cs, output_cs)
+
+        transform: BaseTransformation = self._graph[input_cs][output_cs][0][TRANSFORM_KEY]
+        return transform
 
     def remove_transformation(self, input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem) -> None:
         """
@@ -169,59 +233,16 @@ class TransformationManager:
 
         Raises
         ------
-        ValueError
+        CoordinateSystemNotFoundError
             If either coordinate system does not exist.
-        KeyError
+        TransformationNotFoundError
             If the transformation does not exist.
         """
         self.check_if_coordinate_system_exists(input_cs)
         self.check_if_coordinate_system_exists(output_cs)
 
-        if not self._graph.has_edge(input_cs, output_cs):
-            raise KeyError(f"Transformation from '{input_cs.name}' to '{output_cs.name}' not found.")
+        self.check_if_edge_exists(input_cs, output_cs)
         self._graph.remove_edge(input_cs, output_cs)
-
-    def get_element_transformation(
-        self, element_name: str, target_cs: NgffCoordinateSystem
-    ) -> BaseTransformation | None:
-        """
-        Get the transformation from the coordinate system to which the element belongs to a target coordinate system.
-
-        Parameters
-        ----------
-        element_name
-            The name of the element.
-        target_cs
-            The target coordinate system.
-
-        Returns
-        -------
-        The transformation or None if not found
-
-        Raises
-        ------
-        KeyError
-            If target_cs has not been added or if element_name does not belong to a coordinate system.
-        """
-        if target_cs not in self._graph:
-            raise KeyError(f"Target coordinate system '{target_cs.name}' not found.")
-
-        element_cs = self.get_element_coordinate_system(element_name)
-        if element_cs is None:
-            raise KeyError(f"Element '{element_name}' does not belong to any coordinate system.")
-
-        return self.get_existing_transformation(element_cs, target_cs)
-
-    def build_nx_graph(self) -> nx.MultiDiGraph:
-        """
-        Build a directed graph where nodes are coordinate systems and edges are transformations.
-
-        Returns
-        -------
-        nx.MultiDiGraph
-            A directed graph representing the coordinate systems and transformations.
-        """
-        return self._graph.copy()
 
     def get_shortest_transformation_sequence(
         self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Sequence
 
 import networkx as nx
 
@@ -14,6 +15,7 @@ from spatialdata._core.transformation_manager.exceptions import (
     ElementNotFoundError,
     InternalAttributeAccessWarning,
     TransformationNotFoundError,
+    TransformationPathAmbiguousError,
     TransformationPathNotFoundError,
     suppress_direct_internal_attribute_access_warning,
 )
@@ -116,7 +118,7 @@ class TransformationManager:
             if cs not in self.graph:
                 raise CoordinateSystemNotFoundError(cs.name)
 
-    def check_if_edge_exists_else_raise_error(
+    def check_if_any_edge_exists_else_raise_error(
         self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
     ) -> None:
         """
@@ -311,6 +313,11 @@ class TransformationManager:
         with suppress_direct_internal_attribute_access_warning():
             del self.element_to_cs_mapping[element_name]
 
+    @staticmethod
+    def _get_edge_key_from_transform(transform: BaseTransformation) -> str:
+
+        return repr(transform)
+
     def add_transformation(
         self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem, transformation: BaseTransformation
     ) -> None:
@@ -335,13 +342,15 @@ class TransformationManager:
         self.check_if_coordinate_system_exists_else_raise_error(target_cs)
 
         with suppress_direct_internal_attribute_access_warning():
-            self.graph.add_edge(source_cs, target_cs, **{TRANSFORM_KEY: transformation})
+            edge_key = self._get_edge_key_from_transform(transformation)
+            edge_attributes = {TRANSFORM_KEY: transformation}
+            self.graph.add_edge(source_cs, target_cs, key=edge_key, **edge_attributes)
 
-    def get_existing_transformation(
+    def get_existing_direct_transformations(
         self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
-    ) -> BaseTransformation:
+    ) -> list[BaseTransformation]:
         """
-        Retrieve a transformation defined between coordinate systems.
+        Retrieve transformations directly defined between coordinate systems.
 
         Parameters
         ----------
@@ -352,7 +361,7 @@ class TransformationManager:
 
         Returns
         -------
-        The transformation or None if not found
+        List of transformations
 
         Raises
         ------
@@ -361,15 +370,58 @@ class TransformationManager:
         TransformationNotFoundError
             If the transformation does not exist.
         """
-        self.check_if_edge_exists_else_raise_error(source_cs, target_cs)
+        self.check_if_any_edge_exists_else_raise_error(source_cs, target_cs)
         # also checks if source_cs and target_cs exist
         with suppress_direct_internal_attribute_access_warning():
-            transform: BaseTransformation = self.graph[source_cs][target_cs][0][TRANSFORM_KEY]
-            return transform
+            transforms = []
+            assert target_cs in self.graph[source_cs], TransformationNotFoundError(source_cs.name, target_cs.name)
+            for _edge_key, edge in self.graph[source_cs][target_cs]:
+                transform: BaseTransformation = edge[TRANSFORM_KEY]
+                transforms.append(transform)
+            return transforms
 
-    def remove_transformation(self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem) -> None:
+    def remove_specific_transformation(
+        self,
+        source_cs: NgffCoordinateSystem,
+        target_cs: NgffCoordinateSystem,
+        transformation: BaseTransformation,
+    ) -> None:
         """
-        Remove a transformation between coordinate systems.
+        Remove a specific transformation between coordinate systems.
+
+        Parameters
+        ----------
+        source_cs
+            The input coordinate system.
+        target_cs
+            The output coordinate system.
+        transformation
+            The transformation to remove.
+            (mainly useful for cases with multiple transformations between the same coordinate systems).
+
+        Raises
+        ------
+        CoordinateSystemNotFoundError
+            If either coordinate system does not exist.
+        TransformationNotFoundError
+            If the transformation does not exist.
+        """
+        self.check_if_any_edge_exists_else_raise_error(source_cs, target_cs)
+        # also checks if source_cs and target_cs exist
+        with suppress_direct_internal_attribute_access_warning():
+            expected_edge_key = self._get_edge_key_from_transform(transformation)
+            assert expected_edge_key in self.graph[source_cs][target_cs], TransformationNotFoundError(
+                source_cs.name, target_cs.name, expected_edge_key
+            )
+            self.graph.remove_edge(source_cs, target_cs, key=expected_edge_key)
+
+    def remove_all_transformations(
+        self,
+        source_cs: NgffCoordinateSystem,
+        target_cs: NgffCoordinateSystem,
+    ) -> None:
+        """
+        Remove all transformation between coordinate systems.
 
         Parameters
         ----------
@@ -383,18 +435,69 @@ class TransformationManager:
         CoordinateSystemNotFoundError
             If either coordinate system does not exist.
         TransformationNotFoundError
-            If the transformation does not exist.
+            If no transformation exists between the coordiante systems
         """
-        self.check_if_edge_exists_else_raise_error(source_cs, target_cs)
+        self.check_if_any_edge_exists_else_raise_error(source_cs, target_cs)
         # also checks if source_cs and target_cs exist
         with suppress_direct_internal_attribute_access_warning():
-            self.graph.remove_edge(source_cs, target_cs)
+            assert len(self.graph[source_cs][target_cs]), TransformationNotFoundError(source_cs.name, target_cs.name)
+            for edge_key, _edge in self.graph[source_cs][target_cs]:
+                self.graph.remove_edge(source_cs, target_cs, key=edge_key)
 
-    def get_shortest_transformation_sequence(
-        self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
-    ) -> list[BaseTransformation]:
+    def _get_transformation_sequences_from_path_after_disambiguation(
+        self,
+        paths: Sequence[list[NgffCoordinateSystem]],
+        expected_intermediate_transformations: list[BaseTransformation] | None,
+    ) -> list[list[BaseTransformation]]:
         """
-        Get the shortest sequence of transformations between two coordinate systems.
+        Traverses paths to form sequence of Transformations.
+
+        In case of ambiguity looks into `expected_intermediate_transformations` to disambiguate.
+
+        Parameters
+        ----------
+        paths:
+            sequence of list of nodes
+        expected_intermediate_transformations:
+            list of transformation objects
+
+        Returns
+        -------
+            list of sequences of transformations
+        """
+        intermediate_transformation_edge_keys = set()
+        if expected_intermediate_transformations is not None:
+            intermediate_transformation_edge_keys |= {
+                self._get_edge_key_from_transform(it) for it in expected_intermediate_transformations
+            }
+        all_sequences = []
+        for path in paths:
+            sequence = []
+            for i in range(len(path) - 1):
+                edge_data = self.graph[path[i]][path[i + 1]]
+                if len(edge_data) >= 1:
+                    # when there are multiple edges between a pair of coordinate systems in the path
+                    intermediate_transformation_key_here = intermediate_transformation_edge_keys & set(edge_data.keys())
+                    if len(intermediate_transformation_key_here) == 0:
+                        # transformation was not specified in `intermediate_transformations` for disambiguation
+                        raise TransformationPathAmbiguousError(path[i].name, path[i + 1].name)
+
+                    edge_key_to_use = list(intermediate_transformation_key_here)[0]
+                    # choosing the first one arbitrarily
+                    sequence.append(edge_data[edge_key_to_use][TRANSFORM_KEY])
+                else:
+                    sequence.append(edge_data[0][TRANSFORM_KEY])
+            all_sequences.append(sequence)
+        return all_sequences
+
+    def get_all_shortest_transformation_sequences(
+        self,
+        source_cs: NgffCoordinateSystem,
+        target_cs: NgffCoordinateSystem,
+        expected_intermediate_transformations: list[BaseTransformation] | None = None,
+    ) -> list[list[BaseTransformation]]:
+        """
+        Get all shortest sequences of transformations between two coordinate systems.
 
         Parameters
         ----------
@@ -402,11 +505,16 @@ class TransformationManager:
             The source coordinate system.
         target_cs
             The target coordinate system.
+        expected_intermediate_transformations
+            list of intermediate transformations.
+            Used to choose an edge when multiple edges are found between the same coordinate systems.
 
         Returns
         -------
-        list[BaseTransformation]
-            The shortest sequence of transformations from source_cs to target_cs.
+        list[list[BaseTransformation]]
+            All shortest sequences of transformations from source_cs to target_cs.
+            When multiple transformations are defined between the same coordinate systems, only those containing
+            a transformation among intermediate transformations are included.
 
         Raises
         ------
@@ -414,27 +522,29 @@ class TransformationManager:
             If either coordinate system does not exist.
         TransformationPathNotFoundError
             If no path exists between the source and target coordinate systems.
+        TransformationPathAmbiguousError
+            When multiple transformations are defined between the same coordinate systems and transformations
+            are not specified in `expeceted_intermediate_transformations` for disambiguation.
         """
         with suppress_direct_internal_attribute_access_warning():
             try:
-                return [self.get_existing_transformation(source_cs=source_cs, target_cs=target_cs)]
-            except TransformationNotFoundError as _tnfe:
-                pass
-
-            try:
-                path = nx.shortest_path(self.graph, source=source_cs, target=target_cs)
+                paths = list(nx.shortest_simple_paths(self.graph, source=source_cs, target=target_cs))
 
             except nx.NetworkXNoPath as nxe:
                 raise TransformationPathNotFoundError(source_cs.name, target_cs.name) from nxe
 
-            transformations = []
-            for i in range(len(path) - 1):
-                edge_data = self.graph[path[i]][path[i + 1]]
-                transformations.append(edge_data[0][TRANSFORM_KEY])
-            return transformations
+            try:
+                return self._get_transformation_sequences_from_path_after_disambiguation(
+                    paths, expected_intermediate_transformations
+                )
+            except TransformationPathAmbiguousError as tpae:
+                raise tpae from TransformationPathAmbiguousError(source_cs.name, target_cs.name)
 
     def get_all_transformation_sequences(
-        self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
+        self,
+        source_cs: NgffCoordinateSystem,
+        target_cs: NgffCoordinateSystem,
+        expected_intermediate_transformations: list[BaseTransformation] | None = None,
     ) -> list[list[BaseTransformation]]:
         """
         Get all existing sequences of transformations between two coordinate systems.
@@ -445,23 +555,40 @@ class TransformationManager:
             The source coordinate system.
         target_cs
             The target coordinate system.
+        expected_intermediate_transformations
+            list of intermediate transformations.
+            Used to choose an edge when multiple edges are found between the same coordinate systems.
 
         Returns
         -------
         list[list[BaseTransformation]]
             All existing sequences of transformations from source_cs to target_cs.
+            When multiple transformations are defined between the same coordinate systems, only those containing
+            a transformation among intermediate transformations are included.
+
+        Raises
+        ------
+        CoordinateSystemNotFoundError
+            If either coordinate system does not exist.
+        TransformationPathNotFoundError
+            If no path exists between the source and target coordinate systems.
+        TransformationPathAmbiguousError
+            When multiple transformations are defined between the same coordinate systems and transformations
+            are not specified in `expected_intermediate_transformations` for disambiguation.
         """
         with suppress_direct_internal_attribute_access_warning():
-            paths = list(nx.all_simple_paths(self.graph, source=source_cs, target=target_cs))
+            try:
+                paths = list(nx.all_simple_paths(self.graph, source=source_cs, target=target_cs))
 
-            all_sequences = []
-            for path in paths:
-                sequence = []
-                for i in range(len(path) - 1):
-                    edge_data = self.graph[path[i]][path[i + 1]]
-                    sequence.append(edge_data[0][TRANSFORM_KEY])
-                all_sequences.append(sequence)
-            return all_sequences
+            except nx.NetworkXNoPath as nxe:
+                raise TransformationPathNotFoundError(source_cs.name, target_cs.name) from nxe
+
+            try:
+                return self._get_transformation_sequences_from_path_after_disambiguation(
+                    paths, expected_intermediate_transformations
+                )
+            except TransformationPathAmbiguousError as tpae:
+                raise tpae from TransformationPathAmbiguousError(source_cs.name, target_cs.name)
 
     def _get_transformations_associated_with_cs(self, cs: NgffCoordinateSystem) -> list[BaseTransformation]:
         """
@@ -482,12 +609,12 @@ class TransformationManager:
             transformations = []
             # Check outgoing edges (cs -> other)
             for successor in self.graph.successors(cs):
-                transformation = self.get_existing_transformation(source_cs=cs, target_cs=successor)
-                transformations.append(transformation)
+                transformations_outgoing = self.get_existing_direct_transformations(cs, successor)
+                transformations += transformations_outgoing
             # Check incoming edges (other -> cs)
             for predecessor in self.graph.predecessors(cs):
-                transformation = self.get_existing_transformation(source_cs=predecessor, target_cs=cs)
-                transformations.append(transformation)
+                transformations_incoming = self.get_existing_direct_transformations(source_cs=predecessor, target_cs=cs)
+                transformations += transformations_incoming
 
             return transformations
 

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -86,6 +86,23 @@ class TransformationManager:
         if cs not in self._graph:
             raise CoordinateSystemNotFoundError(cs.name)
 
+    def assert_coordinate_system_does_not_exist(self, cs: NgffCoordinateSystem) -> None:
+        """
+        Assert that coordinate system doesn't exist in the graph.
+
+        Parameters
+        ----------
+        cs
+            The coordinate system to check.
+
+        Raises
+        ------
+        CoordinateSystemAlreadyExistsError
+            If the coordinate system already exists.
+        """
+        if cs in self._graph:
+            raise CoordinateSystemAlreadyExistsError(cs.name)
+
     def assert_an_edge_exists_between_coordinate_systems(
         self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem, edge_key: str | None = None
     ) -> None:
@@ -149,8 +166,8 @@ class TransformationManager:
 
         Raises
         ------
-        Co
-
+        CoordinateSystemHasElementsError
+            if the coordinate system has elements belonging to it.
         """
         elements = self._get_elements_belonging_to_cs(cs)
         # also checks if cs exists
@@ -171,13 +188,8 @@ class TransformationManager:
         CoordinateSystemAlreadyExistsError
             If the coordinate system already exists.
         """
-        try:
-            self.assert_coordinate_system_exists(cs)
-        except CoordinateSystemNotFoundError:
-            self._graph.add_node(cs)
-            return
-
-        raise CoordinateSystemAlreadyExistsError(cs.name)
+        self.assert_coordinate_system_does_not_exist(cs)
+        self._graph.add_node(cs)
 
     def remove_coordinate_system(self, cs: NgffCoordinateSystem) -> None:
         """

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -17,10 +17,11 @@ from spatialdata._core.transformation_manager.exceptions import (
     TransformationPathNotFoundError,
     TransformationPathNotSimple,
 )
+from spatialdata.transformations import transformations as sd_transforms
 from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
-from spatialdata.transformations.transformations import BaseTransformation, Sequence
 
 TRANSFORM_KEY = "transformation"
+EDGE_DEF = tuple[NgffCoordinateSystem, NgffCoordinateSystem, sd_transforms.BaseTransformation]
 
 
 class TransformationManager:
@@ -117,7 +118,7 @@ class TransformationManager:
             raise CoordinateSystemNotFoundError(cs.name)
 
     def assert_an_edge_exists_between_coordinate_systems(
-        self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
+        self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem, edge_key: str | None = None
     ) -> None:
         """
         Assert that an edge exists between coordinate systems.
@@ -128,6 +129,9 @@ class TransformationManager:
             The input coordinate system.
         target_cs
             The output coordinate system.
+        edge_key
+            If specified, asserts that the specific edge exists between coordinate systems
+
 
         Raises
         ------
@@ -139,7 +143,7 @@ class TransformationManager:
         self.assert_coordinate_system_exists(source_cs)
         self.assert_coordinate_system_exists(target_cs)
         if not self.graph.has_edge(source_cs, target_cs):
-            raise TransformationNotFoundError(source_cs.name, target_cs.name)
+            raise TransformationNotFoundError(source_cs.name, target_cs.name, edge_key)
 
     def assert_coordinate_system_has_no_transformations(self, cs: NgffCoordinateSystem) -> None:
         """
@@ -298,12 +302,28 @@ class TransformationManager:
         del self.element_to_cs_mapping[element_name]
 
     @staticmethod
-    def _get_edge_key_from_transform(transform: BaseTransformation) -> str:
+    def _get_edge_key(edge_def: EDGE_DEF) -> str:
+        """
+        Encode the definition of an edge into a string to be used as graph-wide edge identifier.
 
-        return f"{id(transform)}_{transform}"
+        Parameters
+        ----------
+        edge_def
+            tuple, (source_cs, target_cs, transformation)
+
+        Returns
+        -------
+        edge_key
+            str, the encoded edge identifier
+        """
+        source_cs, target_cs, transform = edge_def
+        return f"{source_cs.name}_{target_cs.name}_{id(transform)}"
 
     def add_transformation(
-        self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem, transformation: BaseTransformation
+        self,
+        source_cs: NgffCoordinateSystem,
+        target_cs: NgffCoordinateSystem,
+        transformation: sd_transforms.BaseTransformation,
     ) -> None:
         """
         Add a transformation between coordinate systems.
@@ -325,13 +345,13 @@ class TransformationManager:
         self.assert_coordinate_system_exists(source_cs)
         self.assert_coordinate_system_exists(target_cs)
 
-        edge_key = self._get_edge_key_from_transform(transformation)
+        edge_key = self._get_edge_key((source_cs, target_cs, transformation))
         edge_attributes = {TRANSFORM_KEY: transformation}
         self.graph.add_edge(source_cs, target_cs, key=edge_key, **edge_attributes)
 
     def get_direct_transformations(
         self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
-    ) -> list[BaseTransformation]:
+    ) -> list[sd_transforms.BaseTransformation]:
         """
         Retrieve transformations directly defined between coordinate systems.
 
@@ -357,7 +377,7 @@ class TransformationManager:
         transforms = []
         if self.graph.has_edge(source_cs, target_cs):
             for edge_data in self.graph[source_cs][target_cs].values():
-                transform: BaseTransformation = edge_data[TRANSFORM_KEY]
+                transform: sd_transforms.BaseTransformation = edge_data[TRANSFORM_KEY]
                 transforms.append(transform)
         return transforms
 
@@ -365,7 +385,7 @@ class TransformationManager:
         self,
         source_cs: NgffCoordinateSystem,
         target_cs: NgffCoordinateSystem,
-        transformation: BaseTransformation,
+        transformation: sd_transforms.BaseTransformation,
     ) -> None:
         """
         Remove a specific transformation between coordinate systems.
@@ -387,12 +407,9 @@ class TransformationManager:
         TransformationNotFoundError
             If the transformation does not exist.
         """
-        self.assert_an_edge_exists_between_coordinate_systems(source_cs, target_cs)
+        expected_edge_key = self._get_edge_key((source_cs, target_cs, transformation))
+        self.assert_an_edge_exists_between_coordinate_systems(source_cs, target_cs, expected_edge_key)
         # also checks if source_cs and target_cs exist
-        expected_edge_key = self._get_edge_key_from_transform(transformation)
-        assert expected_edge_key in self.graph[source_cs][target_cs], TransformationNotFoundError(
-            source_cs.name, target_cs.name, expected_edge_key
-        )
         self.graph.remove_edge(source_cs, target_cs, key=expected_edge_key)
 
     def remove_all_transformations_between_coordinate_systems(
@@ -427,8 +444,8 @@ class TransformationManager:
     def _get_transformation_sequences_from_simple_paths_after_disambiguation(
         self,
         paths: list[list[NgffCoordinateSystem]],
-        expected_intermediate_transformations: list[BaseTransformation] | None,
-    ) -> list[Sequence]:
+        expected_intermediate_edges: list[EDGE_DEF] | None,
+    ) -> list[sd_transforms.Sequence]:
         """
         Traverses paths to form sequence of Transformations.
 
@@ -438,12 +455,13 @@ class TransformationManager:
         ----------
         paths:
             sequence of list of nodes
-        expected_intermediate_transformations:
-            list of transformation objects
+        expected_intermediate_edges:
+            list of edge definitions, for use when multiple edges are found between two coordinate systems in a path
+            An edge is defined as a tuple, (source_cs, target_cs, transform).
 
         Returns
         -------
-            list of sequences of transformations
+            list of transformations, each an instance of the transformation class Sequence
 
         Raises
         ------
@@ -454,10 +472,11 @@ class TransformationManager:
             assert len(set(path)) == len(path), TransformationPathNotSimple(path)
 
         expected_intermediate_transformation_edge_keys = set()
-        if expected_intermediate_transformations is not None:
-            expected_intermediate_transformation_edge_keys |= {
-                self._get_edge_key_from_transform(it) for it in expected_intermediate_transformations
-            }
+        if expected_intermediate_edges is not None:
+            for edge_def in expected_intermediate_edges:
+                edge_key = self._get_edge_key(edge_def)
+                expected_intermediate_transformation_edge_keys |= {edge_key}
+
         all_sequences = []
         deduplicated_paths = list({repr(x): x for x in paths}.values())
         for path in deduplicated_paths:
@@ -486,15 +505,15 @@ class TransformationManager:
                     # Only one edge, no ambiguity
                     edge_key = next(iter(edge_data.keys()))
                     transformation_list.append(edge_data[edge_key][TRANSFORM_KEY])
-            all_sequences.append(Sequence(transformation_list))
+            all_sequences.append(sd_transforms.Sequence(transformation_list))
         return all_sequences
 
     def get_all_shortest_transformation_sequences(
         self,
         source_cs: NgffCoordinateSystem,
         target_cs: NgffCoordinateSystem,
-        expected_intermediate_transformations: list[BaseTransformation] | None = None,
-    ) -> list[Sequence]:
+        expected_intermediate_edges: list[EDGE_DEF] | None = None,
+    ) -> list[sd_transforms.Sequence]:
         """
         Get all shortest sequences of transformations between two coordinate systems.
 
@@ -504,8 +523,9 @@ class TransformationManager:
             The source coordinate system.
         target_cs
             The target coordinate system.
-        expected_intermediate_transformations
-            list of intermediate transformations.
+        expected_intermediate_edges
+            list of intermediate edges expected.
+            An edge is defined as a tuple, (source_cs, target_cs, transform).
             Used to choose an edge when multiple edges are found between the same coordinate systems.
 
         Returns
@@ -532,7 +552,7 @@ class TransformationManager:
 
         try:
             return self._get_transformation_sequences_from_simple_paths_after_disambiguation(
-                paths, expected_intermediate_transformations
+                paths, expected_intermediate_edges
             )
         except TransformationPathAmbiguousError as tpae:
             raise TransformationPathAmbiguousError(source_cs.name, target_cs.name) from tpae
@@ -541,8 +561,8 @@ class TransformationManager:
         self,
         source_cs: NgffCoordinateSystem,
         target_cs: NgffCoordinateSystem,
-        expected_intermediate_transformations: list[BaseTransformation] | None = None,
-    ) -> list[Sequence]:
+        expected_intermediate_edges: list[EDGE_DEF] | None = None,
+    ) -> list[sd_transforms.Sequence]:
         """
         Get all existing sequences of transformations between two coordinate systems.
 
@@ -552,8 +572,9 @@ class TransformationManager:
             The source coordinate system.
         target_cs
             The target coordinate system.
-        expected_intermediate_transformations
-            list of intermediate transformations.
+        expected_intermediate_edges
+            list of intermediate edges expected.
+            An edge is defined as a tuple, (source_cs, target_cs, transform).
             Used to choose an edge when multiple edges are found between the same coordinate systems.
 
         Returns
@@ -580,12 +601,14 @@ class TransformationManager:
 
         try:
             return self._get_transformation_sequences_from_simple_paths_after_disambiguation(
-                paths, expected_intermediate_transformations
+                paths, expected_intermediate_edges
             )
         except TransformationPathAmbiguousError as tpae:
             raise tpae from TransformationPathAmbiguousError(source_cs.name, target_cs.name)
 
-    def _get_transformations_associated_with_cs(self, cs: NgffCoordinateSystem) -> list[BaseTransformation]:
+    def _get_transformations_associated_with_cs(
+        self, cs: NgffCoordinateSystem
+    ) -> list[sd_transforms.BaseTransformation]:
         """
         Get all transformations associated with a coordinate system.
 

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -326,7 +326,7 @@ class TransformationManager:
         edge_attributes = {TRANSFORM_KEY: transformation}
         self.graph.add_edge(source_cs, target_cs, key=edge_key, **edge_attributes)
 
-    def get_existing_direct_transformations(
+    def get_direct_transformations(
         self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
     ) -> list[BaseTransformation]:
         """
@@ -584,11 +584,11 @@ class TransformationManager:
         transformations = []
         # Check outgoing edges (cs -> other)
         for successor in self.graph.successors(cs):
-            transformations_outgoing = self.get_existing_direct_transformations(cs, successor)
+            transformations_outgoing = self.get_direct_transformations(cs, successor)
             transformations += transformations_outgoing
         # Check incoming edges (other -> cs)
         for predecessor in self.graph.predecessors(cs):
-            transformations_incoming = self.get_existing_direct_transformations(source_cs=predecessor, target_cs=cs)
+            transformations_incoming = self.get_direct_transformations(source_cs=predecessor, target_cs=cs)
             transformations += transformations_incoming
 
         return transformations

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -12,7 +12,10 @@ from spatialdata._core.transformation_manager.exceptions import (
     ElementNotFoundError,
     TransformationNotFoundError,
     TransformationPathAmbiguousError,
+    TransformationPathAmbiguousMultipleEdgeExpectedError,
+    TransformationPathAmbiguousNoEdgeExpectedError,
     TransformationPathNotFoundError,
+    TransformationPathNotSimple,
 )
 from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
 from spatialdata.transformations.transformations import BaseTransformation, Sequence
@@ -421,7 +424,7 @@ class TransformationManager:
                 # need to covert keys() to list to freeze it, else it will change during the following removal
                 self.graph.remove_edge(source_cs, target_cs, key=edge_key)
 
-    def _get_transformation_sequences_from_path_after_disambiguation(
+    def _get_transformation_sequences_from_simple_paths_after_disambiguation(
         self,
         paths: list[list[NgffCoordinateSystem]],
         expected_intermediate_transformations: list[BaseTransformation] | None,
@@ -441,10 +444,18 @@ class TransformationManager:
         Returns
         -------
             list of sequences of transformations
+
+        Raises
+        ------
+            TransformationPathNotSimple
+                if any path in `paths` is not simple, i.e., has recurring coordinate systems
         """
-        intermediate_transformation_edge_keys = set()
+        for path in paths:
+            assert len(set(path)) == len(path), TransformationPathNotSimple(path)
+
+        expected_intermediate_transformation_edge_keys = set()
         if expected_intermediate_transformations is not None:
-            intermediate_transformation_edge_keys |= {
+            expected_intermediate_transformation_edge_keys |= {
                 self._get_edge_key_from_transform(it) for it in expected_intermediate_transformations
             }
         all_sequences = []
@@ -452,16 +463,24 @@ class TransformationManager:
         for path in deduplicated_paths:
             transformation_list = []
             for i in range(len(path) - 1):
-                edge_data = self.graph[path[i]][path[i + 1]]
+                source_cs_here, target_cs_here = path[i], path[i + 1]
+                edge_data = self.graph[source_cs_here][target_cs_here]
                 if len(edge_data) > 1:
                     # when there are multiple edges between a pair of coordinate systems in the path
-                    intermediate_transformation_key_here = intermediate_transformation_edge_keys & set(edge_data.keys())
-                    if len(intermediate_transformation_key_here) == 0:
-                        # transformation was not specified in `intermediate_transformations` for disambiguation
-                        raise TransformationPathAmbiguousError(path[i].name, path[i + 1].name)
-
-                    edge_key_to_use = list(intermediate_transformation_key_here)[0]
-                    # choosing the first one arbitrarily
+                    # find the expected edge based on key
+                    expected_intermediate_transformation_key_here = (
+                        expected_intermediate_transformation_edge_keys & set(edge_data.keys())
+                    )
+                    if len(expected_intermediate_transformation_key_here) == 0:
+                        # transformation was not specified in `expected_intermediate_transformations` for disambiguation
+                        raise TransformationPathAmbiguousNoEdgeExpectedError(source_cs_here.name, target_cs_here.name)
+                    if len(expected_intermediate_transformation_key_here) > 1:
+                        # multiple transformations were specified in `expected_intermediate_transformations`
+                        # for disambiguation
+                        raise TransformationPathAmbiguousMultipleEdgeExpectedError(
+                            source_cs_here.name, target_cs_here.name, len(expected_intermediate_transformation_key_here)
+                        )
+                    edge_key_to_use = list(expected_intermediate_transformation_key_here)[0]
                     transformation_list.append(edge_data[edge_key_to_use][TRANSFORM_KEY])
                 else:
                     # Only one edge, no ambiguity
@@ -512,11 +531,11 @@ class TransformationManager:
             raise TransformationPathNotFoundError(source_cs.name, target_cs.name) from nxe
 
         try:
-            return self._get_transformation_sequences_from_path_after_disambiguation(
+            return self._get_transformation_sequences_from_simple_paths_after_disambiguation(
                 paths, expected_intermediate_transformations
             )
         except TransformationPathAmbiguousError as tpae:
-            raise tpae from TransformationPathAmbiguousError(source_cs.name, target_cs.name)
+            raise TransformationPathAmbiguousError(source_cs.name, target_cs.name) from tpae
 
     def get_all_transformation_sequences(
         self,
@@ -560,7 +579,7 @@ class TransformationManager:
             raise TransformationPathNotFoundError(source_cs.name, target_cs.name) from nxe
 
         try:
-            return self._get_transformation_sequences_from_path_after_disambiguation(
+            return self._get_transformation_sequences_from_simple_paths_after_disambiguation(
                 paths, expected_intermediate_transformations
             )
         except TransformationPathAmbiguousError as tpae:

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -11,7 +11,7 @@ from spatialdata._core.transformation_manager.exceptions import (
     CoordinateSystemHasTransformationsError,
     CoordinateSystemNotFoundError,
     ElementAlreadyExistsError,
-    ElementNotFoundError,
+    ElementNotRegisteredToAnyCoordinateSystemError,
     InvalidPathError,
     TransformationNotFoundError,
     TransformationPathAmbiguousError,
@@ -50,7 +50,7 @@ class TransformationManager:
             If the element does not exist.
         """
         if element_name not in self._element_to_cs_mapping:
-            raise ElementNotFoundError(element_name)
+            raise ElementNotRegisteredToAnyCoordinateSystemError(element_name)
 
     def assert_element_does_not_exists(self, element_name: str) -> None:
         """

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -52,7 +52,7 @@ class TransformationManager:
         if element_name not in self._element_to_cs_mapping:
             raise ElementNotRegisteredToAnyCoordinateSystemError(element_name)
 
-    def assert_element_does_not_exists(self, element_name: str) -> None:
+    def assert_element_does_not_exist(self, element_name: str) -> None:
         """
         Assert than an element doesn't exist in the transformation manager.
 
@@ -190,10 +190,13 @@ class TransformationManager:
 
         Raises
         ------
-        CannotRemoveCoordinateSystemError
-            If the coordinate system cannot be removed.
         CoordinateSystemNotFoundError
             If the coordinate system is not found
+        CannotRemoveCoordinateSystemError
+            If the coordinate system cannot be removed.
+            Chained from
+                CoordinateSystemHasTransformationsError or
+                CoordinateSystemHasElementsError when the system has dependencies.
         """
         try:
             self.assert_coordinate_system_has_no_transformations(cs)
@@ -230,7 +233,7 @@ class TransformationManager:
         CoordinateSystemNotFoundError
             If the coordinate system is not found.
         """
-        self.assert_element_does_not_exists(element_name)
+        self.assert_element_does_not_exist(element_name)
         self.assert_coordinate_system_exists(coordinate_system)
         self._element_to_cs_mapping[element_name] = coordinate_system
 

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import networkx as nx
 
 from spatialdata._core.transformation_manager.exceptions import (
@@ -413,7 +415,7 @@ class TransformationManager:
     def _get_transformation_sequences_from_simple_paths_after_disambiguation(
         self,
         paths: list[list[NgffCoordinateSystem]],
-        expected_intermediate_edges: list[EDGE_DEF] | None,
+        expected_intermediate_edges: Sequence[EDGE_DEF],
     ) -> list[sd_transforms.Sequence]:
         """
         Traverses paths to form sequence of Transformations.
@@ -483,7 +485,7 @@ class TransformationManager:
         self,
         source_cs: NgffCoordinateSystem,
         target_cs: NgffCoordinateSystem,
-        expected_intermediate_edges: list[EDGE_DEF] | None = None,
+        expected_intermediate_edges: Sequence[EDGE_DEF] = (),
     ) -> list[sd_transforms.Sequence]:
         """
         Get all shortest sequences of transformations between two coordinate systems.
@@ -532,7 +534,7 @@ class TransformationManager:
         self,
         source_cs: NgffCoordinateSystem,
         target_cs: NgffCoordinateSystem,
-        expected_intermediate_edges: list[EDGE_DEF] | None = None,
+        expected_intermediate_edges: Sequence[EDGE_DEF] = (),
     ) -> list[sd_transforms.Sequence]:
         """
         Get all existing sequences of transformations between two coordinate systems.

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -10,6 +10,7 @@ from spatialdata._core.transformation_manager.exceptions import (
     CoordinateSystemNotFoundError,
     ElementAlreadyExistsError,
     ElementNotFoundError,
+    InvalidPathError,
     TransformationNotFoundError,
     TransformationPathAmbiguousError,
     TransformationPathAmbiguousMultipleEdgeExpectedError,
@@ -446,6 +447,8 @@ class TransformationManager:
         all_sequences = []
         deduplicated_paths = list({repr(x): x for x in paths}.values())
         for path in deduplicated_paths:
+            assert len(path) > 1, InvalidPathError(path)
+
             transformation_list = []
             for i in range(len(path) - 1):
                 source_cs_here, target_cs_here = path[i], path[i + 1]

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -27,7 +27,7 @@ TRANSFORM_KEY = "transformation"
 class TransformationManager:
     def __init__(self) -> None:
         """Initialize a TransformationManager with empty graph and mappings."""
-        self._graph: nx.MultiDiGraph = nx.MultiDiGraph()
+        self._graph = nx.MultiDiGraph[NgffCoordinateSystem]()
         # MultiDiGraph with NgffCoordinateSystem objects as nodes and transforms as edge attributes
         self._element_to_cs_mapping: dict[str, NgffCoordinateSystem] = {}
         # mapping element_name to the coordinate system to which the element belongs

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -194,7 +194,7 @@ class TransformationManager:
             If the coordinate system is not found
         CannotRemoveCoordinateSystemError
             If the coordinate system cannot be removed.
-            Chained from
+            Caused by
                 CoordinateSystemHasTransformationsError or
                 CoordinateSystemHasElementsError when the system has dependencies.
         """

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -297,7 +297,7 @@ class TransformationManager:
     @staticmethod
     def _get_edge_key_from_transform(transform: BaseTransformation) -> str:
 
-        return repr(transform)
+        return f"{id(transform)}_{transform}"
 
     def add_transformation(
         self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem, transformation: BaseTransformation

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -62,9 +62,9 @@ class TransformationManager:
         """
         return self._element_to_cs_mapping
 
-    def check_if_element_exists_else_raise_error(self, element_name: str) -> None:
+    def assert_element_exists(self, element_name: str) -> None:
         """
-        Check if an element exists in the transformation manager.
+        Assert that an element exists in the transformation manager.
 
         Parameters
         ----------
@@ -79,9 +79,26 @@ class TransformationManager:
         if element_name not in self.element_to_cs_mapping:
             raise ElementNotFoundError(element_name)
 
-    def check_if_coordinate_system_exists_else_raise_error(self, cs: NgffCoordinateSystem) -> None:
+    def assert_element_does_not_exists(self, element_name: str) -> None:
         """
-        Check if a coordinate system exists in the graph.
+        Assert than an element doesn't exist in the transformation manager.
+
+        Parameters
+        ----------
+        element_name
+            The name of the element to check.
+
+        Raises
+        ------
+        ElementAlreadyExistsError
+            If the element already exists.
+        """
+        if element_name in self.element_to_cs_mapping:
+            raise ElementAlreadyExistsError(element_name)
+
+    def assert_coordinate_system_exists(self, cs: NgffCoordinateSystem) -> None:
+        """
+        Assert that coordinate system exists in the graph.
 
         Parameters
         ----------
@@ -96,11 +113,11 @@ class TransformationManager:
         if cs not in self.graph:
             raise CoordinateSystemNotFoundError(cs.name)
 
-    def check_if_any_edge_exists_else_raise_error(
+    def assert_an_edge_exists_between_coordinate_systems(
         self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
     ) -> None:
         """
-        Check if an edge exists between coordinate systems.
+        Assert that an edge exists between coordinate systems.
 
         Parameters
         ----------
@@ -116,14 +133,14 @@ class TransformationManager:
         TransformationNotFoundError
             If the edge does not exist.
         """
-        self.check_if_coordinate_system_exists_else_raise_error(source_cs)
-        self.check_if_coordinate_system_exists_else_raise_error(target_cs)
+        self.assert_coordinate_system_exists(source_cs)
+        self.assert_coordinate_system_exists(target_cs)
         if not self.graph.has_edge(source_cs, target_cs):
             raise TransformationNotFoundError(source_cs.name, target_cs.name)
 
-    def check_if_coordinate_system_has_no_transformations_else_raise_error(self, cs: NgffCoordinateSystem) -> None:
+    def assert_coordinate_system_has_no_transformations(self, cs: NgffCoordinateSystem) -> None:
         """
-        Check if a coordinate system has associated transformations.
+        Assert that coordinate system has no associated transformations.
 
         Parameters
         ----------
@@ -143,9 +160,9 @@ class TransformationManager:
         if transformations:
             raise CoordinateSystemHasTransformationsError(cs.name)
 
-    def check_if_coordinate_system_has_no_elements_else_raise_error(self, cs: NgffCoordinateSystem) -> None:
+    def assert_coordinate_system_has_no_elements(self, cs: NgffCoordinateSystem) -> None:
         """
-        Check if a coordinate system has elements that belong to it.
+        Assert that a coordinate system doesn't have elements belonging to it.
 
         Parameters
         ----------
@@ -177,7 +194,7 @@ class TransformationManager:
             If the coordinate system already exists.
         """
         try:
-            self.check_if_coordinate_system_exists_else_raise_error(cs)
+            self.assert_coordinate_system_exists(cs)
         except CoordinateSystemNotFoundError:
             self.graph.add_node(cs)
             return
@@ -195,17 +212,15 @@ class TransformationManager:
 
         Raises
         ------
-        CoordinateSystemHasTransformationsError
-            If the coordinate system has associated transformations.
-        CoordinateSystemHasElementsError
-            If the coordinate system has associated elements.
+        CannotRemoveCoordinateSystemError
+            If the coordinate system cannot be removed.
         CoordinateSystemNotFoundError
             If the coordinate system is not found
         """
         try:
-            self.check_if_coordinate_system_has_no_transformations_else_raise_error(cs)
-            # also checks if cs exists
-            self.check_if_coordinate_system_has_no_elements_else_raise_error(cs)
+            self.assert_coordinate_system_has_no_transformations(cs)
+            # also asserts that cs exists
+            self.assert_coordinate_system_has_no_elements(cs)
         except (CoordinateSystemHasTransformationsError, CoordinateSystemHasElementsError) as err:
             raise CannotRemoveCoordinateSystemError(cs.name) from err
 
@@ -237,14 +252,9 @@ class TransformationManager:
         CoordinateSystemNotFoundError
             If the coordinate system is not found.
         """
-        try:
-            self.check_if_element_exists_else_raise_error(element_name)
-        except ElementNotFoundError:
-            self.check_if_coordinate_system_exists_else_raise_error(coordinate_system)
-            self.element_to_cs_mapping[element_name] = coordinate_system
-            return
-
-        raise ElementAlreadyExistsError(element_name)
+        self.assert_element_does_not_exists(element_name)
+        self.assert_coordinate_system_exists(coordinate_system)
+        self.element_to_cs_mapping[element_name] = coordinate_system
 
     def get_element_coordinate_system(self, element_name: str) -> NgffCoordinateSystem:
         """
@@ -264,7 +274,7 @@ class TransformationManager:
         ElementNotFoundError
             If the element does not exist.
         """
-        self.check_if_element_exists_else_raise_error(element_name)
+        self.assert_element_exists(element_name)
         return self.element_to_cs_mapping[element_name]
 
     def unset_element(self, element_name: str) -> None:
@@ -281,7 +291,7 @@ class TransformationManager:
         ElementNotFoundError
             If the element has not been registered to any coordinate system.
         """
-        self.check_if_element_exists_else_raise_error(element_name)
+        self.assert_element_exists(element_name)
         del self.element_to_cs_mapping[element_name]
 
     @staticmethod
@@ -309,8 +319,8 @@ class TransformationManager:
         CoordinateSystemNotFoundError
             If either coordinate system does not exist.
         """
-        self.check_if_coordinate_system_exists_else_raise_error(source_cs)
-        self.check_if_coordinate_system_exists_else_raise_error(target_cs)
+        self.assert_coordinate_system_exists(source_cs)
+        self.assert_coordinate_system_exists(target_cs)
 
         edge_key = self._get_edge_key_from_transform(transformation)
         edge_attributes = {TRANSFORM_KEY: transformation}
@@ -340,7 +350,7 @@ class TransformationManager:
         TransformationNotFoundError
             If the transformation does not exist.
         """
-        self.check_if_any_edge_exists_else_raise_error(source_cs, target_cs)
+        self.assert_an_edge_exists_between_coordinate_systems(source_cs, target_cs)
         # also checks if source_cs and target_cs exist
         transforms = []
         assert target_cs in self.graph[source_cs], TransformationNotFoundError(source_cs.name, target_cs.name)
@@ -375,7 +385,7 @@ class TransformationManager:
         TransformationNotFoundError
             If the transformation does not exist.
         """
-        self.check_if_any_edge_exists_else_raise_error(source_cs, target_cs)
+        self.assert_an_edge_exists_between_coordinate_systems(source_cs, target_cs)
         # also checks if source_cs and target_cs exist
         expected_edge_key = self._get_edge_key_from_transform(transformation)
         assert expected_edge_key in self.graph[source_cs][target_cs], TransformationNotFoundError(
@@ -405,9 +415,8 @@ class TransformationManager:
         TransformationNotFoundError
             If no transformation exists between the coordiante systems
         """
-        self.check_if_any_edge_exists_else_raise_error(source_cs, target_cs)
+        self.assert_an_edge_exists_between_coordinate_systems(source_cs, target_cs)
         # also checks if source_cs and target_cs exist
-        assert len(self.graph[source_cs][target_cs]), TransformationNotFoundError(source_cs.name, target_cs.name)
         for edge_key in list(self.graph[source_cs][target_cs].keys()):
             # need to covert keys() to list to freeze it, else it will change during the following removal
             self.graph.remove_edge(source_cs, target_cs, key=edge_key)
@@ -570,7 +579,7 @@ class TransformationManager:
         -------
         List of transformations
         """
-        self.check_if_coordinate_system_exists_else_raise_error(cs)
+        self.assert_coordinate_system_exists(cs)
 
         transformations = []
         # Check outgoing edges (cs -> other)
@@ -603,7 +612,7 @@ class TransformationManager:
             If the coordinate system does not exist.
 
         """
-        self.check_if_coordinate_system_exists_else_raise_error(cs)
+        self.assert_coordinate_system_exists(cs)
 
         elements = []
         for element_name, element_cs in self.element_to_cs_mapping.items():

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -250,7 +250,7 @@ class TransformationManager:
         self.assert_element_exists(element_name)
         return self._element_to_cs_mapping[element_name]
 
-    def unset_element(self, element_name: str) -> None:
+    def _unset_element(self, element_name: str) -> None:
         """
         Unregister an element from the coordinate system to which it belongs.
 

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import warnings
-
 import networkx as nx
 
 from spatialdata._core.transformation_manager.exceptions import (
@@ -12,11 +10,9 @@ from spatialdata._core.transformation_manager.exceptions import (
     CoordinateSystemNotFoundError,
     ElementAlreadyExistsError,
     ElementNotFoundError,
-    InternalAttributeAccessWarning,
     TransformationNotFoundError,
     TransformationPathAmbiguousError,
     TransformationPathNotFoundError,
-    suppress_direct_internal_attribute_access_warning,
 )
 from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
 from spatialdata.transformations.transformations import BaseTransformation, Sequence
@@ -47,14 +43,6 @@ class TransformationManager:
         TransformationManager methods whenever possible for better maintainability
         and to ensure proper validation and error handling.
         """
-        warnings.warn(
-            "Direct access to the internal graph is discouraged. "
-            "Please use TransformationManager methods whenever possible for better "
-            "maintainability and to ensure proper validation and error handling.",
-            InternalAttributeAccessWarning,
-            stacklevel=2,
-        )
-
         return self._graph
 
     @property
@@ -72,13 +60,6 @@ class TransformationManager:
         TransformationManager methods whenever possible for better maintainability
         and to ensure proper validation and error handling.
         """
-        warnings.warn(
-            "Direct access to the internal element_to_cs_mapping is discouraged. "
-            "Please use TransformationManager methods whenever possible for better "
-            "maintainability and to ensure proper validation and error handling",
-            InternalAttributeAccessWarning,
-            stacklevel=2,
-        )
         return self._element_to_cs_mapping
 
     def check_if_element_exists_else_raise_error(self, element_name: str) -> None:
@@ -95,9 +76,8 @@ class TransformationManager:
         ElementNotFoundError
             If the element does not exist.
         """
-        with suppress_direct_internal_attribute_access_warning():
-            if element_name not in self.element_to_cs_mapping:
-                raise ElementNotFoundError(element_name)
+        if element_name not in self.element_to_cs_mapping:
+            raise ElementNotFoundError(element_name)
 
     def check_if_coordinate_system_exists_else_raise_error(self, cs: NgffCoordinateSystem) -> None:
         """
@@ -113,9 +93,8 @@ class TransformationManager:
         CoordinateSystemNotFoundError
             If the coordinate system does not exist.
         """
-        with suppress_direct_internal_attribute_access_warning():
-            if cs not in self.graph:
-                raise CoordinateSystemNotFoundError(cs.name)
+        if cs not in self.graph:
+            raise CoordinateSystemNotFoundError(cs.name)
 
     def check_if_any_edge_exists_else_raise_error(
         self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
@@ -139,9 +118,8 @@ class TransformationManager:
         """
         self.check_if_coordinate_system_exists_else_raise_error(source_cs)
         self.check_if_coordinate_system_exists_else_raise_error(target_cs)
-        with suppress_direct_internal_attribute_access_warning():
-            if not self.graph.has_edge(source_cs, target_cs):
-                raise TransformationNotFoundError(source_cs.name, target_cs.name)
+        if not self.graph.has_edge(source_cs, target_cs):
+            raise TransformationNotFoundError(source_cs.name, target_cs.name)
 
     def check_if_coordinate_system_has_no_transformations_else_raise_error(self, cs: NgffCoordinateSystem) -> None:
         """
@@ -201,9 +179,8 @@ class TransformationManager:
         try:
             self.check_if_coordinate_system_exists_else_raise_error(cs)
         except CoordinateSystemNotFoundError:
-            with suppress_direct_internal_attribute_access_warning():
-                self.graph.add_node(cs)
-                return
+            self.graph.add_node(cs)
+            return
 
         raise CoordinateSystemAlreadyExistsError(cs.name)
 
@@ -232,8 +209,7 @@ class TransformationManager:
         except (CoordinateSystemHasTransformationsError, CoordinateSystemHasElementsError) as err:
             raise CannotRemoveCoordinateSystemError(cs.name) from err
 
-        with suppress_direct_internal_attribute_access_warning():
-            self.graph.remove_node(cs)
+        self.graph.remove_node(cs)
 
     def list_coordinate_systems(self) -> list[NgffCoordinateSystem]:
         """
@@ -243,8 +219,7 @@ class TransformationManager:
         -------
         A list of coordinate system objects.
         """
-        with suppress_direct_internal_attribute_access_warning():
-            return list(self.graph.nodes())
+        return list(self.graph.nodes())
 
     def add_element(self, element_name: str, coordinate_system: NgffCoordinateSystem) -> None:
         """
@@ -266,9 +241,8 @@ class TransformationManager:
             self.check_if_element_exists_else_raise_error(element_name)
         except ElementNotFoundError:
             self.check_if_coordinate_system_exists_else_raise_error(coordinate_system)
-            with suppress_direct_internal_attribute_access_warning():
-                self.element_to_cs_mapping[element_name] = coordinate_system
-                return
+            self.element_to_cs_mapping[element_name] = coordinate_system
+            return
 
         raise ElementAlreadyExistsError(element_name)
 
@@ -291,8 +265,7 @@ class TransformationManager:
             If the element does not exist.
         """
         self.check_if_element_exists_else_raise_error(element_name)
-        with suppress_direct_internal_attribute_access_warning():
-            return self.element_to_cs_mapping[element_name]
+        return self.element_to_cs_mapping[element_name]
 
     def unset_element(self, element_name: str) -> None:
         """
@@ -309,8 +282,7 @@ class TransformationManager:
             If the element has not been registered to any coordinate system.
         """
         self.check_if_element_exists_else_raise_error(element_name)
-        with suppress_direct_internal_attribute_access_warning():
-            del self.element_to_cs_mapping[element_name]
+        del self.element_to_cs_mapping[element_name]
 
     @staticmethod
     def _get_edge_key_from_transform(transform: BaseTransformation) -> str:
@@ -340,10 +312,9 @@ class TransformationManager:
         self.check_if_coordinate_system_exists_else_raise_error(source_cs)
         self.check_if_coordinate_system_exists_else_raise_error(target_cs)
 
-        with suppress_direct_internal_attribute_access_warning():
-            edge_key = self._get_edge_key_from_transform(transformation)
-            edge_attributes = {TRANSFORM_KEY: transformation}
-            self.graph.add_edge(source_cs, target_cs, key=edge_key, **edge_attributes)
+        edge_key = self._get_edge_key_from_transform(transformation)
+        edge_attributes = {TRANSFORM_KEY: transformation}
+        self.graph.add_edge(source_cs, target_cs, key=edge_key, **edge_attributes)
 
     def get_existing_direct_transformations(
         self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
@@ -371,13 +342,12 @@ class TransformationManager:
         """
         self.check_if_any_edge_exists_else_raise_error(source_cs, target_cs)
         # also checks if source_cs and target_cs exist
-        with suppress_direct_internal_attribute_access_warning():
-            transforms = []
-            assert target_cs in self.graph[source_cs], TransformationNotFoundError(source_cs.name, target_cs.name)
-            for edge_data in self.graph[source_cs][target_cs].values():
-                transform: BaseTransformation = edge_data[TRANSFORM_KEY]
-                transforms.append(transform)
-            return transforms
+        transforms = []
+        assert target_cs in self.graph[source_cs], TransformationNotFoundError(source_cs.name, target_cs.name)
+        for edge_data in self.graph[source_cs][target_cs].values():
+            transform: BaseTransformation = edge_data[TRANSFORM_KEY]
+            transforms.append(transform)
+        return transforms
 
     def remove_specific_transformation(
         self,
@@ -407,12 +377,11 @@ class TransformationManager:
         """
         self.check_if_any_edge_exists_else_raise_error(source_cs, target_cs)
         # also checks if source_cs and target_cs exist
-        with suppress_direct_internal_attribute_access_warning():
-            expected_edge_key = self._get_edge_key_from_transform(transformation)
-            assert expected_edge_key in self.graph[source_cs][target_cs], TransformationNotFoundError(
-                source_cs.name, target_cs.name, expected_edge_key
-            )
-            self.graph.remove_edge(source_cs, target_cs, key=expected_edge_key)
+        expected_edge_key = self._get_edge_key_from_transform(transformation)
+        assert expected_edge_key in self.graph[source_cs][target_cs], TransformationNotFoundError(
+            source_cs.name, target_cs.name, expected_edge_key
+        )
+        self.graph.remove_edge(source_cs, target_cs, key=expected_edge_key)
 
     def remove_all_transformations_between_coordinate_systems(
         self,
@@ -438,11 +407,10 @@ class TransformationManager:
         """
         self.check_if_any_edge_exists_else_raise_error(source_cs, target_cs)
         # also checks if source_cs and target_cs exist
-        with suppress_direct_internal_attribute_access_warning():
-            assert len(self.graph[source_cs][target_cs]), TransformationNotFoundError(source_cs.name, target_cs.name)
-            for edge_key in list(self.graph[source_cs][target_cs].keys()):
-                # need to covert keys() to list to freeze it, else it will change during the following removal
-                self.graph.remove_edge(source_cs, target_cs, key=edge_key)
+        assert len(self.graph[source_cs][target_cs]), TransformationNotFoundError(source_cs.name, target_cs.name)
+        for edge_key in list(self.graph[source_cs][target_cs].keys()):
+            # need to covert keys() to list to freeze it, else it will change during the following removal
+            self.graph.remove_edge(source_cs, target_cs, key=edge_key)
 
     def _get_transformation_sequences_from_path_after_disambiguation(
         self,
@@ -529,19 +497,17 @@ class TransformationManager:
             When multiple transformations are defined between the same coordinate systems and transformations
             are not specified in `expeceted_intermediate_transformations` for disambiguation.
         """
-        with suppress_direct_internal_attribute_access_warning():
-            try:
-                paths = list(nx.all_shortest_paths(self.graph, source=source_cs, target=target_cs))
+        try:
+            paths = list(nx.all_shortest_paths(self.graph, source=source_cs, target=target_cs))
+        except nx.NetworkXNoPath as nxe:
+            raise TransformationPathNotFoundError(source_cs.name, target_cs.name) from nxe
 
-            except nx.NetworkXNoPath as nxe:
-                raise TransformationPathNotFoundError(source_cs.name, target_cs.name) from nxe
-
-            try:
-                return self._get_transformation_sequences_from_path_after_disambiguation(
-                    paths, expected_intermediate_transformations
-                )
-            except TransformationPathAmbiguousError as tpae:
-                raise tpae from TransformationPathAmbiguousError(source_cs.name, target_cs.name)
+        try:
+            return self._get_transformation_sequences_from_path_after_disambiguation(
+                paths, expected_intermediate_transformations
+            )
+        except TransformationPathAmbiguousError as tpae:
+            raise tpae from TransformationPathAmbiguousError(source_cs.name, target_cs.name)
 
     def get_all_transformation_sequences(
         self,
@@ -579,19 +545,17 @@ class TransformationManager:
             When multiple transformations are defined between the same coordinate systems and transformations
             are not specified in `expected_intermediate_transformations` for disambiguation.
         """
-        with suppress_direct_internal_attribute_access_warning():
-            try:
-                paths = list(nx.all_simple_paths(self.graph, source=source_cs, target=target_cs))
+        try:
+            paths = list(nx.all_simple_paths(self.graph, source=source_cs, target=target_cs))
+        except nx.NetworkXNoPath as nxe:
+            raise TransformationPathNotFoundError(source_cs.name, target_cs.name) from nxe
 
-            except nx.NetworkXNoPath as nxe:
-                raise TransformationPathNotFoundError(source_cs.name, target_cs.name) from nxe
-
-            try:
-                return self._get_transformation_sequences_from_path_after_disambiguation(
-                    paths, expected_intermediate_transformations
-                )
-            except TransformationPathAmbiguousError as tpae:
-                raise tpae from TransformationPathAmbiguousError(source_cs.name, target_cs.name)
+        try:
+            return self._get_transformation_sequences_from_path_after_disambiguation(
+                paths, expected_intermediate_transformations
+            )
+        except TransformationPathAmbiguousError as tpae:
+            raise tpae from TransformationPathAmbiguousError(source_cs.name, target_cs.name)
 
     def _get_transformations_associated_with_cs(self, cs: NgffCoordinateSystem) -> list[BaseTransformation]:
         """
@@ -608,18 +572,17 @@ class TransformationManager:
         """
         self.check_if_coordinate_system_exists_else_raise_error(cs)
 
-        with suppress_direct_internal_attribute_access_warning():
-            transformations = []
-            # Check outgoing edges (cs -> other)
-            for successor in self.graph.successors(cs):
-                transformations_outgoing = self.get_existing_direct_transformations(cs, successor)
-                transformations += transformations_outgoing
-            # Check incoming edges (other -> cs)
-            for predecessor in self.graph.predecessors(cs):
-                transformations_incoming = self.get_existing_direct_transformations(source_cs=predecessor, target_cs=cs)
-                transformations += transformations_incoming
+        transformations = []
+        # Check outgoing edges (cs -> other)
+        for successor in self.graph.successors(cs):
+            transformations_outgoing = self.get_existing_direct_transformations(cs, successor)
+            transformations += transformations_outgoing
+        # Check incoming edges (other -> cs)
+        for predecessor in self.graph.predecessors(cs):
+            transformations_incoming = self.get_existing_direct_transformations(source_cs=predecessor, target_cs=cs)
+            transformations += transformations_incoming
 
-            return transformations
+        return transformations
 
     def _get_elements_belonging_to_cs(self, cs: NgffCoordinateSystem) -> list[str]:
         """
@@ -642,21 +605,19 @@ class TransformationManager:
         """
         self.check_if_coordinate_system_exists_else_raise_error(cs)
 
-        with suppress_direct_internal_attribute_access_warning():
-            elements = []
-            for element_name, element_cs in self.element_to_cs_mapping.items():
-                if element_cs == cs:
-                    elements.append(element_name)
+        elements = []
+        for element_name, element_cs in self.element_to_cs_mapping.items():
+            if element_cs == cs:
+                elements.append(element_name)
 
-            return elements
+        return elements
 
     def __repr__(self) -> str:
         """Return a string representation of the TransformationManager."""
-        with suppress_direct_internal_attribute_access_warning():
-            return (
-                f"TransformationManager("
-                f"  coordinate_systems={list(self.graph.nodes())}, "
-                f"  coordinate_transforms={[x[TRANSFORM_KEY] for *_, x in self.graph.edges(data=True)]}, "
-                f"  elements={list(self.element_to_cs_mapping.keys())}"
-                f")"
-            )
+        return (
+            f"TransformationManager("
+            f"  coordinate_systems={list(self.graph.nodes())}, "
+            f"  coordinate_transforms={[x[TRANSFORM_KEY] for *_, x in self.graph.edges(data=True)]}, "
+            f"  elements={list(self.element_to_cs_mapping.keys())}"
+            f")"
+        )

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -32,40 +32,6 @@ class TransformationManager:
         self._element_to_cs_mapping: dict[str, NgffCoordinateSystem] = {}
         # mapping element_name to the coordinate system to which the element belongs
 
-    @property
-    def graph(self) -> nx.MultiDiGraph[NgffCoordinateSystem]:
-        """
-        Get the internal transformation graph.
-
-        Returns
-        -------
-        The MultiDiGraph containing coordinate systems and transformations.
-
-        Note
-        ----
-        Direct manipulation of the graph is discouraged. Please use the
-        TransformationManager methods whenever possible for better maintainability
-        and to ensure proper validation and error handling.
-        """
-        return self._graph
-
-    @property
-    def element_to_cs_mapping(self) -> dict[str, NgffCoordinateSystem]:
-        """
-        Get the element to coordinate system mapping.
-
-        Returns
-        -------
-        A dictionary mapping element names to their coordinate systems.
-
-        Note
-        ----
-        Direct manipulation of internal element_to_cs_mapping is discouraged. Please use the
-        TransformationManager methods whenever possible for better maintainability
-        and to ensure proper validation and error handling.
-        """
-        return self._element_to_cs_mapping
-
     def assert_element_exists(self, element_name: str) -> None:
         """
         Assert that an element exists in the transformation manager.
@@ -80,7 +46,7 @@ class TransformationManager:
         ElementNotFoundError
             If the element does not exist.
         """
-        if element_name not in self.element_to_cs_mapping:
+        if element_name not in self._element_to_cs_mapping:
             raise ElementNotFoundError(element_name)
 
     def assert_element_does_not_exists(self, element_name: str) -> None:
@@ -97,7 +63,7 @@ class TransformationManager:
         ElementAlreadyExistsError
             If the element already exists.
         """
-        if element_name in self.element_to_cs_mapping:
+        if element_name in self._element_to_cs_mapping:
             raise ElementAlreadyExistsError(element_name)
 
     def assert_coordinate_system_exists(self, cs: NgffCoordinateSystem) -> None:
@@ -114,7 +80,7 @@ class TransformationManager:
         CoordinateSystemNotFoundError
             If the coordinate system does not exist.
         """
-        if cs not in self.graph:
+        if cs not in self._graph:
             raise CoordinateSystemNotFoundError(cs.name)
 
     def assert_an_edge_exists_between_coordinate_systems(
@@ -142,7 +108,7 @@ class TransformationManager:
         """
         self.assert_coordinate_system_exists(source_cs)
         self.assert_coordinate_system_exists(target_cs)
-        if not self.graph.has_edge(source_cs, target_cs):
+        if not self._graph.has_edge(source_cs, target_cs):
             raise TransformationNotFoundError(source_cs.name, target_cs.name, edge_key)
 
     def assert_coordinate_system_has_no_transformations(self, cs: NgffCoordinateSystem) -> None:
@@ -203,7 +169,7 @@ class TransformationManager:
         try:
             self.assert_coordinate_system_exists(cs)
         except CoordinateSystemNotFoundError:
-            self.graph.add_node(cs)
+            self._graph.add_node(cs)
             return
 
         raise CoordinateSystemAlreadyExistsError(cs.name)
@@ -231,7 +197,7 @@ class TransformationManager:
         except (CoordinateSystemHasTransformationsError, CoordinateSystemHasElementsError) as err:
             raise CannotRemoveCoordinateSystemError(cs.name) from err
 
-        self.graph.remove_node(cs)
+        self._graph.remove_node(cs)
 
     def list_coordinate_systems(self) -> list[NgffCoordinateSystem]:
         """
@@ -241,7 +207,7 @@ class TransformationManager:
         -------
         A list of coordinate system objects.
         """
-        return list(self.graph.nodes())
+        return list(self._graph.nodes())
 
     def add_element(self, element_name: str, coordinate_system: NgffCoordinateSystem) -> None:
         """
@@ -261,7 +227,7 @@ class TransformationManager:
         """
         self.assert_element_does_not_exists(element_name)
         self.assert_coordinate_system_exists(coordinate_system)
-        self.element_to_cs_mapping[element_name] = coordinate_system
+        self._element_to_cs_mapping[element_name] = coordinate_system
 
     def get_element_coordinate_system(self, element_name: str) -> NgffCoordinateSystem:
         """
@@ -282,7 +248,7 @@ class TransformationManager:
             If the element does not exist.
         """
         self.assert_element_exists(element_name)
-        return self.element_to_cs_mapping[element_name]
+        return self._element_to_cs_mapping[element_name]
 
     def unset_element(self, element_name: str) -> None:
         """
@@ -299,7 +265,7 @@ class TransformationManager:
             If the element has not been registered to any coordinate system.
         """
         self.assert_element_exists(element_name)
-        del self.element_to_cs_mapping[element_name]
+        del self._element_to_cs_mapping[element_name]
 
     @staticmethod
     def _get_edge_key(edge_def: EDGE_DEF) -> str:
@@ -347,7 +313,7 @@ class TransformationManager:
 
         edge_key = self._get_edge_key((source_cs, target_cs, transformation))
         edge_attributes = {TRANSFORM_KEY: transformation}
-        self.graph.add_edge(source_cs, target_cs, key=edge_key, **edge_attributes)
+        self._graph.add_edge(source_cs, target_cs, key=edge_key, **edge_attributes)
 
     def get_direct_transformations(
         self, source_cs: NgffCoordinateSystem, target_cs: NgffCoordinateSystem
@@ -375,8 +341,8 @@ class TransformationManager:
         self.assert_coordinate_system_exists(target_cs)
 
         transforms = []
-        if self.graph.has_edge(source_cs, target_cs):
-            for edge_data in self.graph[source_cs][target_cs].values():
+        if self._graph.has_edge(source_cs, target_cs):
+            for edge_data in self._graph[source_cs][target_cs].values():
                 transform: sd_transforms.BaseTransformation = edge_data[TRANSFORM_KEY]
                 transforms.append(transform)
         return transforms
@@ -410,7 +376,7 @@ class TransformationManager:
         expected_edge_key = self._get_edge_key((source_cs, target_cs, transformation))
         self.assert_an_edge_exists_between_coordinate_systems(source_cs, target_cs, expected_edge_key)
         # also checks if source_cs and target_cs exist
-        self.graph.remove_edge(source_cs, target_cs, key=expected_edge_key)
+        self._graph.remove_edge(source_cs, target_cs, key=expected_edge_key)
 
     def remove_all_transformations_between_coordinate_systems(
         self,
@@ -436,10 +402,10 @@ class TransformationManager:
         """
         self.assert_coordinate_system_exists(source_cs)
         self.assert_coordinate_system_exists(target_cs)
-        if self.graph.has_edge(source_cs, target_cs):
-            for edge_key in list(self.graph[source_cs][target_cs].keys()):
+        if self._graph.has_edge(source_cs, target_cs):
+            for edge_key in list(self._graph[source_cs][target_cs].keys()):
                 # need to covert keys() to list to freeze it, else it will change during the following removal
-                self.graph.remove_edge(source_cs, target_cs, key=edge_key)
+                self._graph.remove_edge(source_cs, target_cs, key=edge_key)
 
     def _get_transformation_sequences_from_simple_paths_after_disambiguation(
         self,
@@ -483,7 +449,7 @@ class TransformationManager:
             transformation_list = []
             for i in range(len(path) - 1):
                 source_cs_here, target_cs_here = path[i], path[i + 1]
-                edge_data = self.graph[source_cs_here][target_cs_here]
+                edge_data = self._graph[source_cs_here][target_cs_here]
                 if len(edge_data) > 1:
                     # when there are multiple edges between a pair of coordinate systems in the path
                     # find the expected edge based on key
@@ -546,7 +512,7 @@ class TransformationManager:
             are not specified in `expeceted_intermediate_transformations` for disambiguation.
         """
         try:
-            paths = list(nx.all_shortest_paths(self.graph, source=source_cs, target=target_cs))
+            paths = list(nx.all_shortest_paths(self._graph, source=source_cs, target=target_cs))
         except nx.NetworkXNoPath as nxe:
             raise TransformationPathNotFoundError(source_cs.name, target_cs.name) from nxe
 
@@ -595,7 +561,7 @@ class TransformationManager:
             are not specified in `expected_intermediate_transformations` for disambiguation.
         """
         try:
-            paths = list(nx.all_simple_paths(self.graph, source=source_cs, target=target_cs))
+            paths = list(nx.all_simple_paths(self._graph, source=source_cs, target=target_cs))
         except nx.NetworkXNoPath as nxe:
             raise TransformationPathNotFoundError(source_cs.name, target_cs.name) from nxe
 
@@ -625,11 +591,11 @@ class TransformationManager:
 
         transformations = []
         # Check outgoing edges (cs -> other)
-        for successor in self.graph.successors(cs):
+        for successor in self._graph.successors(cs):
             transformations_outgoing = self.get_direct_transformations(cs, successor)
             transformations += transformations_outgoing
         # Check incoming edges (other -> cs)
-        for predecessor in self.graph.predecessors(cs):
+        for predecessor in self._graph.predecessors(cs):
             transformations_incoming = self.get_direct_transformations(source_cs=predecessor, target_cs=cs)
             transformations += transformations_incoming
 
@@ -657,7 +623,7 @@ class TransformationManager:
         self.assert_coordinate_system_exists(cs)
 
         elements = []
-        for element_name, element_cs in self.element_to_cs_mapping.items():
+        for element_name, element_cs in self._element_to_cs_mapping.items():
             if element_cs == cs:
                 elements.append(element_name)
 
@@ -667,8 +633,8 @@ class TransformationManager:
         """Return a string representation of the TransformationManager."""
         return (
             f"TransformationManager("
-            f"  coordinate_systems={list(self.graph.nodes())}, "
-            f"  coordinate_transforms={[x[TRANSFORM_KEY] for *_, x in self.graph.edges(data=True)]}, "
-            f"  elements={list(self.element_to_cs_mapping.keys())}"
+            f"  coordinate_systems={list(self._graph.nodes())}, "
+            f"  coordinate_transforms={[x[TRANSFORM_KEY] for *_, x in self._graph.edges(data=True)]}, "
+            f"  elements={list(self._element_to_cs_mapping.keys())}"
             f")"
         )

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -443,7 +443,8 @@ class TransformationManager:
                 if any path in `paths` is not simple, i.e., has recurring coordinate systems
         """
         for path in paths:
-            assert len(set(path)) == len(path), TransformationPathNotSimple(path)
+            if len(set(path)) != len(path):
+                raise TransformationPathNotSimple(path)
 
         expected_intermediate_transformation_edge_keys = set()
         if expected_intermediate_edges is not None:
@@ -454,7 +455,8 @@ class TransformationManager:
         all_sequences = []
         deduplicated_paths = list({repr(x): x for x in paths}.values())
         for path in deduplicated_paths:
-            assert len(path) > 1, InvalidPathError(path)
+            if len(path) <= 1:
+                raise InvalidPathError(path)
 
             transformation_list = []
             for i in range(len(path) - 1):

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -129,9 +129,11 @@ class TransformationManager:
             If the coordinate system has associated transformations.
 
         """
-        transformations = self._get_transformations_associated_with_cs(cs)
-        # also checks if cs exists
-        if transformations:
+        self.assert_coordinate_system_exists(cs)
+        has_successors = next(self._graph.successors(cs), None) is not None
+        has_predecessors = next(self._graph.predecessors(cs), None) is not None
+
+        if has_successors or has_predecessors:
             raise CoordinateSystemHasTransformationsError(cs.name)
 
     def assert_coordinate_system_has_no_elements(self, cs: NgffCoordinateSystem) -> None:
@@ -574,35 +576,6 @@ class TransformationManager:
             )
         except TransformationPathAmbiguousError as tpae:
             raise tpae from TransformationPathAmbiguousError(source_cs.name, target_cs.name)
-
-    def _get_transformations_associated_with_cs(
-        self, cs: NgffCoordinateSystem
-    ) -> list[sd_transforms.BaseTransformation]:
-        """
-        Get all transformations associated with a coordinate system.
-
-        Parameters
-        ----------
-        cs
-            The coordinate system to check.
-
-        Returns
-        -------
-        List of transformations
-        """
-        self.assert_coordinate_system_exists(cs)
-
-        transformations = []
-        # Check outgoing edges (cs -> other)
-        for successor in self._graph.successors(cs):
-            transformations_outgoing = self.get_direct_transformations(cs, successor)
-            transformations += transformations_outgoing
-        # Check incoming edges (other -> cs)
-        for predecessor in self._graph.predecessors(cs):
-            transformations_incoming = self.get_direct_transformations(source_cs=predecessor, target_cs=cs)
-            transformations += transformations_incoming
-
-        return transformations
 
     def _get_elements_belonging_to_cs(self, cs: NgffCoordinateSystem) -> list[str]:
         """

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -24,7 +24,7 @@ from spatialdata.transformations import transformations as sd_transforms
 from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
 
 TRANSFORM_KEY = "transformation"
-EDGE_DEF = tuple[NgffCoordinateSystem, NgffCoordinateSystem, sd_transforms.BaseTransformation]
+type EDGE_DEF = tuple[NgffCoordinateSystem, NgffCoordinateSystem, sd_transforms.BaseTransformation]
 
 
 class TransformationManager:

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -341,22 +341,21 @@ class TransformationManager:
 
         Returns
         -------
-        List of transformations
+        List of transformations (empty if there are no direct transformations).
 
         Raises
         ------
         CoordinateSystemNotFoundError
             If either coordinate system does not exist.
-        TransformationNotFoundError
-            If the transformation does not exist.
         """
-        self.assert_an_edge_exists_between_coordinate_systems(source_cs, target_cs)
-        # also checks if source_cs and target_cs exist
+        self.assert_coordinate_system_exists(source_cs)
+        self.assert_coordinate_system_exists(target_cs)
+
         transforms = []
-        assert target_cs in self.graph[source_cs], TransformationNotFoundError(source_cs.name, target_cs.name)
-        for edge_data in self.graph[source_cs][target_cs].values():
-            transform: BaseTransformation = edge_data[TRANSFORM_KEY]
-            transforms.append(transform)
+        if self.graph.has_edge(source_cs, target_cs):
+            for edge_data in self.graph[source_cs][target_cs].values():
+                transform: BaseTransformation = edge_data[TRANSFORM_KEY]
+                transforms.append(transform)
         return transforms
 
     def remove_specific_transformation(
@@ -415,11 +414,12 @@ class TransformationManager:
         TransformationNotFoundError
             If no transformation exists between the coordiante systems
         """
-        self.assert_an_edge_exists_between_coordinate_systems(source_cs, target_cs)
-        # also checks if source_cs and target_cs exist
-        for edge_key in list(self.graph[source_cs][target_cs].keys()):
-            # need to covert keys() to list to freeze it, else it will change during the following removal
-            self.graph.remove_edge(source_cs, target_cs, key=edge_key)
+        self.assert_coordinate_system_exists(source_cs)
+        self.assert_coordinate_system_exists(target_cs)
+        if self.graph.has_edge(source_cs, target_cs):
+            for edge_key in list(self.graph[source_cs][target_cs].keys()):
+                # need to covert keys() to list to freeze it, else it will change during the following removal
+                self.graph.remove_edge(source_cs, target_cs, key=edge_key)
 
     def _get_transformation_sequences_from_path_after_disambiguation(
         self,

--- a/src/spatialdata/_core/transformation_manager/__init__.py
+++ b/src/spatialdata/_core/transformation_manager/__init__.py
@@ -23,13 +23,13 @@ TRANSFORM_KEY = "transformation"
 class TransformationManager:
     def __init__(self) -> None:
         """Initialize a TransformationManager with empty graph and mappings."""
-        self._graph = nx.MultiDiGraph[NgffCoordinateSystem]()
+        self._graph: nx.MultiDiGraph[NgffCoordinateSystem] = nx.MultiDiGraph()
         # MultiDiGraph with NgffCoordinateSystem objects as nodes and transforms as edge attributes
         self._element_to_cs_mapping: dict[str, NgffCoordinateSystem] = {}
         # mapping element_name to the coordinate system to which the element belongs
 
     @property
-    def graph(self) -> nx.MultiDiGraph:
+    def graph(self) -> nx.MultiDiGraph[NgffCoordinateSystem]:
         """
         Get the internal transformation graph.
 

--- a/src/spatialdata/_core/transformation_manager/exceptions.py
+++ b/src/spatialdata/_core/transformation_manager/exceptions.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+
+class CoordinateSystemNotFoundError(ValueError):
+    """
+    Exception raised when a coordinate system is not found in the transformation manager.
+
+    Attributes
+    ----------
+    name : str
+        The name of the coordinate system that was not found.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        super().__init__(f"Coordinate system '{name}' not found in the transformation manager.")
+
+
+class ElementNotFoundError(KeyError):
+    """
+    Exception raised when an element is not found in the transformation manager.
+
+    Attributes
+    ----------
+    element_name : str
+        The name of the element that was not found.
+    """
+
+    def __init__(self, element_name: str) -> None:
+        self.element_name = element_name
+        super().__init__(f"Element '{element_name}' not found in the transformation manager.")
+
+
+class TransformationNotFoundError(KeyError):
+    """
+    Exception raised when a transformation is not found between coordinate systems.
+
+    Attributes
+    ----------
+    input_cs_name : str
+        The name of the input coordinate system.
+    output_cs_name : str
+        The name of the output coordinate system.
+    """
+
+    def __init__(self, input_cs_name: str, output_cs_name: str) -> None:
+        self.input_cs_name = input_cs_name
+        self.output_cs_name = output_cs_name
+        super().__init__(f"Transformation from '{input_cs_name}' to '{output_cs_name}' not found.")

--- a/src/spatialdata/_core/transformation_manager/exceptions.py
+++ b/src/spatialdata/_core/transformation_manager/exceptions.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager
+
 
 class CoordinateSystemNotFoundError(ValueError):
     """
@@ -47,3 +51,118 @@ class TransformationNotFoundError(KeyError):
         self.input_cs_name = input_cs_name
         self.output_cs_name = output_cs_name
         super().__init__(f"Transformation from '{input_cs_name}' to '{output_cs_name}' not found.")
+
+
+class CoordinateSystemAlreadyExistsError(ValueError):
+    """
+    Exception raised when coordinate system already exists.
+
+    Attributes
+    ----------
+    name : str
+        The name of the coordinate system that already exists.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        super().__init__(f"Coordinate system '{name}' already exists")
+
+
+class ElementAlreadyExistsError(ValueError):
+    """
+    Exception raised when trying to add an Element that already exists.
+
+    Attributes
+    ----------
+    name : str
+        The name of the Element that already exists.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        super().__init__(f"Element '{name}' already exists in the transformation manager")
+
+
+class TransformationPathNotFoundError(ValueError):
+    """
+    Exception raised when no transformation path exists between coordinate systems.
+
+    Attributes
+    ----------
+    source_cs_name : str
+        The name of the source coordinate system.
+    target_cs_name : str
+        The name of the target coordinate system.
+    """
+
+    def __init__(self, source_cs_name: str, target_cs_name: str) -> None:
+        self.source_cs_name = source_cs_name
+        self.target_cs_name = target_cs_name
+        super().__init__(f"No transformation path found from {source_cs_name} to {target_cs_name}")
+
+
+class CannotRemoveCoordinateSystemError(ValueError):
+    """Exception raised when trying to remove a coordinate system.
+
+    Attributes
+    ----------
+    name: str
+        name of the coordinate system
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        super().__init__(f"Cannot remove coordinate system with name {name}.")
+
+
+class CoordinateSystemHasTransformationsError(ValueError):
+    """
+    Exception raised when trying to remove a coordinate system that has associated transformations.
+
+    Attributes
+    ----------
+    name : str
+        The name of the coordinate system that has transformations.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        super().__init__(f"Coordinate System ('{name}') has transformations.")
+
+
+class CoordinateSystemHasElementsError(ValueError):
+    """
+    Exception raised when trying to remove a coordinate system that has associated elements.
+
+    Attributes
+    ----------
+    name : str
+        The name of the coordinate system that has elements.
+    associated_elements : list[str]
+        List of element names associated with the coordinate system.
+    """
+
+    def __init__(self, name: str, associated_elements: list[str]) -> None:
+        self.name = name
+        self.associated_elements = associated_elements
+        super().__init__(f"Coordinate system '{name}' has elements belonging to it: {associated_elements}")
+
+
+class TransformationManagerWarning(UserWarning):
+    """Base warning category for TransformationManager."""
+
+    pass
+
+
+class InternalAttributeAccessWarning(TransformationManagerWarning):
+    """Warning for direct access to internal attributes."""
+
+    pass
+
+
+@contextmanager
+def suppress_direct_internal_attribute_access_warning() -> Iterator[None]:
+    """Context manager to suppress InternalAttributeAccessWarning when accessing internal attributes."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", InternalAttributeAccessWarning)
+        yield

--- a/src/spatialdata/_core/transformation_manager/exceptions.py
+++ b/src/spatialdata/_core/transformation_manager/exceptions.py
@@ -52,9 +52,10 @@ class TransformationNotFoundError(KeyError):
     def __init__(self, source_cs_name: str, target_cs_name: str, edge_key: str | None = None) -> None:
         self.input_cs_name = source_cs_name
         self.output_cs_name = target_cs_name
+        self.edge_key = edge_key
         msg = f"Transformation from '{source_cs_name}' to '{target_cs_name}' not found"
         if edge_key is not None:
-            msg = f"{msg} with key '{edge_key}'"
+            msg += f" with key '{edge_key}'"
         super().__init__(msg)
 
 

--- a/src/spatialdata/_core/transformation_manager/exceptions.py
+++ b/src/spatialdata/_core/transformation_manager/exceptions.py
@@ -45,12 +45,17 @@ class TransformationNotFoundError(KeyError):
         The name of the input coordinate system.
     output_cs_name : str
         The name of the output coordinate system.
+    edge_key: str or None
+        key used when adding transformation
     """
 
-    def __init__(self, input_cs_name: str, output_cs_name: str) -> None:
-        self.input_cs_name = input_cs_name
-        self.output_cs_name = output_cs_name
-        super().__init__(f"Transformation from '{input_cs_name}' to '{output_cs_name}' not found.")
+    def __init__(self, source_cs_name: str, target_cs_name: str, edge_key: str | None = None) -> None:
+        self.input_cs_name = source_cs_name
+        self.output_cs_name = target_cs_name
+        msg = f"Transformation from '{source_cs_name}' to '{target_cs_name}' not found"
+        if edge_key is not None:
+            msg = f"{msg} with key '{edge_key}'"
+        super().__init__(msg)
 
 
 class CoordinateSystemAlreadyExistsError(ValueError):
@@ -99,6 +104,24 @@ class TransformationPathNotFoundError(ValueError):
         self.source_cs_name = source_cs_name
         self.target_cs_name = target_cs_name
         super().__init__(f"No transformation path found from {source_cs_name} to {target_cs_name}")
+
+
+class TransformationPathAmbiguousError(ValueError):
+    """
+    Exception raised when multiple transformation path exists between coordinate systems.
+
+    Attributes
+    ----------
+    source_cs_name : str
+        The name of the source coordinate system.
+    target_cs_name : str
+        The name of the target coordinate system.
+    """
+
+    def __init__(self, source_cs_name: str, target_cs_name: str) -> None:
+        self.source_cs_name = source_cs_name
+        self.target_cs_name = target_cs_name
+        super().__init__(f"Transformation Path ambiguous from {source_cs_name} to {target_cs_name}")
 
 
 class CannotRemoveCoordinateSystemError(ValueError):

--- a/src/spatialdata/_core/transformation_manager/exceptions.py
+++ b/src/spatialdata/_core/transformation_manager/exceptions.py
@@ -18,6 +18,21 @@ class CoordinateSystemNotFoundError(ValueError):
         super().__init__(f"Coordinate system '{name}' not found in the transformation manager.")
 
 
+class CoordinateSystemAlreadyExistsError(ValueError):
+    """
+    Exception raised when a coordinate system already exists in the transformation manager.
+
+    Attributes
+    ----------
+    name : str
+        The name of the coordinate system to check.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        super().__init__(f"Coordinate system '{name}' already exists in the transformation manager.")
+
+
 class ElementNotRegisteredToAnyCoordinateSystemError(KeyError):
     """
     Exception raised when an element is not found in the transformation manager.
@@ -55,21 +70,6 @@ class TransformationNotFoundError(KeyError):
         if edge_key is not None:
             msg += f" with key '{edge_key}'"
         super().__init__(msg)
-
-
-class CoordinateSystemAlreadyExistsError(ValueError):
-    """
-    Exception raised when coordinate system already exists.
-
-    Attributes
-    ----------
-    name : str
-        The name of the coordinate system that already exists.
-    """
-
-    def __init__(self, name: str) -> None:
-        self.name = name
-        super().__init__(f"Coordinate system '{name}' already exists")
 
 
 class ElementAlreadyExistsError(ValueError):

--- a/src/spatialdata/_core/transformation_manager/exceptions.py
+++ b/src/spatialdata/_core/transformation_manager/exceptions.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-import warnings
-from collections.abc import Iterator
-from contextlib import contextmanager
-
 
 class CoordinateSystemNotFoundError(ValueError):
     """
@@ -176,17 +172,3 @@ class TransformationManagerWarning(UserWarning):
     """Base warning category for TransformationManager."""
 
     pass
-
-
-class InternalAttributeAccessWarning(TransformationManagerWarning):
-    """Warning for direct access to internal attributes."""
-
-    pass
-
-
-@contextmanager
-def suppress_direct_internal_attribute_access_warning() -> Iterator[None]:
-    """Context manager to suppress InternalAttributeAccessWarning when accessing internal attributes."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", InternalAttributeAccessWarning)
-        yield

--- a/src/spatialdata/_core/transformation_manager/exceptions.py
+++ b/src/spatialdata/_core/transformation_manager/exceptions.py
@@ -18,7 +18,7 @@ class CoordinateSystemNotFoundError(ValueError):
         super().__init__(f"Coordinate system '{name}' not found in the transformation manager.")
 
 
-class ElementNotFoundError(KeyError):
+class ElementNotRegisteredToAnyCoordinateSystemError(KeyError):
     """
     Exception raised when an element is not found in the transformation manager.
 
@@ -30,7 +30,7 @@ class ElementNotFoundError(KeyError):
 
     def __init__(self, element_name: str) -> None:
         self.element_name = element_name
-        super().__init__(f"Element '{element_name}' not found in the transformation manager.")
+        super().__init__(f"Element '{element_name}' has not been registered to any coordinate system.")
 
 
 class TransformationNotFoundError(KeyError):
@@ -148,7 +148,7 @@ class TransformationPathAmbiguousNoEdgeExpectedError(TransformationPathAmbiguous
 
     def cause_of_confusion(self) -> str:
 
-        return "None of the edges were specified to be expected"
+        return "Multiple edges found. None of them were specified to be expected"
 
 
 class TransformationPathAmbiguousMultipleEdgeExpectedError(TransformationPathAmbiguousError):

--- a/src/spatialdata/_core/transformation_manager/exceptions.py
+++ b/src/spatialdata/_core/transformation_manager/exceptions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
+
 
 class CoordinateSystemNotFoundError(ValueError):
     """
@@ -118,7 +120,47 @@ class TransformationPathAmbiguousError(ValueError):
     def __init__(self, source_cs_name: str, target_cs_name: str) -> None:
         self.source_cs_name = source_cs_name
         self.target_cs_name = target_cs_name
-        super().__init__(f"Transformation Path ambiguous from {source_cs_name} to {target_cs_name}")
+        base_msg = f"Transformation Path ambiguous from {source_cs_name} to {target_cs_name}."
+        cause_of_confusion = self.cause_of_confusion()
+        msg = f"{base_msg} {cause_of_confusion}" if cause_of_confusion else base_msg
+        super().__init__(msg)
+
+    def cause_of_confusion(self) -> str:
+        return ""
+
+
+class TransformationPathAmbiguousNoEdgeExpectedError(TransformationPathAmbiguousError):
+    def __init__(self, source_cs_name: str, target_cs_name: str) -> None:
+        super().__init__(source_cs_name, target_cs_name)
+
+    def cause_of_confusion(self) -> str:
+
+        return "None of the edges were specified to be expected"
+
+
+class TransformationPathAmbiguousMultipleEdgeExpectedError(TransformationPathAmbiguousError):
+    def __init__(self, source_cs_name: str, target_cs_name: str, number_of_edges_expected: int) -> None:
+        self.number_of_edges_expected = number_of_edges_expected
+        super().__init__(source_cs_name, target_cs_name)
+
+    def cause_of_confusion(self) -> str:
+        return f"Multiple ({self.number_of_edges_expected}) edges were specified to be expected"
+
+
+class TransformationPathNotSimple(ValueError):
+    """
+    Exception raised when a path represented by a list of coordinate systems is not simple.
+
+    A simple path is one in which each coordinate system appears only once
+    """
+
+    def __init__(self, path: list[NgffCoordinateSystem]) -> None:
+        self.path = path
+        css_formatted_one_per_line = "\n".join(repr(cs) for cs in path)
+        super().__init__(
+            f"Transformation Path not simple, i.e., some coordinate systems appear multiple times:\n"
+            f"{css_formatted_one_per_line}"
+        )
 
 
 class CannotRemoveCoordinateSystemError(ValueError):

--- a/src/spatialdata/_core/transformation_manager/exceptions.py
+++ b/src/spatialdata/_core/transformation_manager/exceptions.py
@@ -87,6 +87,19 @@ class ElementAlreadyExistsError(ValueError):
         super().__init__(f"Element '{name}' already exists in the transformation manager")
 
 
+class InvalidPathError(ValueError):
+    """
+    Exception raised when a path is defined with less than 2 nodes.
+
+    Attributes
+    ----------
+    invalid_path : list[NgffCoordinateSystem]
+    """
+
+    def __init__(self, invalid_path: list[NgffCoordinateSystem]) -> None:
+        super().__init__(f"Found an invalid path with less than 2 nodes: {invalid_path}")
+
+
 class TransformationPathNotFoundError(ValueError):
     """
     Exception raised when no transformation path exists between coordinate systems.

--- a/src/spatialdata/_io/io_raster.py
+++ b/src/spatialdata/_io/io_raster.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Literal, TypeGuard, cast
+from typing import Any, Literal, TypeGuard, cast, get_args
 
 import dask.array as da
 import numpy as np
@@ -28,6 +28,7 @@ from spatialdata._io.format import (
     RasterFormatType,
     get_ome_zarr_format,
 )
+from spatialdata._types import ELEMENT_TYPE, ELEMENT_TYPE_RASTER, GROUP_NAME
 from spatialdata._utils import get_pyramid_levels
 from spatialdata.models.models import ATTRS_KEY
 from spatialdata.models.pyramids_utils import dask_arrays_to_datatree
@@ -160,10 +161,12 @@ def _prepare_storage_options(
 
 
 def _read_multiscale(
-    store: str | Path, raster_type: Literal["image", "labels"], reader_format: Format
+    store: str | Path, raster_type: ELEMENT_TYPE_RASTER, reader_format: Format
 ) -> DataArray | DataTree:
     assert isinstance(store, str | Path)
-    assert raster_type in ["image", "labels"]
+    assert raster_type in get_args(ELEMENT_TYPE_RASTER), ValueError(
+        f"{raster_type} is not a valid raster type. Must be one of {get_args(ELEMENT_TYPE_RASTER)}."
+    )
 
     nodes: list[Node] = []
     image_loc = ZarrLocation(store, fmt=reader_format)
@@ -208,7 +211,7 @@ def _read_multiscale(
     transformations = _get_transformations_from_ngff_dict(encoded_ngff_transformations)
     # if image, read channels metadata
     channels: list[Any] | None = None
-    if raster_type == "image":
+    if raster_type == ELEMENT_TYPE.IMAGE:
         if legacy_channels_metadata is not None:
             channels = [d["label"] for d in legacy_channels_metadata["channels"]]
         if omero_metadata is not None:
@@ -223,7 +226,7 @@ def _read_multiscale(
     data = node.load(Multiscales).array(resolution=datasets[0])
     si = DataArray(
         data,
-        name="image",
+        name=ELEMENT_TYPE.IMAGE,
         dims=axes,
         coords={"c": channels} if channels is not None else {},
     )
@@ -259,7 +262,7 @@ def _get_multiscale_nodes(image_nodes: list[Node], nodes: list[Node]) -> list[No
 
 
 def _write_raster(
-    raster_type: Literal["image", "labels"],
+    raster_type: ELEMENT_TYPE_RASTER,
     raster_data: DataArray | DataTree,
     group: zarr.Group,
     name: str,
@@ -292,12 +295,13 @@ def _write_raster(
     metadata
         Additional metadata for the raster element
     """
-    if raster_type not in ["image", "labels"]:
-        raise ValueError(f"{raster_type} is not a valid raster type. Must be 'image' or 'labels'.")
+    assert raster_type in get_args(ELEMENT_TYPE_RASTER), ValueError(
+        f"{raster_type} is not a valid raster type. Must be one of {get_args(ELEMENT_TYPE_RASTER)}."
+    )
     # "name" and "label_metadata" are only used for labels. "name" is written in write_multiscale_ngff() but ignored in
     # write_image_ngff() (possibly an ome-zarr-py bug). We only use "name" to ensure correct group access in the
     # ome-zarr API.
-    if raster_type == "labels":
+    if raster_type == ELEMENT_TYPE.LABELS:
         metadata["name"] = name
         metadata["label_metadata"] = label_metadata
 
@@ -326,8 +330,8 @@ def _write_raster(
     else:
         raise ValueError("Not a valid labels object")
 
-    group = group["labels"][name] if raster_type == "labels" else group
-    if raster_type == "image":
+    group = group[GROUP_NAME.LABELS][name] if raster_type == ELEMENT_TYPE.LABELS else group
+    if raster_type == ELEMENT_TYPE.IMAGE:
         # ome-zarr-py >= 0.18 no longer writes the omero channel metadata, so we write it ourselves.
         overwrite_channel_names(group, raster_data)
     if ATTRS_KEY not in group.attrs:
@@ -418,7 +422,7 @@ def _apply_compression(
 
 
 def _write_raster_dataarray(
-    raster_type: Literal["image", "labels"],
+    raster_type: ELEMENT_TYPE_RASTER,
     group: zarr.Group,
     element_name: str,
     raster_data: DataArray,
@@ -448,7 +452,7 @@ def _write_raster_dataarray(
     metadata
         Additional metadata for the raster element
     """
-    write_single_scale_ngff = write_image_ngff if raster_type == "image" else write_labels_ngff
+    write_single_scale_ngff = write_image_ngff if raster_type == ELEMENT_TYPE.IMAGE else write_labels_ngff
 
     data = raster_data.data
     transformations = _get_transformations(raster_data)
@@ -479,7 +483,7 @@ def _write_raster_dataarray(
         **metadata,
     )
 
-    trans_group = group["labels"][element_name] if raster_type == "labels" else group
+    trans_group = group[GROUP_NAME.LABELS][element_name] if raster_type == ELEMENT_TYPE.LABELS else group
     overwrite_coordinate_transformations_raster(
         group=trans_group,
         transformations=transformations,
@@ -489,7 +493,7 @@ def _write_raster_dataarray(
 
 
 def _write_raster_datatree(
-    raster_type: Literal["image", "labels"],
+    raster_type: ELEMENT_TYPE_RASTER,
     group: zarr.Group,
     element_name: str,
     raster_data: DataTree,
@@ -519,7 +523,9 @@ def _write_raster_datatree(
     metadata
         Additional metadata for the raster element
     """
-    write_multi_scale_ngff = write_multiscale_ngff if raster_type == "image" else write_multiscale_labels_ngff
+    write_multi_scale_ngff = (
+        write_multiscale_ngff if raster_type == ELEMENT_TYPE.IMAGE else write_multiscale_labels_ngff
+    )
     data = get_pyramid_levels(raster_data, attr="data")
     list_of_input_axes: list[Any] = get_pyramid_levels(raster_data, attr="dims")
     assert len(set(list_of_input_axes)) == 1
@@ -562,7 +568,7 @@ def _write_raster_datatree(
     # This workaround should not be needed once https://github.com/ome/ome-zarr-py/issues/580 is fixed.
     group = zarr.open_group(store=group.store, path=group.path, mode="r+", use_consolidated=False)
 
-    trans_group = group["labels"][element_name] if raster_type == "labels" else group
+    trans_group = group[GROUP_NAME.LABELS][element_name] if raster_type == ELEMENT_TYPE.LABELS else group
     overwrite_coordinate_transformations_raster(
         group=trans_group,
         transformations=transformations,
@@ -582,7 +588,7 @@ def write_image(
     **metadata: str | JSONDict | list[JSONDict],
 ) -> None:
     _write_raster(
-        raster_type="image",
+        raster_type=ELEMENT_TYPE.IMAGE,
         raster_data=image,
         group=group,
         name=name,
@@ -604,7 +610,7 @@ def write_labels(
     **metadata: JSONDict,
 ) -> None:
     _write_raster(
-        raster_type="labels",
+        raster_type=ELEMENT_TYPE.LABELS,
         raster_data=labels,
         group=group,
         name=name,

--- a/src/spatialdata/_io/io_zarr.py
+++ b/src/spatialdata/_io/io_zarr.py
@@ -76,10 +76,10 @@ def _read_zarr_group_spatialdata_element(
                         reader_format = get_raster_format_for_read(elem_group, sdata_version)
                         element = read_func(
                             elem_group_path,
-                            cast(Literal["image", "labels"], element_type),
+                            cast(ELEMENT_TYPE_RASTER, element_type),
                             reader_format,
                         )
-                    elif element_type in ["shapes", "points", "tables"]:
+                    elif element_type in get_args(ELEMENT_TYPE_RASTER) + (ELEMENT_TYPE.TABLES,):
                         element = read_func(elem_group_path)
                     else:
                         raise ValueError(f"Unknown element type {element_type}")

--- a/src/spatialdata/_io/io_zarr.py
+++ b/src/spatialdata/_io/io_zarr.py
@@ -30,6 +30,7 @@ from spatialdata._logging import logger
 from spatialdata._types import (
     ELEMENT_TYPE,
     ELEMENT_TYPE_RASTER,
+    ELEMENT_TYPE_VECTOR,
     GROUP_NAME,
     Raster_T,
 )
@@ -79,7 +80,7 @@ def _read_zarr_group_spatialdata_element(
                             cast(ELEMENT_TYPE_RASTER, element_type),
                             reader_format,
                         )
-                    elif element_type in get_args(ELEMENT_TYPE_RASTER) + (ELEMENT_TYPE.TABLES,):
+                    elif element_type in get_args(ELEMENT_TYPE_VECTOR) + (ELEMENT_TYPE.TABLES,):
                         element = read_func(elem_group_path)
                     else:
                         raise ValueError(f"Unknown element type {element_type}")

--- a/src/spatialdata/_io/io_zarr.py
+++ b/src/spatialdata/_io/io_zarr.py
@@ -5,7 +5,7 @@ import warnings
 from collections.abc import Callable
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal, cast, get_args
 
 import zarr.storage
 from anndata import AnnData
@@ -27,7 +27,12 @@ from spatialdata._io.io_raster import _read_multiscale
 from spatialdata._io.io_shapes import _read_shapes
 from spatialdata._io.io_table import _read_table
 from spatialdata._logging import logger
-from spatialdata._types import Raster_T
+from spatialdata._types import (
+    ELEMENT_TYPE,
+    ELEMENT_TYPE_RASTER,
+    GROUP_NAME,
+    Raster_T,
+)
 
 
 def _read_zarr_group_spatialdata_element(
@@ -36,8 +41,8 @@ def _read_zarr_group_spatialdata_element(
     sdata_version: Literal["0.1", "0.2"],
     selector: set[str],
     read_func: Callable[..., Any],
-    group_name: Literal["images", "labels", "shapes", "points", "tables"],
-    element_type: Literal["image", "labels", "shapes", "points", "tables"],
+    group_name: GROUP_NAME,
+    element_type: ELEMENT_TYPE,
     element_container: (dict[str, Raster_T] | dict[str, DaskDataFrame] | dict[str, GeoDataFrame] | dict[str, AnnData]),
     on_bad_files: Literal[BadFileHandleMethod.ERROR, BadFileHandleMethod.WARN],
 ) -> None:
@@ -67,7 +72,7 @@ def _read_zarr_group_spatialdata_element(
                         ValueError,
                     ),
                 ):
-                    if element_type in ["image", "labels"]:
+                    if element_type in get_args(ELEMENT_TYPE_RASTER):
                         reader_format = get_raster_format_for_read(elem_group, sdata_version)
                         element = read_func(
                             elem_group_path,
@@ -183,19 +188,19 @@ def read_zarr(
 
     # we could make this more readable. One can get lost when looking at this dict and iteration over the items
     group_readers: dict[
-        Literal["images", "labels", "shapes", "points", "tables"],
+        GROUP_NAME,
         tuple[
             Callable[..., Any],
-            Literal["image", "labels", "shapes", "points", "tables"],
+            ELEMENT_TYPE,
             dict[str, Raster_T] | dict[str, DaskDataFrame] | dict[str, GeoDataFrame] | dict[str, AnnData],
         ],
     ] = {
-        # ome-zarr-py needs a kwargs that has "image" has key. So here we have "image" and not "images"
-        "images": (_read_multiscale, "image", images),
-        "labels": (_read_multiscale, "labels", labels),
-        "points": (_read_points, "points", points),
-        "shapes": (_read_shapes, "shapes", shapes),
-        "tables": (_read_table, "tables", tables),
+        # ome-zarr-py needs a kwargs that has "image" as key. So here we have "image" and not "images"
+        GROUP_NAME.IMAGES: (_read_multiscale, ELEMENT_TYPE.IMAGE, images),
+        GROUP_NAME.LABELS: (_read_multiscale, ELEMENT_TYPE.LABELS, labels),
+        GROUP_NAME.POINTS: (_read_points, ELEMENT_TYPE.POINTS, points),
+        GROUP_NAME.SHAPES: (_read_shapes, ELEMENT_TYPE.SHAPES, shapes),
+        GROUP_NAME.TABLES: (_read_table, ELEMENT_TYPE.TABLES, tables),
     }
     for group_name, (
         read_func,

--- a/src/spatialdata/_types.py
+++ b/src/spatialdata/_types.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
-from typing import Any
+from enum import StrEnum
+from typing import Any, Literal
 
 import numpy as np
 from xarray import DataArray, DataTree
 
-__all__ = ["ArrayLike", "ColorLike", "DTypeLike", "Raster_T"]
+__all__ = [
+    "ArrayLike",
+    "ColorLike",
+    "DTypeLike",
+    "Raster_T",
+    "ELEMENT_TYPE",
+    "ELEMENT_TYPE_RASTER",
+    "ELEMENT_TYPE_VECTOR",
+    "GROUP_NAME",
+]
 
 from numpy.typing import DTypeLike, NDArray
 
@@ -14,3 +24,23 @@ IntArrayLike = NDArray[np.integer[Any]]
 
 type Raster_T = DataArray | DataTree
 ColorLike = tuple[float, ...] | str
+
+
+class ELEMENT_TYPE(StrEnum):
+    IMAGE = "image"
+    LABELS = "labels"
+    SHAPES = "shapes"
+    POINTS = "points"
+    TABLES = "tables"
+
+
+class GROUP_NAME(StrEnum):
+    IMAGES = "images"
+    LABELS = "labels"
+    SHAPES = "shapes"
+    POINTS = "points"
+    TABLES = "tables"
+
+
+ELEMENT_TYPE_RASTER = Literal[ELEMENT_TYPE.IMAGE, ELEMENT_TYPE.LABELS]
+ELEMENT_TYPE_VECTOR = Literal[ELEMENT_TYPE.POINTS, ELEMENT_TYPE.SHAPES]

--- a/src/spatialdata/_utils.py
+++ b/src/spatialdata/_utils.py
@@ -35,7 +35,7 @@ def disable_dask_tune_optimization() -> Generator[None, None, None]:
         config.set({"optimization.tune.active": old_setting})
 
 
-def _parse_list_into_array(array: list[Number] | ArrayLike) -> ArrayLike:
+def _parse_list_into_array(array: list[list[Number]] | list[Number] | ArrayLike) -> ArrayLike:
     if isinstance(array, list):
         array = np.array(array)
     if array.dtype != float:

--- a/src/spatialdata/transformations/transformations.py
+++ b/src/spatialdata/transformations/transformations.py
@@ -509,7 +509,7 @@ class Scale(BaseTransformation):
 class Affine(BaseTransformation):
     def __init__(
         self,
-        matrix: list[Number] | ArrayLike,
+        matrix: list[list[Number]] | ArrayLike,
         input_axes: tuple[ValidAxis_t, ...],
         output_axes: tuple[ValidAxis_t, ...],
     ) -> None:

--- a/tests/core/transformation_manager/conftest.py
+++ b/tests/core/transformation_manager/conftest.py
@@ -62,7 +62,7 @@ def four_point_graph() -> tuple[list[NgffCoordinateSystem], list[Scale | Transla
 
 
 @pytest.fixture
-def five_point_graph() -> tuple[list[NgffCoordinateSystem], list[Scale | Translation]]:
+def five_point_graph() -> tuple[list[NgffCoordinateSystem], list[Scale | Translation | Affine]]:
     """Fixture providing a five-point graph with five coordinate systems and five transformations."""
 
     coordinate_systems = [

--- a/tests/core/transformation_manager/conftest.py
+++ b/tests/core/transformation_manager/conftest.py
@@ -32,9 +32,6 @@ def fully_connected_two_point_graph() -> tuple[list[NgffCoordinateSystem], list[
     """Fixture providing a fully connected two-point graph with two coordinate systems and transformations."""
     coordinate_systems = [get_ngff_coodinate_system("cs1"), get_ngff_coodinate_system("cs2")]
     transformations = [
-        Identity(),
-        Identity(),
-        Translation(translation=[1.0, 2.0], axes=("x", "y")),
         Translation(translation=[-1.0, -2.0], axes=("x", "y")),
     ]
     return coordinate_systems, transformations

--- a/tests/core/transformation_manager/conftest.py
+++ b/tests/core/transformation_manager/conftest.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import pytest
 
+from spatialdata.transformations import Affine, Scale, Translation
 from spatialdata.transformations.ngff.ngff_coordinate_system import NgffAxis, NgffCoordinateSystem
-from spatialdata.transformations.transformations import Identity, Translation
 
 
 def get_ngff_coodinate_system(cs_name: str) -> NgffCoordinateSystem:
@@ -20,15 +20,15 @@ def get_ngff_coodinate_system(cs_name: str) -> NgffCoordinateSystem:
 
 
 @pytest.fixture
-def one_point_graph() -> tuple[list[NgffCoordinateSystem], list[Identity]]:
+def one_point_graph() -> tuple[list[NgffCoordinateSystem], list[Translation]]:
     """Fixture providing a single point graph with one coordinate system and one transformation."""
     coordinate_systems = [get_ngff_coodinate_system("cs1")]
-    transformations = [Identity()]
+    transformations = [Translation(translation=[1.0, 2.0], axes=("x", "y"))]
     return coordinate_systems, transformations
 
 
 @pytest.fixture
-def fully_connected_two_point_graph() -> tuple[list[NgffCoordinateSystem], list[Identity | Translation]]:
+def fully_connected_two_point_graph() -> tuple[list[NgffCoordinateSystem], list[Translation]]:
     """Fixture providing a fully connected two-point graph with two coordinate systems and transformations."""
     coordinate_systems = [get_ngff_coodinate_system("cs1"), get_ngff_coodinate_system("cs2")]
     transformations = [
@@ -38,7 +38,7 @@ def fully_connected_two_point_graph() -> tuple[list[NgffCoordinateSystem], list[
 
 
 @pytest.fixture
-def four_point_graph() -> tuple[list[NgffCoordinateSystem], list[Identity | Translation]]:
+def four_point_graph() -> tuple[list[NgffCoordinateSystem], list[Scale | Translation]]:
     """Fixture providing a four-point graph with four coordinate systems and transformations."""
     coordinate_systems = [
         get_ngff_coodinate_system("cs1"),
@@ -49,7 +49,44 @@ def four_point_graph() -> tuple[list[NgffCoordinateSystem], list[Identity | Tran
     transformations = [
         Translation(translation=[1.0, 2.0], axes=("x", "y")),  # cs1 -> cs2
         Translation(translation=[3.0, 4.0], axes=("x", "y")),  # cs2 -> cs3
-        Identity(),  # cs3 -> cs4
+        Scale(
+            scale=[
+                2,
+                2,
+            ],
+            axes=("x", "y"),
+        ),  # cs3 -> cs4;
         Translation(translation=[4.0, 6.0], axes=("x", "y")),  # cs1 -> cs3 (consistent with cs1->cs2 and cs2->cs3)
+    ]
+    return coordinate_systems, transformations
+
+
+@pytest.fixture
+def five_point_graph() -> tuple[list[NgffCoordinateSystem], list[Scale | Translation]]:
+    """Fixture providing a five-point graph with five coordinate systems and five transformations."""
+
+    coordinate_systems = [
+        get_ngff_coodinate_system("cs1"),
+        get_ngff_coodinate_system("cs2"),
+        get_ngff_coodinate_system("cs3"),
+        get_ngff_coodinate_system("cs4"),
+        get_ngff_coodinate_system("cs5"),
+    ]
+    transformations = [
+        Translation(translation=[1.0, 2.0], axes=("x", "y")),  # cs1 -> cs2, cs4 -> cs3
+        Translation(translation=[3.0, 4.0], axes=("x", "y")),  # cs2 -> cs3, cs1 -> cs4
+        Translation(translation=[4.0, 6.0], axes=("x", "y")),  # cs1 -> cs3 (consistent with cs1->cs2 and cs2->cs3)
+        Scale(
+            scale=[
+                2,
+                2,
+            ],
+            axes=("x", "y"),
+        ),  # cs3 -> cs5;
+        Affine(
+            matrix=[[2, 0, 0], [0, 2, 0], [0, 0, 1]],
+            input_axes=("x", "y"),
+            output_axes=("x", "y"),
+        ),  # cs3 -> cs5
     ]
     return coordinate_systems, transformations

--- a/tests/core/transformation_manager/conftest.py
+++ b/tests/core/transformation_manager/conftest.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+"""
+Fixtures for transformation manager tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from spatialdata.transformations.ngff.ngff_coordinate_system import NgffAxis, NgffCoordinateSystem
+from spatialdata.transformations.transformations import Identity, Translation
+
+
+def get_ngff_coodinate_system(cs_name: str) -> NgffCoordinateSystem:
+    return NgffCoordinateSystem(
+        name=cs_name,
+        axes=[NgffAxis(name="x", type="space", unit="micrometer"), NgffAxis(name="y", type="space", unit="micrometer")],
+    )
+
+
+@pytest.fixture
+def one_point_graph() -> tuple[list[NgffCoordinateSystem], list[Identity]]:
+    """Fixture providing a single point graph with one coordinate system and one transformation."""
+    coordinate_systems = [get_ngff_coodinate_system("cs1")]
+    transformations = [Identity()]
+    return coordinate_systems, transformations
+
+
+@pytest.fixture
+def fully_connected_two_point_graph() -> tuple[list[NgffCoordinateSystem], list[Identity | Translation]]:
+    """Fixture providing a fully connected two-point graph with two coordinate systems and transformations."""
+    coordinate_systems = [get_ngff_coodinate_system("cs1"), get_ngff_coodinate_system("cs2")]
+    transformations = [
+        Identity(),
+        Identity(),
+        Translation(translation=[1.0, 2.0], axes=("x", "y")),
+        Translation(translation=[-1.0, -2.0], axes=("x", "y")),
+    ]
+    return coordinate_systems, transformations
+
+
+@pytest.fixture
+def four_point_graph() -> tuple[list[NgffCoordinateSystem], list[Identity | Translation]]:
+    """Fixture providing a four-point graph with four coordinate systems and transformations."""
+    coordinate_systems = [
+        get_ngff_coodinate_system("cs1"),
+        get_ngff_coodinate_system("cs2"),
+        get_ngff_coodinate_system("cs3"),
+        get_ngff_coodinate_system("cs4"),
+    ]
+    transformations = [
+        Translation(translation=[1.0, 2.0], axes=("x", "y")),  # cs1 -> cs2
+        Translation(translation=[3.0, 4.0], axes=("x", "y")),  # cs2 -> cs3
+        Identity(),  # cs3 -> cs4
+        Translation(translation=[4.0, 6.0], axes=("x", "y")),  # cs1 -> cs3 (consistent with cs1->cs2 and cs2->cs3)
+    ]
+    return coordinate_systems, transformations

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -11,8 +11,7 @@ from __future__ import annotations
 import networkx as nx
 import pytest
 
-from spatialdata import TransformationManager
-from spatialdata._core.transformation_manager import TRANSFORM_KEY
+from spatialdata._core.transformation_manager import TRANSFORM_KEY, TransformationManager
 from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
 
 
@@ -51,7 +50,7 @@ def test_remove_coordinate_system(one_point_graph):
     coordinate_systems, _ = one_point_graph
     cs = coordinate_systems[0]
     tm._graph.add_node(cs)
-    tm._graph.remove_node(cs)
+    tm.remove_coordinate_system(cs)
     assert cs not in tm._graph.nodes()
 
 
@@ -64,7 +63,7 @@ def test_remove_coordinate_system_nonexistent():
 
 
 def test_remove_coordinate_system_with_associations(fully_connected_two_point_graph):
-    """Test removing a coordinate system with associations."""
+    """Test that removing a coordinate system with associations raises ValueError."""
     tm = TransformationManager()
     coordinate_systems, _transformations = fully_connected_two_point_graph
     cs1, cs2 = coordinate_systems
@@ -74,10 +73,9 @@ def test_remove_coordinate_system_with_associations(fully_connected_two_point_gr
     transform = _transformations[0]
     tm.add_transformation(cs1, cs2, transform)
 
-    # NetworkX removes the node and all its edges
-    tm._graph.remove_node(cs1)
-    assert cs1 not in tm._graph.nodes()
-    assert not tm._graph.has_edge(cs1, cs2)
+    # Should raise ValueError when trying to remove a coordinate system with transformations
+    with pytest.raises(ValueError, match="Cannot remove coordinate system"):
+        tm.remove_coordinate_system(cs1)
 
 
 def test_remove_coordinate_system_with_element_associations(one_point_graph):
@@ -198,7 +196,7 @@ def test_get_existing_transformation(fully_connected_two_point_graph, cs_names):
     transform = transformations[0]
     tm.add_transformation(cs1, cs2, transform)
 
-    retrieved = tm.get_transformation(cs1, cs2)
+    retrieved = tm.get_existing_transformation(cs1, cs2)
     assert retrieved == transform
 
 
@@ -210,7 +208,7 @@ def test_get_existing_transformation_nonexistent(fully_connected_two_point_graph
     tm._graph.add_node(cs1)
     tm._graph.add_node(cs2)
 
-    retrieved = tm.get_transformation(cs1, cs2)
+    retrieved = tm.get_existing_transformation(cs1, cs2)
     assert retrieved is None
 
 

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -12,6 +12,9 @@ import networkx as nx
 import pytest
 
 from spatialdata._core.transformation_manager import TRANSFORM_KEY, TransformationManager
+from spatialdata._core.transformation_manager.exceptions import (
+    TransformationNotFoundError,
+)
 from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
 
 
@@ -127,25 +130,6 @@ def test_add_element_nonexistent_cs():
         tm.add_element("image1", cs)
 
 
-def test_get_element_coordinate_system(one_point_graph):
-    """Test getting the coordinate system of an element."""
-    tm = TransformationManager()
-    coordinate_systems, _ = one_point_graph
-    cs = coordinate_systems[0]
-    tm._graph.add_node(cs)
-    tm.add_element("image1", cs)
-
-    cs_name = tm.get_element_coordinate_system("image1")
-    assert cs_name == cs
-
-
-def test_get_element_coordinate_system_nonexistent():
-    """Test getting the coordinate system of a non-existent element."""
-    tm = TransformationManager()
-    cs_name = tm.get_element_coordinate_system("nonexistent")
-    assert cs_name is None
-
-
 @pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
 def test_add_transformation(fully_connected_two_point_graph, cs_names):
     """Test adding a transformation between coordinate systems."""
@@ -170,17 +154,13 @@ def test_add_transformation_nonexistent_cs(fully_connected_two_point_graph, cs_n
     transform = transformations[0]
     cs1, cs2 = coordinate_systems
 
-    with pytest.raises(
-        ValueError, match=f"Coordinate system '{cs1.name}' does not exist in the transformation manager"
-    ):
+    with pytest.raises(ValueError, match=f"Coordinate system '{cs1.name}' not found in the transformation manager"):
         tm.add_transformation(cs1, cs2, transform)
 
     # Add one coordinate system
     tm._graph.add_node(cs1)
 
-    with pytest.raises(
-        ValueError, match=f"Coordinate system '{cs2.name}' does not exist in the transformation manager"
-    ):
+    with pytest.raises(ValueError, match=f"Coordinate system '{cs2.name}' not found in the transformation manager"):
         tm.add_transformation(cs1, cs2, transform)
 
 
@@ -208,8 +188,10 @@ def test_get_existing_transformation_nonexistent(fully_connected_two_point_graph
     tm._graph.add_node(cs1)
     tm._graph.add_node(cs2)
 
-    retrieved = tm.get_existing_transformation(cs1, cs2)
-    assert retrieved is None
+    with pytest.raises(
+        TransformationNotFoundError, match=f"Transformation from '{cs1.name}' to '{cs2.name}' not found"
+    ):
+        tm.get_existing_transformation(cs1, cs2)
 
 
 @pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
@@ -235,42 +217,10 @@ def test_remove_transformation_nonexistent():
     cs2 = NgffCoordinateSystem(name="cs2", axes=[])
     tm._graph.add_node(cs1)
     tm._graph.add_node(cs2)
-    with pytest.raises(KeyError, match="Transformation from 'cs1' to 'cs2' not found"):
+    with pytest.raises(
+        TransformationNotFoundError, match=f"Transformation from '{cs1.name}' to '{cs2.name}' not found"
+    ):
         tm.remove_transformation(cs1, cs2)
-
-
-def test_build_nx_graph(four_point_graph):
-    """Test building a networkx graph from the transformation manager."""
-    tm = TransformationManager()
-    coordinate_systems, transformations = four_point_graph
-    cs1, cs2, cs3, cs4 = coordinate_systems
-    tm._graph.add_node(cs1)
-    tm._graph.add_node(cs2)
-    tm._graph.add_node(cs3)
-    tm._graph.add_node(cs4)
-
-    transform1 = transformations[0]  # cs1 -> cs2
-    transform2 = transformations[1]  # cs2 -> cs3
-    transform3 = transformations[2]  # cs3 -> cs4
-    transform4 = transformations[3]  # cs1 -> cs3
-    tm.add_transformation(cs1, cs2, transform1)
-    tm.add_transformation(cs2, cs3, transform2)
-    tm.add_transformation(cs3, cs4, transform3)
-    tm.add_transformation(cs1, cs3, transform4)
-
-    g = tm.build_nx_graph()
-    assert g.has_node(cs1)
-    assert g.has_node(cs2)
-    assert g.has_node(cs3)
-    assert g.has_node(cs4)
-    assert g.has_edge(cs1, cs2)
-    assert g.has_edge(cs2, cs3)
-    assert g.has_edge(cs3, cs4)
-    assert g.has_edge(cs1, cs3)
-    assert g[cs1][cs2][0][TRANSFORM_KEY] == transform1
-    assert g[cs2][cs3][0][TRANSFORM_KEY] == transform2
-    assert g[cs3][cs4][0][TRANSFORM_KEY] == transform3
-    assert g[cs1][cs3][0][TRANSFORM_KEY] == transform4
 
 
 def test_get_shortest_transformation_sequence_direct(four_point_graph):

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -21,9 +21,9 @@ from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordina
 def test_initialization():
     """Test that TransformationManager initializes correctly."""
     tm = TransformationManager()
-    assert len(tm._graph.nodes()) == 0
-    assert len(tm._graph.edges()) == 0
-    assert tm._element_to_cs_mapping == {}
+    assert len(tm.graph.nodes()) == 0
+    assert len(tm.graph.edges()) == 0
+    assert tm.element_to_cs_mapping == {}
 
 
 def test_add_coordinate_system(one_point_graph):
@@ -31,8 +31,8 @@ def test_add_coordinate_system(one_point_graph):
     tm = TransformationManager()
     coordinate_systems, _ = one_point_graph
     cs = coordinate_systems[0]
-    tm._graph.add_node(cs)
-    assert cs in tm._graph.nodes()
+    tm.add_coordinate_system(cs)
+    assert cs in tm.graph.nodes()
 
 
 def test_add_coordinate_system_duplicate(one_point_graph):
@@ -40,10 +40,9 @@ def test_add_coordinate_system_duplicate(one_point_graph):
     tm = TransformationManager()
     coordinate_systems, _ = one_point_graph
     cs = coordinate_systems[0]
-    tm._graph.add_node(cs)
-    # NetworkX allows adding the same node multiple times, so this test may need to be updated
-    # For now, let's just check that the node exists
-    assert cs in tm._graph.nodes()
+    tm.add_coordinate_system(cs)
+    with pytest.raises(ValueError, match=f"Coordinate system '{cs.name}' already exists"):
+        tm.add_coordinate_system(cs)
 
 
 def test_remove_coordinate_system(one_point_graph):
@@ -52,9 +51,9 @@ def test_remove_coordinate_system(one_point_graph):
 
     coordinate_systems, _ = one_point_graph
     cs = coordinate_systems[0]
-    tm._graph.add_node(cs)
+    tm.add_coordinate_system(cs)
     tm.remove_coordinate_system(cs)
-    assert cs not in tm._graph.nodes()
+    assert cs not in tm.graph.nodes()
 
 
 def test_remove_coordinate_system_nonexistent():
@@ -62,7 +61,7 @@ def test_remove_coordinate_system_nonexistent():
     tm = TransformationManager()
     cs = NgffCoordinateSystem(name="cs1", axes=[])
     with pytest.raises(nx.NetworkXError):
-        tm._graph.remove_node(cs)
+        tm.graph.remove_node(cs)
 
 
 def test_remove_coordinate_system_with_associations(fully_connected_two_point_graph):
@@ -70,8 +69,8 @@ def test_remove_coordinate_system_with_associations(fully_connected_two_point_gr
     tm = TransformationManager()
     coordinate_systems, _transformations = fully_connected_two_point_graph
     cs1, cs2 = coordinate_systems
-    tm._graph.add_node(cs1)
-    tm._graph.add_node(cs2)
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
 
     transform = _transformations[0]
     tm.add_transformation(cs1, cs2, transform)
@@ -86,13 +85,13 @@ def test_remove_coordinate_system_with_element_associations(one_point_graph):
     tm = TransformationManager()
     coordinate_systems, _ = one_point_graph
     cs = coordinate_systems[0]
-    tm._graph.add_node(cs)
+    tm.add_coordinate_system(cs)
     tm.add_element("image1", cs)
 
     # The current implementation doesn't prevent removing nodes with element associations
     # This test may need to be updated based on the actual behavior
-    tm._graph.remove_node(cs)
-    assert cs not in tm._graph.nodes()
+    tm.graph.remove_node(cs)
+    assert cs not in tm.graph.nodes()
 
 
 @pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
@@ -101,8 +100,8 @@ def test_list_coordinate_systems(fully_connected_two_point_graph, cs_names):
     tm = TransformationManager()
     coordinate_systems, _ = fully_connected_two_point_graph
     cs1, cs2 = coordinate_systems
-    tm._graph.add_node(cs1)
-    tm._graph.add_node(cs2)
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
 
     systems = tm.list_coordinate_systems()
     assert set(systems) == {cs1, cs2}
@@ -113,10 +112,10 @@ def test_add_element(one_point_graph):
     tm = TransformationManager()
     coordinate_systems, _ = one_point_graph
     cs = coordinate_systems[0]
-    tm._graph.add_node(cs)
+    tm.add_coordinate_system(cs)
     tm.add_element("image1", cs)
 
-    mapping = tm._element_to_cs_mapping
+    mapping = tm.element_to_cs_mapping
     assert "image1" in mapping
     assert mapping["image1"] == cs
 
@@ -136,14 +135,14 @@ def test_add_transformation(fully_connected_two_point_graph, cs_names):
     tm = TransformationManager()
     coordinate_systems, transformations = fully_connected_two_point_graph
     cs1, cs2 = coordinate_systems
-    tm._graph.add_node(cs1)
-    tm._graph.add_node(cs2)
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
 
     transform = transformations[0]
     tm.add_transformation(cs1, cs2, transform)
 
-    assert tm._graph.has_edge(cs1, cs2)
-    assert tm._graph[cs1][cs2][0][TRANSFORM_KEY] == transform
+    assert tm.graph.has_edge(cs1, cs2)
+    assert tm.graph[cs1][cs2][0][TRANSFORM_KEY] == transform
 
 
 @pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
@@ -158,7 +157,7 @@ def test_add_transformation_nonexistent_cs(fully_connected_two_point_graph, cs_n
         tm.add_transformation(cs1, cs2, transform)
 
     # Add one coordinate system
-    tm._graph.add_node(cs1)
+    tm.add_coordinate_system(cs1)
 
     with pytest.raises(ValueError, match=f"Coordinate system '{cs2.name}' not found in the transformation manager"):
         tm.add_transformation(cs1, cs2, transform)
@@ -170,8 +169,8 @@ def test_get_existing_transformation(fully_connected_two_point_graph, cs_names):
     tm = TransformationManager()
     coordinate_systems, transformations = fully_connected_two_point_graph
     cs1, cs2 = coordinate_systems
-    tm._graph.add_node(cs1)
-    tm._graph.add_node(cs2)
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
 
     transform = transformations[0]
     tm.add_transformation(cs1, cs2, transform)
@@ -185,8 +184,8 @@ def test_get_existing_transformation_nonexistent(fully_connected_two_point_graph
     tm = TransformationManager()
     coordinate_systems, _transformations = fully_connected_two_point_graph
     cs1, cs2 = coordinate_systems
-    tm._graph.add_node(cs1)
-    tm._graph.add_node(cs2)
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
 
     with pytest.raises(
         TransformationNotFoundError, match=f"Transformation from '{cs1.name}' to '{cs2.name}' not found"
@@ -200,14 +199,14 @@ def test_remove_transformation(fully_connected_two_point_graph, cs_names):
     tm = TransformationManager()
     coordinate_systems, transformations = fully_connected_two_point_graph
     cs1, cs2 = coordinate_systems
-    tm._graph.add_node(cs1)
-    tm._graph.add_node(cs2)
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
 
     transform = transformations[0]
     tm.add_transformation(cs1, cs2, transform)
 
     tm.remove_transformation(cs1, cs2)
-    assert not tm._graph.has_edge(cs1, cs2)
+    assert not tm.graph.has_edge(cs1, cs2)
 
 
 def test_remove_transformation_nonexistent():
@@ -215,8 +214,8 @@ def test_remove_transformation_nonexistent():
     tm = TransformationManager()
     cs1 = NgffCoordinateSystem(name="cs1", axes=[])
     cs2 = NgffCoordinateSystem(name="cs2", axes=[])
-    tm._graph.add_node(cs1)
-    tm._graph.add_node(cs2)
+    tm.graph.add_node(cs1)
+    tm.graph.add_node(cs2)
     with pytest.raises(
         TransformationNotFoundError, match=f"Transformation from '{cs1.name}' to '{cs2.name}' not found"
     ):
@@ -228,10 +227,10 @@ def test_get_shortest_transformation_sequence_direct(four_point_graph):
     tm = TransformationManager()
     coordinate_systems, transformations = four_point_graph
     cs1, cs2, cs3, cs4 = coordinate_systems
-    tm._graph.add_node(cs1)
-    tm._graph.add_node(cs2)
-    tm._graph.add_node(cs3)
-    tm._graph.add_node(cs4)
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
 
     transform1 = transformations[0]  # cs1 -> cs2
     transform2 = transformations[1]  # cs2 -> cs3
@@ -249,10 +248,10 @@ def test_get_shortest_transformation_sequence_indirect(four_point_graph):
     tm = TransformationManager()
     coordinate_systems, transformations = four_point_graph
     cs1, cs2, cs3, cs4 = coordinate_systems
-    tm._graph.add_node(cs1)
-    tm._graph.add_node(cs2)
-    tm._graph.add_node(cs3)
-    tm._graph.add_node(cs4)
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
 
     transform1 = transformations[0]  # cs1 -> cs2
     transform2 = transformations[1]  # cs2 -> cs3
@@ -270,10 +269,10 @@ def test_get_shortest_transformation_sequence_no_path(four_point_graph):
     tm = TransformationManager()
     coordinate_systems, transformations = four_point_graph
     cs1, cs2, cs3, cs4 = coordinate_systems
-    tm._graph.add_node(cs1)
-    tm._graph.add_node(cs2)
-    tm._graph.add_node(cs3)
-    tm._graph.add_node(cs4)
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
 
     transform1 = transformations[0]  # cs1 -> cs2
     transform2 = transformations[1]  # cs2 -> cs3
@@ -290,10 +289,10 @@ def test_get_all_transformation_sequences(four_point_graph):
     tm = TransformationManager()
     coordinate_systems, transformations = four_point_graph
     cs1, cs2, cs3, cs4 = coordinate_systems
-    tm._graph.add_node(cs1)
-    tm._graph.add_node(cs2)
-    tm._graph.add_node(cs3)
-    tm._graph.add_node(cs4)
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
 
     transform1 = transformations[0]  # cs1 -> cs2
     transform2 = transformations[1]  # cs2 -> cs3
@@ -315,10 +314,10 @@ def test_get_all_transformation_sequences_no_path(four_point_graph):
     tm = TransformationManager()
     coordinate_systems, transformations = four_point_graph
     cs1, cs2, cs3, cs4 = coordinate_systems
-    tm._graph.add_node(cs1)
-    tm._graph.add_node(cs2)
-    tm._graph.add_node(cs3)
-    tm._graph.add_node(cs4)
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
 
     transform1 = transformations[0]  # cs1 -> cs2
     transform2 = transformations[1]  # cs2 -> cs3
@@ -335,7 +334,7 @@ def test_repr(one_point_graph):
     tm = TransformationManager()
     coordinate_systems, _ = one_point_graph
     cs = coordinate_systems[0]
-    tm._graph.add_node(cs)
+    tm.add_coordinate_system(cs)
     tm.add_element("image1", cs)
 
     repr_str = repr(tm)

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -8,171 +8,180 @@ This module tests all the functionality of the TransformationManager class to ac
 
 from __future__ import annotations
 
-import networkx as nx
 import pytest
 
 from spatialdata._core.transformation_manager import TRANSFORM_KEY, TransformationManager
 from spatialdata._core.transformation_manager.exceptions import (
+    CannotRemoveCoordinateSystemError,
+    CoordinateSystemAlreadyExistsError,
+    CoordinateSystemNotFoundError,
     TransformationNotFoundError,
+    TransformationPathNotFoundError,
+    suppress_direct_internal_attribute_access_warning,
 )
-from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
 
 
 def test_initialization():
     """Test that TransformationManager initializes correctly."""
-    tm = TransformationManager()
-    assert len(tm.graph.nodes()) == 0
-    assert len(tm.graph.edges()) == 0
-    assert tm.element_to_cs_mapping == {}
+    with suppress_direct_internal_attribute_access_warning():
+        tm = TransformationManager()
+        assert len(tm.graph.nodes()) == 0
+        assert len(tm.graph.edges()) == 0
+        assert tm.element_to_cs_mapping == {}
 
 
 def test_add_coordinate_system(one_point_graph):
     """Test adding a coordinate system."""
-    tm = TransformationManager()
-    coordinate_systems, _ = one_point_graph
-    cs = coordinate_systems[0]
-    tm.add_coordinate_system(cs)
-    assert cs in tm.graph.nodes()
+    with suppress_direct_internal_attribute_access_warning():
+        tm = TransformationManager()
+        [cs1], _ = one_point_graph
+
+        tm.add_coordinate_system(cs1)
+        assert cs1 in tm.graph.nodes()
 
 
 def test_add_coordinate_system_duplicate(one_point_graph):
-    """Test that adding a duplicate coordinate system raises ValueError."""
+    """Test adding an already existing coordinate system"""
     tm = TransformationManager()
-    coordinate_systems, _ = one_point_graph
-    cs = coordinate_systems[0]
-    tm.add_coordinate_system(cs)
-    with pytest.raises(ValueError, match=f"Coordinate system '{cs.name}' already exists"):
-        tm.add_coordinate_system(cs)
+    [cs1], _ = one_point_graph
+
+    tm.add_coordinate_system(cs1)
+    with pytest.raises(CoordinateSystemAlreadyExistsError, match=f"Coordinate system '{cs1.name}' already exists"):
+        tm.add_coordinate_system(cs1)
 
 
 def test_remove_coordinate_system(one_point_graph):
     """Test removing a coordinate system."""
     tm = TransformationManager()
+    [cs1], _ = one_point_graph
 
-    coordinate_systems, _ = one_point_graph
-    cs = coordinate_systems[0]
-    tm.add_coordinate_system(cs)
-    tm.remove_coordinate_system(cs)
-    assert cs not in tm.graph.nodes()
-
-
-def test_remove_coordinate_system_nonexistent():
-    """Test that removing a non-existent coordinate system raises KeyError."""
-    tm = TransformationManager()
-    cs = NgffCoordinateSystem(name="cs1", axes=[])
-    with pytest.raises(nx.NetworkXError):
-        tm.graph.remove_node(cs)
-
-
-def test_remove_coordinate_system_with_associations(fully_connected_two_point_graph):
-    """Test that removing a coordinate system with associations raises ValueError."""
-    tm = TransformationManager()
-    coordinate_systems, _transformations = fully_connected_two_point_graph
-    cs1, cs2 = coordinate_systems
     tm.add_coordinate_system(cs1)
-    tm.add_coordinate_system(cs2)
+    tm.remove_coordinate_system(cs1)
 
-    transform = _transformations[0]
-    tm.add_transformation(cs1, cs2, transform)
+    with suppress_direct_internal_attribute_access_warning():
+        assert cs1 not in tm.graph.nodes()
 
-    # Should raise ValueError when trying to remove a coordinate system with transformations
-    with pytest.raises(ValueError, match="Cannot remove coordinate system"):
+
+def test_remove_coordinate_system_nonexistent(one_point_graph):
+    """Test that removing a non-existent coordinate system raises CoordinateSystemNotFoundError."""
+    tm = TransformationManager()
+    [cs1], _ = one_point_graph
+
+    # Add the coordinate system first
+    tm.add_coordinate_system(cs1)
+
+    # Remove it
+    tm.remove_coordinate_system(cs1)
+
+    # Try to remove it again - should raise CoordinateSystemNotFoundError
+    with pytest.raises(CoordinateSystemNotFoundError):
         tm.remove_coordinate_system(cs1)
 
 
-def test_remove_coordinate_system_with_element_associations(one_point_graph):
-    """Test that removing a coordinate system with element associations raises ValueError."""
+def test_remove_coordinate_system_with_associated_transformations(fully_connected_two_point_graph):
+    """
+    Test that removing a coordinate system with associated transformations raises CannotRemoveCoordinateSystemError.
+    """
     tm = TransformationManager()
-    coordinate_systems, _ = one_point_graph
-    cs = coordinate_systems[0]
-    tm.add_coordinate_system(cs)
-    tm.add_element("image1", cs)
+    [cs1, cs2], [transformation] = fully_connected_two_point_graph
 
-    # The current implementation doesn't prevent removing nodes with element associations
-    # This test may need to be updated based on the actual behavior
-    tm.graph.remove_node(cs)
-    assert cs not in tm.graph.nodes()
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+
+    tm.add_transformation(cs1, cs2, transformation)
+
+    # Should raise CannotRemoveCoordinateSystem when trying to remove a coordinate system with transformations
+    with pytest.raises(CannotRemoveCoordinateSystemError, match="Cannot remove coordinate system"):
+        tm.remove_coordinate_system(cs1)
 
 
-@pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
-def test_list_coordinate_systems(fully_connected_two_point_graph, cs_names):
+def test_remove_coordinate_system_with_belonging_elements(one_point_graph):
+    """Test that removing a coordinate system with element associations raises CannotRemoveCoordinateSystemError."""
+    tm = TransformationManager()
+    [cs1], _ = one_point_graph
+    tm.add_coordinate_system(cs1)
+    tm.add_element("image1", cs1)
+
+    with pytest.raises(CannotRemoveCoordinateSystemError, match="Cannot remove coordinate system"):
+        tm.remove_coordinate_system(cs1)
+
+
+def test_list_coordinate_systems(fully_connected_two_point_graph):
     """Test listing all coordinate systems."""
     tm = TransformationManager()
-    coordinate_systems, _ = fully_connected_two_point_graph
-    cs1, cs2 = coordinate_systems
+    [cs1, cs2], _ = fully_connected_two_point_graph
     tm.add_coordinate_system(cs1)
     tm.add_coordinate_system(cs2)
 
     systems = tm.list_coordinate_systems()
-    assert set(systems) == {cs1, cs2}
+    assert len(systems) == 2
+    assert cs1 in systems
+    assert cs2 in systems
 
 
 def test_add_element(one_point_graph):
     """Test adding an element with an existing coordinate system."""
     tm = TransformationManager()
-    coordinate_systems, _ = one_point_graph
-    cs = coordinate_systems[0]
-    tm.add_coordinate_system(cs)
-    tm.add_element("image1", cs)
-
-    mapping = tm.element_to_cs_mapping
-    assert "image1" in mapping
-    assert mapping["image1"] == cs
-
-
-def test_add_element_nonexistent_cs():
-    """Test that adding an element with a non-existent coordinate system raises KeyError."""
-    tm = TransformationManager()
-    cs = NgffCoordinateSystem(name="nonexistent_cs", axes=[])
-    # The current implementation issues a warning and returns, doesn't raise an error
-    with pytest.warns(UserWarning, match="Cannot set coordinate system"):
-        tm.add_element("image1", cs)
-
-
-@pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
-def test_add_transformation(fully_connected_two_point_graph, cs_names):
-    """Test adding a transformation between coordinate systems."""
-    tm = TransformationManager()
-    coordinate_systems, transformations = fully_connected_two_point_graph
-    cs1, cs2 = coordinate_systems
+    [cs1], _ = one_point_graph
     tm.add_coordinate_system(cs1)
-    tm.add_coordinate_system(cs2)
+    tm.add_element("image1", cs1)
 
-    transform = transformations[0]
-    tm.add_transformation(cs1, cs2, transform)
+    with suppress_direct_internal_attribute_access_warning():
+        mapping = tm.element_to_cs_mapping
+        assert "image1" in mapping
+        assert mapping["image1"] == cs1
 
-    assert tm.graph.has_edge(cs1, cs2)
-    assert tm.graph[cs1][cs2][0][TRANSFORM_KEY] == transform
 
-
-@pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
-def test_add_transformation_nonexistent_cs(fully_connected_two_point_graph, cs_names):
-    """Test that adding a transformation with non-existent coordinate systems raises ValueError."""
+def test_add_element_nonexistent_cs(one_point_graph):
+    """Test that adding an element with a non-existent coordinate system raises CoordinateSystemNotFoundError."""
     tm = TransformationManager()
-    coordinate_systems, transformations = fully_connected_two_point_graph
-    transform = transformations[0]
-    cs1, cs2 = coordinate_systems
+    [cs1], _ = one_point_graph
+    element_name = "image1"
+    with pytest.raises(CoordinateSystemNotFoundError, match=f"Coordinate system '{cs1.name}' not found in"):
+        tm.add_element(element_name, cs1)
 
-    with pytest.raises(ValueError, match=f"Coordinate system '{cs1.name}' not found in the transformation manager"):
+
+def test_add_transformation(fully_connected_two_point_graph):
+    """Test adding a transformation between coordinate systems."""
+    with suppress_direct_internal_attribute_access_warning():
+        tm = TransformationManager()
+        [cs1, cs2], [transform] = fully_connected_two_point_graph
+
+        tm.add_coordinate_system(cs1)
+        tm.add_coordinate_system(cs2)
+
+        tm.add_transformation(cs1, cs2, transform)
+
+        assert tm.graph.has_edge(cs1, cs2)
+        assert tm.graph[cs1][cs2][0][TRANSFORM_KEY] == transform
+
+
+def test_add_transformation_nonexistent_cs(fully_connected_two_point_graph):
+    """Test that adding a transformation with non-existent coordinate systems raises CoordinateSystemNotFoundError."""
+    tm = TransformationManager()
+    [cs1, cs2], [transform] = fully_connected_two_point_graph
+
+    with pytest.raises(
+        CoordinateSystemNotFoundError, match=f"Coordinate system '{cs1.name}' not found in the transformation manager"
+    ):
         tm.add_transformation(cs1, cs2, transform)
 
     # Add one coordinate system
     tm.add_coordinate_system(cs1)
 
-    with pytest.raises(ValueError, match=f"Coordinate system '{cs2.name}' not found in the transformation manager"):
+    with pytest.raises(
+        CoordinateSystemNotFoundError, match=f"Coordinate system '{cs2.name}' not found in the transformation manager"
+    ):
         tm.add_transformation(cs1, cs2, transform)
 
 
-@pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
-def test_get_existing_transformation(fully_connected_two_point_graph, cs_names):
+def test_get_existing_transformation(fully_connected_two_point_graph):
     """Test getting an existing transformation."""
     tm = TransformationManager()
-    coordinate_systems, transformations = fully_connected_two_point_graph
-    cs1, cs2 = coordinate_systems
+    [cs1, cs2], [transform] = fully_connected_two_point_graph
     tm.add_coordinate_system(cs1)
     tm.add_coordinate_system(cs2)
 
-    transform = transformations[0]
     tm.add_transformation(cs1, cs2, transform)
 
     retrieved = tm.get_existing_transformation(cs1, cs2)
@@ -193,48 +202,43 @@ def test_get_existing_transformation_nonexistent(fully_connected_two_point_graph
         tm.get_existing_transformation(cs1, cs2)
 
 
-@pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
-def test_remove_transformation(fully_connected_two_point_graph, cs_names):
+def test_remove_transformation(fully_connected_two_point_graph):
     """Test removing a transformation."""
-    tm = TransformationManager()
-    coordinate_systems, transformations = fully_connected_two_point_graph
-    cs1, cs2 = coordinate_systems
-    tm.add_coordinate_system(cs1)
-    tm.add_coordinate_system(cs2)
+    with suppress_direct_internal_attribute_access_warning():
+        tm = TransformationManager()
+        [cs1, cs2], [transform] = fully_connected_two_point_graph
+        tm.add_coordinate_system(cs1)
+        tm.add_coordinate_system(cs2)
 
-    transform = transformations[0]
-    tm.add_transformation(cs1, cs2, transform)
+        tm.add_transformation(cs1, cs2, transform)
 
-    tm.remove_transformation(cs1, cs2)
-    assert not tm.graph.has_edge(cs1, cs2)
-
-
-def test_remove_transformation_nonexistent():
-    """Test that removing a non-existent transformation raises KeyError."""
-    tm = TransformationManager()
-    cs1 = NgffCoordinateSystem(name="cs1", axes=[])
-    cs2 = NgffCoordinateSystem(name="cs2", axes=[])
-    tm.graph.add_node(cs1)
-    tm.graph.add_node(cs2)
-    with pytest.raises(
-        TransformationNotFoundError, match=f"Transformation from '{cs1.name}' to '{cs2.name}' not found"
-    ):
         tm.remove_transformation(cs1, cs2)
+        assert not tm.graph.has_edge(cs1, cs2)
+
+
+def test_remove_transformation_nonexistent(fully_connected_two_point_graph):
+    """Test that removing a non-existent transformation raises TransformationNotFoundError."""
+    with suppress_direct_internal_attribute_access_warning():
+        tm = TransformationManager()
+        [cs1, cs2], _ = fully_connected_two_point_graph
+        tm.graph.add_node(cs1)
+        tm.graph.add_node(cs2)
+        with pytest.raises(
+            TransformationNotFoundError, match=f"Transformation from '{cs1.name}' to '{cs2.name}' not found"
+        ):
+            tm.remove_transformation(cs1, cs2)
 
 
 def test_get_shortest_transformation_sequence_direct(four_point_graph):
     """Test getting the shortest transformation sequence for a direct transformation."""
     tm = TransformationManager()
-    coordinate_systems, transformations = four_point_graph
-    cs1, cs2, cs3, cs4 = coordinate_systems
+    [cs1, cs2, cs3, cs4], [transform1, transform2, _transform3, transform4] = four_point_graph
+
     tm.add_coordinate_system(cs1)
     tm.add_coordinate_system(cs2)
     tm.add_coordinate_system(cs3)
     tm.add_coordinate_system(cs4)
 
-    transform1 = transformations[0]  # cs1 -> cs2
-    transform2 = transformations[1]  # cs2 -> cs3
-    transform4 = transformations[3]  # cs1 -> cs3
     tm.add_transformation(cs1, cs2, transform1)
     tm.add_transformation(cs2, cs3, transform2)
     tm.add_transformation(cs1, cs3, transform4)
@@ -246,58 +250,44 @@ def test_get_shortest_transformation_sequence_direct(four_point_graph):
 def test_get_shortest_transformation_sequence_indirect(four_point_graph):
     """Test getting the shortest transformation sequence for an indirect transformation."""
     tm = TransformationManager()
-    coordinate_systems, transformations = four_point_graph
-    cs1, cs2, cs3, cs4 = coordinate_systems
+    [cs1, cs2, cs3, _cs4], [transform1, transform2, _transform3, _transform4] = four_point_graph
     tm.add_coordinate_system(cs1)
     tm.add_coordinate_system(cs2)
     tm.add_coordinate_system(cs3)
-    tm.add_coordinate_system(cs4)
 
-    transform1 = transformations[0]  # cs1 -> cs2
-    transform2 = transformations[1]  # cs2 -> cs3
-    transform3 = transformations[2]  # cs3 -> cs4
     tm.add_transformation(cs1, cs2, transform1)
     tm.add_transformation(cs2, cs3, transform2)
-    tm.add_transformation(cs3, cs4, transform3)
 
     sequence = tm.get_shortest_transformation_sequence(cs1, cs3)
     assert sequence == [transform1, transform2]
 
 
 def test_get_shortest_transformation_sequence_no_path(four_point_graph):
-    """Test that getting a transformation sequence with no path raises ValueError."""
+    """Test that getting a transformation sequence with no path raises TransformationPathNotFoundError."""
     tm = TransformationManager()
-    coordinate_systems, transformations = four_point_graph
-    cs1, cs2, cs3, cs4 = coordinate_systems
+    [cs1, cs2, cs3, cs4], [transform1, transform2, _transform3, _transform4] = four_point_graph
     tm.add_coordinate_system(cs1)
     tm.add_coordinate_system(cs2)
     tm.add_coordinate_system(cs3)
     tm.add_coordinate_system(cs4)
 
-    transform1 = transformations[0]  # cs1 -> cs2
-    transform2 = transformations[1]  # cs2 -> cs3
-
     tm.add_transformation(cs1, cs2, transform1)
     tm.add_transformation(cs2, cs3, transform2)
 
-    with pytest.raises(ValueError, match=f"No path found from {cs1.name} to {cs4.name}"):
+    expected_error_msg = "No transformation path found from"
+    with pytest.raises(TransformationPathNotFoundError, match=expected_error_msg):
         tm.get_shortest_transformation_sequence(cs1, cs4)
 
 
 def test_get_all_transformation_sequences(four_point_graph):
     """Test getting all transformation sequences."""
     tm = TransformationManager()
-    coordinate_systems, transformations = four_point_graph
-    cs1, cs2, cs3, cs4 = coordinate_systems
+    [cs1, cs2, cs3, cs4], [transform1, transform2, transform3, transform4] = four_point_graph
     tm.add_coordinate_system(cs1)
     tm.add_coordinate_system(cs2)
     tm.add_coordinate_system(cs3)
     tm.add_coordinate_system(cs4)
 
-    transform1 = transformations[0]  # cs1 -> cs2
-    transform2 = transformations[1]  # cs2 -> cs3
-    transform3 = transformations[2]  # cs3 -> cs4
-    transform4 = transformations[3]  # cs1 -> cs3
     tm.add_transformation(cs1, cs2, transform1)
     tm.add_transformation(cs2, cs3, transform2)
     tm.add_transformation(cs3, cs4, transform3)
@@ -312,15 +302,12 @@ def test_get_all_transformation_sequences(four_point_graph):
 def test_get_all_transformation_sequences_no_path(four_point_graph):
     """Test that getting all transformation sequences with no path returns an empty list."""
     tm = TransformationManager()
-    coordinate_systems, transformations = four_point_graph
-    cs1, cs2, cs3, cs4 = coordinate_systems
+    [cs1, cs2, cs3, cs4], [transform1, transform2, _transform3, _transform4] = four_point_graph
+
     tm.add_coordinate_system(cs1)
     tm.add_coordinate_system(cs2)
     tm.add_coordinate_system(cs3)
     tm.add_coordinate_system(cs4)
-
-    transform1 = transformations[0]  # cs1 -> cs2
-    transform2 = transformations[1]  # cs2 -> cs3
 
     tm.add_transformation(cs1, cs2, transform1)
     tm.add_transformation(cs2, cs3, transform2)

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -8,17 +8,19 @@ This module tests all the functionality of the TransformationManager class to ac
 
 from __future__ import annotations
 
+import networkx as nx
 import pytest
 
 from spatialdata import TransformationManager
-from spatialdata._types import ELEMENT_TYPE
+from spatialdata._core.transformation_manager import TRANSFORM_KEY
+from spatialdata.transformations.ngff.ngff_coordinate_system import NgffCoordinateSystem
 
 
 def test_initialization():
     """Test that TransformationManager initializes correctly."""
     tm = TransformationManager()
-    assert tm._coordinate_systems == {}
-    assert tm._coordinate_transforms == {}
+    assert len(tm._graph.nodes()) == 0
+    assert len(tm._graph.edges()) == 0
     assert tm._element_to_cs_mapping == {}
 
 
@@ -27,9 +29,8 @@ def test_add_coordinate_system(one_point_graph):
     tm = TransformationManager()
     coordinate_systems, _ = one_point_graph
     cs = coordinate_systems[0]
-    tm.add_coordinate_system(cs)
-    assert cs.name in tm._coordinate_systems
-    assert tm._coordinate_systems[cs.name] == cs
+    tm._graph.add_node(cs)
+    assert cs in tm._graph.nodes()
 
 
 def test_add_coordinate_system_duplicate(one_point_graph):
@@ -37,36 +38,10 @@ def test_add_coordinate_system_duplicate(one_point_graph):
     tm = TransformationManager()
     coordinate_systems, _ = one_point_graph
     cs = coordinate_systems[0]
-    tm.add_coordinate_system(cs)
-    with pytest.raises(ValueError, match=f"Coordinate system with name '{cs.name}' already exists"):
-        tm.add_coordinate_system(cs)
-
-
-def test_get_transformations_associated_with_cs(fully_connected_two_point_graph):
-    """Test getting transformations associated with a coordinate system."""
-    tm = TransformationManager()
-    coordinate_systems, transformations = fully_connected_two_point_graph
-    cs1, cs2 = coordinate_systems
-    tm.add_coordinate_system(cs1)
-    tm.add_coordinate_system(cs2)
-
-    transform = transformations[0]
-    tm.add_transformation(cs1.name, cs2.name, transform)
-
-    associated = tm._get_transformations_associated_with_cs(cs1.name)
-    assert associated == [(cs1.name, cs2.name)]
-
-
-def test_get_elements_associated_with_cs(one_point_graph):
-    """Test getting elements associated with a coordinate system."""
-    tm = TransformationManager()
-    coordinate_systems, _ = one_point_graph
-    cs = coordinate_systems[0]
-    tm.add_coordinate_system(cs)
-    tm.add_element(ELEMENT_TYPE.IMAGE, "image1", cs.name)
-
-    associated = tm._get_elements_associated_with_cs(cs.name)
-    assert associated == [(ELEMENT_TYPE.IMAGE, "image1")]
+    tm._graph.add_node(cs)
+    # NetworkX allows adding the same node multiple times, so this test may need to be updated
+    # For now, let's just check that the node exists
+    assert cs in tm._graph.nodes()
 
 
 def test_remove_coordinate_system(one_point_graph):
@@ -75,31 +50,34 @@ def test_remove_coordinate_system(one_point_graph):
 
     coordinate_systems, _ = one_point_graph
     cs = coordinate_systems[0]
-    tm.add_coordinate_system(cs)
-    tm.remove_coordinate_system(cs.name)
-    assert cs.name not in tm._coordinate_systems
+    tm._graph.add_node(cs)
+    tm._graph.remove_node(cs)
+    assert cs not in tm._graph.nodes()
 
 
 def test_remove_coordinate_system_nonexistent():
     """Test that removing a non-existent coordinate system raises KeyError."""
     tm = TransformationManager()
-    with pytest.raises(KeyError, match="Coordinate system with name 'cs1' not found"):
-        tm.remove_coordinate_system("cs1")
+    cs = NgffCoordinateSystem(name="cs1", axes=[])
+    with pytest.raises(nx.NetworkXError):
+        tm._graph.remove_node(cs)
 
 
 def test_remove_coordinate_system_with_associations(fully_connected_two_point_graph):
-    """Test that removing a coordinate system with associations raises ValueError."""
+    """Test removing a coordinate system with associations."""
     tm = TransformationManager()
     coordinate_systems, _transformations = fully_connected_two_point_graph
     cs1, cs2 = coordinate_systems
-    tm.add_coordinate_system(cs1)
-    tm.add_coordinate_system(cs2)
+    tm._graph.add_node(cs1)
+    tm._graph.add_node(cs2)
 
     transform = _transformations[0]
-    tm.add_transformation(cs1.name, cs2.name, transform)
+    tm.add_transformation(cs1, cs2, transform)
 
-    with pytest.raises(ValueError, match="Cannot remove coordinate system"):
-        tm.remove_coordinate_system(cs1.name)
+    # NetworkX removes the node and all its edges
+    tm._graph.remove_node(cs1)
+    assert cs1 not in tm._graph.nodes()
+    assert not tm._graph.has_edge(cs1, cs2)
 
 
 def test_remove_coordinate_system_with_element_associations(one_point_graph):
@@ -107,11 +85,13 @@ def test_remove_coordinate_system_with_element_associations(one_point_graph):
     tm = TransformationManager()
     coordinate_systems, _ = one_point_graph
     cs = coordinate_systems[0]
-    tm.add_coordinate_system(cs)
-    tm.add_element(ELEMENT_TYPE.IMAGE, "image1", cs.name)
+    tm._graph.add_node(cs)
+    tm.add_element("image1", cs)
 
-    with pytest.raises(ValueError, match="Cannot remove coordinate system"):
-        tm.remove_coordinate_system(cs.name)
+    # The current implementation doesn't prevent removing nodes with element associations
+    # This test may need to be updated based on the actual behavior
+    tm._graph.remove_node(cs)
+    assert cs not in tm._graph.nodes()
 
 
 @pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
@@ -120,11 +100,11 @@ def test_list_coordinate_systems(fully_connected_two_point_graph, cs_names):
     tm = TransformationManager()
     coordinate_systems, _ = fully_connected_two_point_graph
     cs1, cs2 = coordinate_systems
-    tm.add_coordinate_system(cs1)
-    tm.add_coordinate_system(cs2)
+    tm._graph.add_node(cs1)
+    tm._graph.add_node(cs2)
 
     systems = tm.list_coordinate_systems()
-    assert set(systems) == {cs1.name, cs2.name}
+    assert set(systems) == {cs1, cs2}
 
 
 def test_add_element(one_point_graph):
@@ -132,19 +112,21 @@ def test_add_element(one_point_graph):
     tm = TransformationManager()
     coordinate_systems, _ = one_point_graph
     cs = coordinate_systems[0]
-    tm.add_coordinate_system(cs)
-    tm.add_element(ELEMENT_TYPE.IMAGE, "image1", cs.name)
+    tm._graph.add_node(cs)
+    tm.add_element("image1", cs)
 
     mapping = tm._element_to_cs_mapping
-    assert (ELEMENT_TYPE.IMAGE, "image1") in mapping
-    assert mapping[(ELEMENT_TYPE.IMAGE, "image1")] == cs.name
+    assert "image1" in mapping
+    assert mapping["image1"] == cs
 
 
 def test_add_element_nonexistent_cs():
     """Test that adding an element with a non-existent coordinate system raises KeyError."""
     tm = TransformationManager()
-    with pytest.raises(KeyError, match="Cannot set coordinate system"):
-        tm.add_element(ELEMENT_TYPE.IMAGE, "image1", "nonexistent_cs")
+    cs = NgffCoordinateSystem(name="nonexistent_cs", axes=[])
+    # The current implementation issues a warning and returns, doesn't raise an error
+    with pytest.warns(UserWarning, match="Cannot set coordinate system"):
+        tm.add_element("image1", cs)
 
 
 def test_get_element_coordinate_system(one_point_graph):
@@ -152,17 +134,17 @@ def test_get_element_coordinate_system(one_point_graph):
     tm = TransformationManager()
     coordinate_systems, _ = one_point_graph
     cs = coordinate_systems[0]
-    tm.add_coordinate_system(cs)
-    tm.add_element(ELEMENT_TYPE.IMAGE, "image1", cs.name)
+    tm._graph.add_node(cs)
+    tm.add_element("image1", cs)
 
-    cs_name = tm.get_element_coordinate_system(ELEMENT_TYPE.IMAGE, "image1")
-    assert cs_name == cs.name
+    cs_name = tm.get_element_coordinate_system("image1")
+    assert cs_name == cs
 
 
 def test_get_element_coordinate_system_nonexistent():
     """Test getting the coordinate system of a non-existent element."""
     tm = TransformationManager()
-    cs_name = tm.get_element_coordinate_system(ELEMENT_TYPE.IMAGE, "nonexistent")
+    cs_name = tm.get_element_coordinate_system("nonexistent")
     assert cs_name is None
 
 
@@ -172,15 +154,14 @@ def test_add_transformation(fully_connected_two_point_graph, cs_names):
     tm = TransformationManager()
     coordinate_systems, transformations = fully_connected_two_point_graph
     cs1, cs2 = coordinate_systems
-    tm.add_coordinate_system(cs1)
-    tm.add_coordinate_system(cs2)
+    tm._graph.add_node(cs1)
+    tm._graph.add_node(cs2)
 
     transform = transformations[0]
-    tm.add_transformation(cs1.name, cs2.name, transform)
+    tm.add_transformation(cs1, cs2, transform)
 
-    key = (cs1.name, cs2.name)
-    assert key in tm._coordinate_transforms
-    assert tm._coordinate_transforms[key] == transform
+    assert tm._graph.has_edge(cs1, cs2)
+    assert tm._graph[cs1][cs2][0][TRANSFORM_KEY] == transform
 
 
 @pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
@@ -191,14 +172,18 @@ def test_add_transformation_nonexistent_cs(fully_connected_two_point_graph, cs_n
     transform = transformations[0]
     cs1, cs2 = coordinate_systems
 
-    with pytest.raises(ValueError, match=f"Input coordinate system '{cs1.name}' does not exist"):
-        tm.add_transformation(cs1.name, cs2.name, transform)
+    with pytest.raises(
+        ValueError, match=f"Coordinate system '{cs1.name}' does not exist in the transformation manager"
+    ):
+        tm.add_transformation(cs1, cs2, transform)
 
     # Add one coordinate system
-    tm.add_coordinate_system(cs1)
+    tm._graph.add_node(cs1)
 
-    with pytest.raises(ValueError, match=f"Output coordinate system '{cs2.name}' does not exist"):
-        tm.add_transformation(cs1.name, cs2.name, transform)
+    with pytest.raises(
+        ValueError, match=f"Coordinate system '{cs2.name}' does not exist in the transformation manager"
+    ):
+        tm.add_transformation(cs1, cs2, transform)
 
 
 @pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
@@ -207,13 +192,13 @@ def test_get_existing_transformation(fully_connected_two_point_graph, cs_names):
     tm = TransformationManager()
     coordinate_systems, transformations = fully_connected_two_point_graph
     cs1, cs2 = coordinate_systems
-    tm.add_coordinate_system(cs1)
-    tm.add_coordinate_system(cs2)
+    tm._graph.add_node(cs1)
+    tm._graph.add_node(cs2)
 
     transform = transformations[0]
-    tm.add_transformation(cs1.name, cs2.name, transform)
+    tm.add_transformation(cs1, cs2, transform)
 
-    retrieved = tm.get_existing_transformation(cs1.name, cs2.name)
+    retrieved = tm.get_transformation(cs1, cs2)
     assert retrieved == transform
 
 
@@ -222,10 +207,10 @@ def test_get_existing_transformation_nonexistent(fully_connected_two_point_graph
     tm = TransformationManager()
     coordinate_systems, _transformations = fully_connected_two_point_graph
     cs1, cs2 = coordinate_systems
-    tm.add_coordinate_system(cs1)
-    tm.add_coordinate_system(cs2)
+    tm._graph.add_node(cs1)
+    tm._graph.add_node(cs2)
 
-    retrieved = tm.get_existing_transformation(cs1.name, cs2.name)
+    retrieved = tm.get_transformation(cs1, cs2)
     assert retrieved is None
 
 
@@ -235,21 +220,25 @@ def test_remove_transformation(fully_connected_two_point_graph, cs_names):
     tm = TransformationManager()
     coordinate_systems, transformations = fully_connected_two_point_graph
     cs1, cs2 = coordinate_systems
-    tm.add_coordinate_system(cs1)
-    tm.add_coordinate_system(cs2)
+    tm._graph.add_node(cs1)
+    tm._graph.add_node(cs2)
 
     transform = transformations[0]
-    tm.add_transformation(cs1.name, cs2.name, transform)
+    tm.add_transformation(cs1, cs2, transform)
 
-    tm.remove_transformation(cs1.name, cs2.name)
-    assert (cs1.name, cs2.name) not in tm._coordinate_transforms
+    tm.remove_transformation(cs1, cs2)
+    assert not tm._graph.has_edge(cs1, cs2)
 
 
 def test_remove_transformation_nonexistent():
     """Test that removing a non-existent transformation raises KeyError."""
     tm = TransformationManager()
+    cs1 = NgffCoordinateSystem(name="cs1", axes=[])
+    cs2 = NgffCoordinateSystem(name="cs2", axes=[])
+    tm._graph.add_node(cs1)
+    tm._graph.add_node(cs2)
     with pytest.raises(KeyError, match="Transformation from 'cs1' to 'cs2' not found"):
-        tm.remove_transformation("cs1", "cs2")
+        tm.remove_transformation(cs1, cs2)
 
 
 def test_build_nx_graph(four_point_graph):
@@ -257,33 +246,33 @@ def test_build_nx_graph(four_point_graph):
     tm = TransformationManager()
     coordinate_systems, transformations = four_point_graph
     cs1, cs2, cs3, cs4 = coordinate_systems
-    tm.add_coordinate_system(cs1)
-    tm.add_coordinate_system(cs2)
-    tm.add_coordinate_system(cs3)
-    tm.add_coordinate_system(cs4)
+    tm._graph.add_node(cs1)
+    tm._graph.add_node(cs2)
+    tm._graph.add_node(cs3)
+    tm._graph.add_node(cs4)
 
     transform1 = transformations[0]  # cs1 -> cs2
     transform2 = transformations[1]  # cs2 -> cs3
     transform3 = transformations[2]  # cs3 -> cs4
     transform4 = transformations[3]  # cs1 -> cs3
-    tm.add_transformation(cs1.name, cs2.name, transform1)
-    tm.add_transformation(cs2.name, cs3.name, transform2)
-    tm.add_transformation(cs3.name, cs4.name, transform3)
-    tm.add_transformation(cs1.name, cs3.name, transform4)
+    tm.add_transformation(cs1, cs2, transform1)
+    tm.add_transformation(cs2, cs3, transform2)
+    tm.add_transformation(cs3, cs4, transform3)
+    tm.add_transformation(cs1, cs3, transform4)
 
     g = tm.build_nx_graph()
-    assert g.has_node(cs1.name)
-    assert g.has_node(cs2.name)
-    assert g.has_node(cs3.name)
-    assert g.has_node(cs4.name)
-    assert g.has_edge(cs1.name, cs2.name)
-    assert g.has_edge(cs2.name, cs3.name)
-    assert g.has_edge(cs3.name, cs4.name)
-    assert g.has_edge(cs1.name, cs3.name)
-    assert g[cs1.name][cs2.name]["transformation"] == transform1
-    assert g[cs2.name][cs3.name]["transformation"] == transform2
-    assert g[cs3.name][cs4.name]["transformation"] == transform3
-    assert g[cs1.name][cs3.name]["transformation"] == transform4
+    assert g.has_node(cs1)
+    assert g.has_node(cs2)
+    assert g.has_node(cs3)
+    assert g.has_node(cs4)
+    assert g.has_edge(cs1, cs2)
+    assert g.has_edge(cs2, cs3)
+    assert g.has_edge(cs3, cs4)
+    assert g.has_edge(cs1, cs3)
+    assert g[cs1][cs2][0][TRANSFORM_KEY] == transform1
+    assert g[cs2][cs3][0][TRANSFORM_KEY] == transform2
+    assert g[cs3][cs4][0][TRANSFORM_KEY] == transform3
+    assert g[cs1][cs3][0][TRANSFORM_KEY] == transform4
 
 
 def test_get_shortest_transformation_sequence_direct(four_point_graph):
@@ -291,19 +280,19 @@ def test_get_shortest_transformation_sequence_direct(four_point_graph):
     tm = TransformationManager()
     coordinate_systems, transformations = four_point_graph
     cs1, cs2, cs3, cs4 = coordinate_systems
-    tm.add_coordinate_system(cs1)
-    tm.add_coordinate_system(cs2)
-    tm.add_coordinate_system(cs3)
-    tm.add_coordinate_system(cs4)
+    tm._graph.add_node(cs1)
+    tm._graph.add_node(cs2)
+    tm._graph.add_node(cs3)
+    tm._graph.add_node(cs4)
 
     transform1 = transformations[0]  # cs1 -> cs2
     transform2 = transformations[1]  # cs2 -> cs3
     transform4 = transformations[3]  # cs1 -> cs3
-    tm.add_transformation(cs1.name, cs2.name, transform1)
-    tm.add_transformation(cs2.name, cs3.name, transform2)
-    tm.add_transformation(cs1.name, cs3.name, transform4)
+    tm.add_transformation(cs1, cs2, transform1)
+    tm.add_transformation(cs2, cs3, transform2)
+    tm.add_transformation(cs1, cs3, transform4)
 
-    sequence = tm.get_shortest_transformation_sequence(cs1.name, cs3.name)
+    sequence = tm.get_shortest_transformation_sequence(cs1, cs3)
     assert sequence == [transform4]
 
 
@@ -312,19 +301,19 @@ def test_get_shortest_transformation_sequence_indirect(four_point_graph):
     tm = TransformationManager()
     coordinate_systems, transformations = four_point_graph
     cs1, cs2, cs3, cs4 = coordinate_systems
-    tm.add_coordinate_system(cs1)
-    tm.add_coordinate_system(cs2)
-    tm.add_coordinate_system(cs3)
-    tm.add_coordinate_system(cs4)
+    tm._graph.add_node(cs1)
+    tm._graph.add_node(cs2)
+    tm._graph.add_node(cs3)
+    tm._graph.add_node(cs4)
 
     transform1 = transformations[0]  # cs1 -> cs2
     transform2 = transformations[1]  # cs2 -> cs3
     transform3 = transformations[2]  # cs3 -> cs4
-    tm.add_transformation(cs1.name, cs2.name, transform1)
-    tm.add_transformation(cs2.name, cs3.name, transform2)
-    tm.add_transformation(cs3.name, cs4.name, transform3)
+    tm.add_transformation(cs1, cs2, transform1)
+    tm.add_transformation(cs2, cs3, transform2)
+    tm.add_transformation(cs3, cs4, transform3)
 
-    sequence = tm.get_shortest_transformation_sequence(cs1.name, cs3.name)
+    sequence = tm.get_shortest_transformation_sequence(cs1, cs3)
     assert sequence == [transform1, transform2]
 
 
@@ -333,19 +322,19 @@ def test_get_shortest_transformation_sequence_no_path(four_point_graph):
     tm = TransformationManager()
     coordinate_systems, transformations = four_point_graph
     cs1, cs2, cs3, cs4 = coordinate_systems
-    tm.add_coordinate_system(cs1)
-    tm.add_coordinate_system(cs2)
-    tm.add_coordinate_system(cs3)
-    tm.add_coordinate_system(cs4)
+    tm._graph.add_node(cs1)
+    tm._graph.add_node(cs2)
+    tm._graph.add_node(cs3)
+    tm._graph.add_node(cs4)
 
     transform1 = transformations[0]  # cs1 -> cs2
     transform2 = transformations[1]  # cs2 -> cs3
 
-    tm.add_transformation(cs1.name, cs2.name, transform1)
-    tm.add_transformation(cs2.name, cs3.name, transform2)
+    tm.add_transformation(cs1, cs2, transform1)
+    tm.add_transformation(cs2, cs3, transform2)
 
     with pytest.raises(ValueError, match=f"No path found from {cs1.name} to {cs4.name}"):
-        tm.get_shortest_transformation_sequence(cs1.name, cs4.name)
+        tm.get_shortest_transformation_sequence(cs1, cs4)
 
 
 def test_get_all_transformation_sequences(four_point_graph):
@@ -353,21 +342,21 @@ def test_get_all_transformation_sequences(four_point_graph):
     tm = TransformationManager()
     coordinate_systems, transformations = four_point_graph
     cs1, cs2, cs3, cs4 = coordinate_systems
-    tm.add_coordinate_system(cs1)
-    tm.add_coordinate_system(cs2)
-    tm.add_coordinate_system(cs3)
-    tm.add_coordinate_system(cs4)
+    tm._graph.add_node(cs1)
+    tm._graph.add_node(cs2)
+    tm._graph.add_node(cs3)
+    tm._graph.add_node(cs4)
 
     transform1 = transformations[0]  # cs1 -> cs2
     transform2 = transformations[1]  # cs2 -> cs3
     transform3 = transformations[2]  # cs3 -> cs4
     transform4 = transformations[3]  # cs1 -> cs3
-    tm.add_transformation(cs1.name, cs2.name, transform1)
-    tm.add_transformation(cs2.name, cs3.name, transform2)
-    tm.add_transformation(cs3.name, cs4.name, transform3)
-    tm.add_transformation(cs1.name, cs3.name, transform4)
+    tm.add_transformation(cs1, cs2, transform1)
+    tm.add_transformation(cs2, cs3, transform2)
+    tm.add_transformation(cs3, cs4, transform3)
+    tm.add_transformation(cs1, cs3, transform4)
 
-    sequences = tm.get_all_transformation_sequences(cs1.name, cs4.name)
+    sequences = tm.get_all_transformation_sequences(cs1, cs4)
     assert len(sequences) == 2
     assert [transform1, transform2, transform3] in sequences
     assert [transform4, transform3] in sequences
@@ -378,18 +367,18 @@ def test_get_all_transformation_sequences_no_path(four_point_graph):
     tm = TransformationManager()
     coordinate_systems, transformations = four_point_graph
     cs1, cs2, cs3, cs4 = coordinate_systems
-    tm.add_coordinate_system(cs1)
-    tm.add_coordinate_system(cs2)
-    tm.add_coordinate_system(cs3)
-    tm.add_coordinate_system(cs4)
+    tm._graph.add_node(cs1)
+    tm._graph.add_node(cs2)
+    tm._graph.add_node(cs3)
+    tm._graph.add_node(cs4)
 
     transform1 = transformations[0]  # cs1 -> cs2
     transform2 = transformations[1]  # cs2 -> cs3
 
-    tm.add_transformation(cs1.name, cs2.name, transform1)
-    tm.add_transformation(cs2.name, cs3.name, transform2)
+    tm.add_transformation(cs1, cs2, transform1)
+    tm.add_transformation(cs2, cs3, transform2)
 
-    sequences = tm.get_all_transformation_sequences(cs1.name, cs4.name)
+    sequences = tm.get_all_transformation_sequences(cs1, cs4)
     assert sequences == []
 
 
@@ -398,8 +387,8 @@ def test_repr(one_point_graph):
     tm = TransformationManager()
     coordinate_systems, _ = one_point_graph
     cs = coordinate_systems[0]
-    tm.add_coordinate_system(cs)
-    tm.add_element(ELEMENT_TYPE.IMAGE, "image1", cs.name)
+    tm._graph.add_node(cs)
+    tm.add_element("image1", cs)
 
     repr_str = repr(tm)
     assert "TransformationManager" in repr_str

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -22,6 +22,7 @@ from spatialdata._core.transformation_manager.exceptions import (
     TransformationPathNotFoundError,
     suppress_direct_internal_attribute_access_warning,
 )
+from spatialdata.transformations.transformations import Sequence
 
 
 def test_initialization():
@@ -320,7 +321,7 @@ def test_get_all_shortest_transformation_sequences_direct(four_point_graph):
 
     sequences = tm.get_all_shortest_transformation_sequences(cs1, cs3)
     assert len(sequences) == 1
-    assert [transform4] in sequences
+    assert Sequence([transform4]) in sequences
 
 
 def test_get_all_shortest_transformation_sequences_indirect_one_path(four_point_graph):
@@ -336,7 +337,7 @@ def test_get_all_shortest_transformation_sequences_indirect_one_path(four_point_
 
     sequences = tm.get_all_shortest_transformation_sequences(cs1, cs3)
     assert len(sequences) == 1
-    assert [transform1, transform2] in sequences
+    assert Sequence([transform1, transform2]) in sequences
 
 
 def test_get_all_shortest_transformation_sequences_indirect_two_paths(five_point_graph):
@@ -355,8 +356,8 @@ def test_get_all_shortest_transformation_sequences_indirect_two_paths(five_point
 
     sequences = tm.get_all_shortest_transformation_sequences(cs1, cs3)
     assert len(sequences) == 2
-    assert [transform1, transform2] in sequences
-    assert [transform2, transform1] in sequences
+    assert Sequence([transform1, transform2]) in sequences
+    assert Sequence([transform2, transform1]) in sequences
 
 
 def test_get_all_shortest_transformation_sequences_no_path(four_point_graph):
@@ -398,8 +399,8 @@ def test_get_all_shortest_transformation_sequences_multiple_paths_multiple_edges
         cs1, cs5, expected_intermediate_transformations=[transform4]
     )
     assert len(sequences) == 2
-    assert [transform1, transform2, transform4] in sequences
-    assert [transform2, transform1, transform4] in sequences
+    assert Sequence([transform1, transform2, transform4]) in sequences
+    assert Sequence([transform2, transform1, transform4]) in sequences
 
 
 def test_get_all_shortest_transformation_sequences_multiple_paths_multiple_edges_failure(five_point_graph):
@@ -440,8 +441,8 @@ def test_get_all_transformation_sequences(four_point_graph):
 
     sequences = tm.get_all_transformation_sequences(cs1, cs4)
     assert len(sequences) == 2
-    assert [transform1, transform2, transform3] in sequences
-    assert [transform4, transform3] in sequences
+    assert Sequence([transform1, transform2, transform3]) in sequences
+    assert Sequence([transform4, transform3]) in sequences
 
 
 def test_get_all_transformation_sequences_multiple_paths(five_point_graph):
@@ -461,9 +462,9 @@ def test_get_all_transformation_sequences_multiple_paths(five_point_graph):
 
     sequences = tm.get_all_transformation_sequences(cs1, cs3)
     assert len(sequences) == 3
-    assert [transform1, transform2] in sequences
-    assert [transform2, transform1] in sequences
-    assert [transform3] in sequences
+    assert Sequence([transform1, transform2]) in sequences
+    assert Sequence([transform2, transform1]) in sequences
+    assert Sequence([transform3]) in sequences
 
 
 def test_get_all_transformation_sequences_multiple_paths_multiple_edges_success(five_point_graph):
@@ -486,9 +487,9 @@ def test_get_all_transformation_sequences_multiple_paths_multiple_edges_success(
 
     sequences = tm.get_all_transformation_sequences(cs1, cs5, expected_intermediate_transformations=[transform4])
     assert len(sequences) == 3
-    assert [transform1, transform2, transform4] in sequences
-    assert [transform2, transform1, transform4] in sequences
-    assert [transform3, transform4] in sequences
+    assert Sequence([transform1, transform2, transform4]) in sequences
+    assert Sequence([transform2, transform1, transform4]) in sequences
+    assert Sequence([transform3, transform4]) in sequences
 
 
 def test_get_all_transformation_sequences_multiple_paths_multiple_edges_failure(five_point_graph):

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -192,7 +192,9 @@ def test_add_transformation(fully_connected_two_point_graph):
         tm.add_transformation(cs1, cs2, transform)
 
         assert tm.graph.has_edge(cs1, cs2)
-        assert tm.graph[cs1][cs2][0][TRANSFORM_KEY] == transform
+        # Get the first edge key and check the transformation
+        edge_key = tm._get_edge_key_from_transform(transform)
+        assert tm.graph[cs1][cs2][edge_key][TRANSFORM_KEY] == transform
 
 
 def test_add_transformation_nonexistent_cs(fully_connected_two_point_graph):
@@ -224,7 +226,7 @@ def test_get_existing_transformation(fully_connected_two_point_graph):
     tm.add_transformation(cs1, cs2, transform)
 
     retrieved = tm.get_existing_direct_transformations(cs1, cs2)
-    assert retrieved == transform
+    assert retrieved == [transform]
 
 
 def test_get_existing_transformation_nonexistent(fully_connected_two_point_graph):
@@ -241,8 +243,8 @@ def test_get_existing_transformation_nonexistent(fully_connected_two_point_graph
         tm.get_existing_direct_transformations(cs1, cs2)
 
 
-def test_remove_transformation(fully_connected_two_point_graph):
-    """Test removing a transformation."""
+def test_remove_all_transformations_between_coordinate_systems(fully_connected_two_point_graph):
+    """Test removing all transformations  between coordinate systems."""
     with suppress_direct_internal_attribute_access_warning():
         tm = TransformationManager()
         [cs1, cs2], [transform] = fully_connected_two_point_graph
@@ -251,12 +253,12 @@ def test_remove_transformation(fully_connected_two_point_graph):
 
         tm.add_transformation(cs1, cs2, transform)
 
-        tm.remove_all_transformations(cs1, cs2)
+        tm.remove_all_transformations_between_coordinate_systems(cs1, cs2)
         assert not tm.graph.has_edge(cs1, cs2)
 
 
-def test_remove_transformation_nonexistent(fully_connected_two_point_graph):
-    """Test that removing a non-existent transformation raises TransformationNotFoundError."""
+def test_remove_all_transformation_nonexistent(fully_connected_two_point_graph):
+    """Test that removing non-existent transformations between coordinate systems raises TransformationNotFoundError."""
     with suppress_direct_internal_attribute_access_warning():
         tm = TransformationManager()
         [cs1, cs2], _ = fully_connected_two_point_graph
@@ -265,7 +267,41 @@ def test_remove_transformation_nonexistent(fully_connected_two_point_graph):
         with pytest.raises(
             TransformationNotFoundError, match=f"Transformation from '{cs1.name}' to '{cs2.name}' not found"
         ):
-            tm.remove_all_transformations(cs1, cs2)
+            tm.remove_all_transformations_between_coordinate_systems(cs1, cs2)
+
+
+def test_remove_specific_transformation_between_coordinate_systems(five_point_graph):
+    """Test removing specific transformation between coordinate systems."""
+
+    with suppress_direct_internal_attribute_access_warning():
+        tm = TransformationManager()
+        [_cs1, _cs2, cs3, _cs4, cs5], [_transform1, _transform2, _transform3, transform4, transform5] = five_point_graph
+        tm.add_coordinate_system(cs3)
+        tm.add_coordinate_system(cs5)
+
+        tm.add_transformation(cs3, cs5, transform4)
+        tm.add_transformation(cs3, cs5, transform5)
+
+        tm.remove_specific_transformation(cs3, cs5, transform4)
+        assert not tm.graph.has_edge(cs3, cs5, key=tm._get_edge_key_from_transform(transform4))
+
+
+def test_remove_specific_transformation_between_coordinate_systems_non_existent(five_point_graph):
+    """
+    Test that removing non-existent specific transformation between coordinate systems raises
+    TransformationNotFoundError.
+    """
+
+    with suppress_direct_internal_attribute_access_warning():
+        tm = TransformationManager()
+        [_cs1, _cs2, cs3, _cs4, cs5], [_transform1, _transform2, _transform3, transform4, transform5] = five_point_graph
+        tm.add_coordinate_system(cs3)
+        tm.add_coordinate_system(cs5)
+
+        with pytest.raises(
+            TransformationNotFoundError, match=f"Transformation from '{cs3.name}' to '{cs5.name}' not found"
+        ):
+            tm.remove_specific_transformation(cs3, cs5, transform4)
 
 
 def test_get_all_shortest_transformation_sequences_direct(four_point_graph):
@@ -354,17 +390,16 @@ def test_get_all_shortest_transformation_sequences_multiple_paths_multiple_edges
     tm.add_transformation(cs2, cs3, transform2)
     tm.add_transformation(cs1, cs4, transform2)
     tm.add_transformation(cs4, cs3, transform1)
-    tm.add_transformation(cs1, cs3, transform3)
-    tm.add_transformation(cs4, cs5, transform4)
-    tm.add_transformation(cs4, cs5, transform5)
+    # tm.add_transformation(cs1, cs3, transform3)
+    tm.add_transformation(cs3, cs5, transform4)
+    tm.add_transformation(cs3, cs5, transform5)
 
     sequences = tm.get_all_shortest_transformation_sequences(
         cs1, cs5, expected_intermediate_transformations=[transform4]
     )
-    assert len(sequences) == 3
+    assert len(sequences) == 2
     assert [transform1, transform2, transform4] in sequences
     assert [transform2, transform1, transform4] in sequences
-    assert [transform3, transform4] in sequences
 
 
 def test_get_all_shortest_transformation_sequences_multiple_paths_multiple_edges_failure(five_point_graph):
@@ -382,11 +417,11 @@ def test_get_all_shortest_transformation_sequences_multiple_paths_multiple_edges
     tm.add_transformation(cs1, cs4, transform2)
     tm.add_transformation(cs4, cs3, transform1)
     tm.add_transformation(cs1, cs3, transform3)
-    tm.add_transformation(cs4, cs5, transform4)
-    tm.add_transformation(cs4, cs5, transform5)
+    tm.add_transformation(cs3, cs5, transform4)
+    tm.add_transformation(cs3, cs5, transform5)
 
     with pytest.raises(TransformationPathAmbiguousError, match="Transformation Path ambiguous"):
-        tm.get_all_shortest_transformation_sequences(cs1, cs5, expected_intermediate_transformations=[transform4])
+        tm.get_all_shortest_transformation_sequences(cs1, cs5)
 
 
 def test_get_all_transformation_sequences(four_point_graph):
@@ -446,8 +481,8 @@ def test_get_all_transformation_sequences_multiple_paths_multiple_edges_success(
     tm.add_transformation(cs1, cs4, transform2)
     tm.add_transformation(cs4, cs3, transform1)
     tm.add_transformation(cs1, cs3, transform3)
-    tm.add_transformation(cs4, cs5, transform4)
-    tm.add_transformation(cs4, cs5, transform5)
+    tm.add_transformation(cs3, cs5, transform4)
+    tm.add_transformation(cs3, cs5, transform5)
 
     sequences = tm.get_all_transformation_sequences(cs1, cs5, expected_intermediate_transformations=[transform4])
     assert len(sequences) == 3
@@ -471,11 +506,11 @@ def test_get_all_transformation_sequences_multiple_paths_multiple_edges_failure(
     tm.add_transformation(cs1, cs4, transform2)
     tm.add_transformation(cs4, cs3, transform1)
     tm.add_transformation(cs1, cs3, transform3)
-    tm.add_transformation(cs4, cs5, transform4)
-    tm.add_transformation(cs4, cs5, transform5)
+    tm.add_transformation(cs3, cs5, transform4)
+    tm.add_transformation(cs3, cs5, transform5)
 
     with pytest.raises(TransformationPathAmbiguousError, match="Transformation Path ambiguous"):
-        tm.get_all_transformation_sequences(cs1, cs5, expected_intermediate_transformations=[transform4])
+        tm.get_all_transformation_sequences(cs1, cs5)
 
 
 def test_get_all_transformation_sequences_no_path(four_point_graph):

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -18,6 +18,7 @@ from spatialdata._core.transformation_manager.exceptions import (
     ElementAlreadyExistsError,
     ElementNotFoundError,
     TransformationNotFoundError,
+    TransformationPathAmbiguousError,
     TransformationPathNotFoundError,
     suppress_direct_internal_attribute_access_warning,
 )
@@ -222,7 +223,7 @@ def test_get_existing_transformation(fully_connected_two_point_graph):
 
     tm.add_transformation(cs1, cs2, transform)
 
-    retrieved = tm.get_existing_transformation(cs1, cs2)
+    retrieved = tm.get_existing_direct_transformations(cs1, cs2)
     assert retrieved == transform
 
 
@@ -237,7 +238,7 @@ def test_get_existing_transformation_nonexistent(fully_connected_two_point_graph
     with pytest.raises(
         TransformationNotFoundError, match=f"Transformation from '{cs1.name}' to '{cs2.name}' not found"
     ):
-        tm.get_existing_transformation(cs1, cs2)
+        tm.get_existing_direct_transformations(cs1, cs2)
 
 
 def test_remove_transformation(fully_connected_two_point_graph):
@@ -250,7 +251,7 @@ def test_remove_transformation(fully_connected_two_point_graph):
 
         tm.add_transformation(cs1, cs2, transform)
 
-        tm.remove_transformation(cs1, cs2)
+        tm.remove_all_transformations(cs1, cs2)
         assert not tm.graph.has_edge(cs1, cs2)
 
 
@@ -264,11 +265,11 @@ def test_remove_transformation_nonexistent(fully_connected_two_point_graph):
         with pytest.raises(
             TransformationNotFoundError, match=f"Transformation from '{cs1.name}' to '{cs2.name}' not found"
         ):
-            tm.remove_transformation(cs1, cs2)
+            tm.remove_all_transformations(cs1, cs2)
 
 
-def test_get_shortest_transformation_sequence_direct(four_point_graph):
-    """Test getting the shortest transformation sequence for a direct transformation."""
+def test_get_all_shortest_transformation_sequences_direct(four_point_graph):
+    """Test getting all shortest transformation sequences for a direct transformation path."""
     tm = TransformationManager()
     [cs1, cs2, cs3, cs4], [transform1, transform2, _transform3, transform4] = four_point_graph
 
@@ -281,12 +282,13 @@ def test_get_shortest_transformation_sequence_direct(four_point_graph):
     tm.add_transformation(cs2, cs3, transform2)
     tm.add_transformation(cs1, cs3, transform4)
 
-    sequence = tm.get_shortest_transformation_sequence(cs1, cs3)
-    assert sequence == [transform4]
+    sequences = tm.get_all_shortest_transformation_sequences(cs1, cs3)
+    assert len(sequences) == 1
+    assert [transform4] in sequences
 
 
-def test_get_shortest_transformation_sequence_indirect(four_point_graph):
-    """Test getting the shortest transformation sequence for an indirect transformation."""
+def test_get_all_shortest_transformation_sequences_indirect_one_path(four_point_graph):
+    """Test getting all shortest transformation sequences for one indirect transformation path."""
     tm = TransformationManager()
     [cs1, cs2, cs3, _cs4], [transform1, transform2, _transform3, _transform4] = four_point_graph
     tm.add_coordinate_system(cs1)
@@ -296,12 +298,33 @@ def test_get_shortest_transformation_sequence_indirect(four_point_graph):
     tm.add_transformation(cs1, cs2, transform1)
     tm.add_transformation(cs2, cs3, transform2)
 
-    sequence = tm.get_shortest_transformation_sequence(cs1, cs3)
-    assert sequence == [transform1, transform2]
+    sequences = tm.get_all_shortest_transformation_sequences(cs1, cs3)
+    assert len(sequences) == 1
+    assert [transform1, transform2] in sequences
 
 
-def test_get_shortest_transformation_sequence_no_path(four_point_graph):
-    """Test that getting a transformation sequence with no path raises TransformationPathNotFoundError."""
+def test_get_all_shortest_transformation_sequences_indirect_two_paths(five_point_graph):
+    """Test getting all shortest transformation sequences for two indirect transformation paths."""
+    tm = TransformationManager()
+    ([cs1, cs2, cs3, cs4, _cs5], [transform1, transform2, _transform3, _transform4, _transform5]) = five_point_graph
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
+
+    tm.add_transformation(cs1, cs2, transform1)
+    tm.add_transformation(cs2, cs3, transform2)
+    tm.add_transformation(cs1, cs4, transform2)
+    tm.add_transformation(cs4, cs3, transform1)
+
+    sequences = tm.get_all_shortest_transformation_sequences(cs1, cs3)
+    assert len(sequences) == 2
+    assert [transform1, transform2] in sequences
+    assert [transform2, transform1] in sequences
+
+
+def test_get_all_shortest_transformation_sequences_no_path(four_point_graph):
+    """Test that getting all shortest transformation sequences with no path raises TransformationPathNotFoundError."""
     tm = TransformationManager()
     [cs1, cs2, cs3, cs4], [transform1, transform2, _transform3, _transform4] = four_point_graph
     tm.add_coordinate_system(cs1)
@@ -314,7 +337,56 @@ def test_get_shortest_transformation_sequence_no_path(four_point_graph):
 
     expected_error_msg = "No transformation path found from"
     with pytest.raises(TransformationPathNotFoundError, match=expected_error_msg):
-        tm.get_shortest_transformation_sequence(cs1, cs4)
+        tm.get_all_shortest_transformation_sequences(cs1, cs4)
+
+
+def test_get_all_shortest_transformation_sequences_multiple_paths_multiple_edges_success(five_point_graph):
+    """Test getting all shortest transformation sequences, with multiple path and multiple edges between nodes."""
+    tm = TransformationManager()
+    [cs1, cs2, cs3, cs4, cs5], [transform1, transform2, transform3, transform4, transform5] = five_point_graph
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
+    tm.add_coordinate_system(cs5)
+
+    tm.add_transformation(cs1, cs2, transform1)
+    tm.add_transformation(cs2, cs3, transform2)
+    tm.add_transformation(cs1, cs4, transform2)
+    tm.add_transformation(cs4, cs3, transform1)
+    tm.add_transformation(cs1, cs3, transform3)
+    tm.add_transformation(cs4, cs5, transform4)
+    tm.add_transformation(cs4, cs5, transform5)
+
+    sequences = tm.get_all_shortest_transformation_sequences(
+        cs1, cs5, expected_intermediate_transformations=[transform4]
+    )
+    assert len(sequences) == 3
+    assert [transform1, transform2, transform4] in sequences
+    assert [transform2, transform1, transform4] in sequences
+    assert [transform3, transform4] in sequences
+
+
+def test_get_all_shortest_transformation_sequences_multiple_paths_multiple_edges_failure(five_point_graph):
+    """Test getting all shortest transformation sequences, with multiple path and multiple edges between nodes."""
+    tm = TransformationManager()
+    [cs1, cs2, cs3, cs4, cs5], [transform1, transform2, transform3, transform4, transform5] = five_point_graph
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
+    tm.add_coordinate_system(cs5)
+
+    tm.add_transformation(cs1, cs2, transform1)
+    tm.add_transformation(cs2, cs3, transform2)
+    tm.add_transformation(cs1, cs4, transform2)
+    tm.add_transformation(cs4, cs3, transform1)
+    tm.add_transformation(cs1, cs3, transform3)
+    tm.add_transformation(cs4, cs5, transform4)
+    tm.add_transformation(cs4, cs5, transform5)
+
+    with pytest.raises(TransformationPathAmbiguousError, match="Transformation Path ambiguous"):
+        tm.get_all_shortest_transformation_sequences(cs1, cs5, expected_intermediate_transformations=[transform4])
 
 
 def test_get_all_transformation_sequences(four_point_graph):
@@ -337,8 +409,91 @@ def test_get_all_transformation_sequences(four_point_graph):
     assert [transform4, transform3] in sequences
 
 
+def test_get_all_transformation_sequences_multiple_paths(five_point_graph):
+    """Test getting all transformation sequences, with multiple path and multiple edges between nodes."""
+    tm = TransformationManager()
+    [cs1, cs2, cs3, cs4, _cs5], [transform1, transform2, transform3, _transform4, _transform5] = five_point_graph
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
+
+    tm.add_transformation(cs1, cs2, transform1)
+    tm.add_transformation(cs2, cs3, transform2)
+    tm.add_transformation(cs1, cs4, transform2)
+    tm.add_transformation(cs4, cs3, transform1)
+    tm.add_transformation(cs1, cs3, transform3)
+
+    sequences = tm.get_all_transformation_sequences(cs1, cs3)
+    assert len(sequences) == 3
+    assert [transform1, transform2] in sequences
+    assert [transform2, transform1] in sequences
+    assert [transform3] in sequences
+
+
+def test_get_all_transformation_sequences_multiple_paths_multiple_edges_success(five_point_graph):
+    """Test getting all transformation sequences, with multiple paths and multiple edges between nodes."""
+    tm = TransformationManager()
+    [cs1, cs2, cs3, cs4, cs5], [transform1, transform2, transform3, transform4, transform5] = five_point_graph
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
+    tm.add_coordinate_system(cs5)
+
+    tm.add_transformation(cs1, cs2, transform1)
+    tm.add_transformation(cs2, cs3, transform2)
+    tm.add_transformation(cs1, cs4, transform2)
+    tm.add_transformation(cs4, cs3, transform1)
+    tm.add_transformation(cs1, cs3, transform3)
+    tm.add_transformation(cs4, cs5, transform4)
+    tm.add_transformation(cs4, cs5, transform5)
+
+    sequences = tm.get_all_transformation_sequences(cs1, cs5, expected_intermediate_transformations=[transform4])
+    assert len(sequences) == 3
+    assert [transform1, transform2, transform4] in sequences
+    assert [transform2, transform1, transform4] in sequences
+    assert [transform3, transform4] in sequences
+
+
+def test_get_all_transformation_sequences_multiple_paths_multiple_edges_failure(five_point_graph):
+    """Test getting all transformation sequences, with multiple paths and multiple edges between nodes."""
+    tm = TransformationManager()
+    [cs1, cs2, cs3, cs4, cs5], [transform1, transform2, transform3, transform4, transform5] = five_point_graph
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
+    tm.add_coordinate_system(cs5)
+
+    tm.add_transformation(cs1, cs2, transform1)
+    tm.add_transformation(cs2, cs3, transform2)
+    tm.add_transformation(cs1, cs4, transform2)
+    tm.add_transformation(cs4, cs3, transform1)
+    tm.add_transformation(cs1, cs3, transform3)
+    tm.add_transformation(cs4, cs5, transform4)
+    tm.add_transformation(cs4, cs5, transform5)
+
+    with pytest.raises(TransformationPathAmbiguousError, match="Transformation Path ambiguous"):
+        tm.get_all_transformation_sequences(cs1, cs5, expected_intermediate_transformations=[transform4])
+
+
+def test_get_all_transformation_sequences_no_path(four_point_graph):
+    """Test getting all transformation sequences."""
+    tm = TransformationManager()
+    [cs1, cs2, cs3, cs4], [transform1, transform2, transform3, transform4] = four_point_graph
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
+
+    expected_error_msg = "No transformation path found from"
+    with pytest.raises(TransformationPathNotFoundError, match=expected_error_msg):
+        tm.get_all_shortest_transformation_sequences(cs1, cs4)
+
+
 def test_get_element_coordinate_system_success(one_point_graph):
-    """Test successfully getting an element's coordinate system (covers lines 292-293)."""
+    """Test successfully getting an element's coordinate system."""
     tm = TransformationManager()
     [cs1], _ = one_point_graph
     tm.add_coordinate_system(cs1)

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -15,6 +15,8 @@ from spatialdata._core.transformation_manager.exceptions import (
     CannotRemoveCoordinateSystemError,
     CoordinateSystemAlreadyExistsError,
     CoordinateSystemNotFoundError,
+    ElementAlreadyExistsError,
+    ElementNotFoundError,
     TransformationNotFoundError,
     TransformationPathNotFoundError,
     suppress_direct_internal_attribute_access_warning,
@@ -94,6 +96,10 @@ def test_remove_coordinate_system_with_associated_transformations(fully_connecte
     with pytest.raises(CannotRemoveCoordinateSystemError, match="Cannot remove coordinate system"):
         tm.remove_coordinate_system(cs1)
 
+    # Should raise CannotRemoveCoordinateSystem when trying to remove a coordinate system with transformations
+    with pytest.raises(CannotRemoveCoordinateSystemError, match="Cannot remove coordinate system"):
+        tm.remove_coordinate_system(cs2)
+
 
 def test_remove_coordinate_system_with_belonging_elements(one_point_graph):
     """Test that removing a coordinate system with element associations raises CannotRemoveCoordinateSystemError."""
@@ -132,13 +138,45 @@ def test_add_element(one_point_graph):
         assert mapping["image1"] == cs1
 
 
-def test_add_element_nonexistent_cs(one_point_graph):
-    """Test that adding an element with a non-existent coordinate system raises CoordinateSystemNotFoundError."""
+def test_add_element_duplicate(one_point_graph):
+    """Test that adding a duplicate element raises ElementAlreadyExistsError."""
     tm = TransformationManager()
     [cs1], _ = one_point_graph
+    tm.add_coordinate_system(cs1)
     element_name = "image1"
-    with pytest.raises(CoordinateSystemNotFoundError, match=f"Coordinate system '{cs1.name}' not found in"):
+    tm.add_element(element_name, cs1)
+
+    # Try to add the same element again - should raise ElementAlreadyExistsError
+    with pytest.raises(
+        ElementAlreadyExistsError, match=f"Element '{element_name}' already exists in the transformation manager"
+    ):
         tm.add_element(element_name, cs1)
+
+
+def test_unset_element(one_point_graph):
+    """Test unsetting an element."""
+    tm = TransformationManager()
+    [cs1], _ = one_point_graph
+    tm.add_coordinate_system(cs1)
+    tm.add_element("image1", cs1)
+    tm.unset_element("image1")
+
+    with suppress_direct_internal_attribute_access_warning():
+        assert "image1" not in tm.element_to_cs_mapping
+
+
+def test_unset_element_nonexistent(one_point_graph):
+    """Test that unsetting a non-existent element raises ElementNotFoundError."""
+    tm = TransformationManager()
+    [cs1], _ = one_point_graph
+    tm.add_coordinate_system(cs1)
+    element_name = "image1"
+
+    # Try to unset non-existent element
+    with pytest.raises(
+        ElementNotFoundError, match=f"Element '{element_name}' not found in the transformation manager."
+    ):
+        tm.unset_element(element_name)
 
 
 def test_add_transformation(fully_connected_two_point_graph):
@@ -299,32 +337,43 @@ def test_get_all_transformation_sequences(four_point_graph):
     assert [transform4, transform3] in sequences
 
 
-def test_get_all_transformation_sequences_no_path(four_point_graph):
-    """Test that getting all transformation sequences with no path returns an empty list."""
+def test_get_element_coordinate_system_success(one_point_graph):
+    """Test successfully getting an element's coordinate system (covers lines 292-293)."""
     tm = TransformationManager()
-    [cs1, cs2, cs3, cs4], [transform1, transform2, _transform3, _transform4] = four_point_graph
+    [cs1], _ = one_point_graph
+    tm.add_coordinate_system(cs1)
+    tm.add_element("image1", cs1)
 
+    # This should successfully return the coordinate system
+    result = tm.get_element_coordinate_system("image1")
+    assert result == cs1
+
+
+def test_repr_method_comprehensive(fully_connected_two_point_graph):
+    """Test TransformationManager.__repr__ method comprehensively."""
+
+    # Test empty TransformationManager
+    tm_empty = TransformationManager()
+    repr_empty = repr(tm_empty)
+    assert "TransformationManager" in repr_empty
+    assert "coordinate_systems=[]" in repr_empty
+    assert "coordinate_transforms=[]" in repr_empty
+    assert "elements=[]" in repr_empty
+
+    # Test TransformationManager with data
+    tm = TransformationManager()
+    [cs1, cs2], [transform] = fully_connected_two_point_graph
     tm.add_coordinate_system(cs1)
     tm.add_coordinate_system(cs2)
-    tm.add_coordinate_system(cs3)
-    tm.add_coordinate_system(cs4)
 
-    tm.add_transformation(cs1, cs2, transform1)
-    tm.add_transformation(cs2, cs3, transform2)
-
-    sequences = tm.get_all_transformation_sequences(cs1, cs4)
-    assert sequences == []
-
-
-def test_repr(one_point_graph):
-    """Test the string representation of TransformationManager."""
-    tm = TransformationManager()
-    coordinate_systems, _ = one_point_graph
-    cs = coordinate_systems[0]
-    tm.add_coordinate_system(cs)
-    tm.add_element("image1", cs)
+    tm.add_transformation(cs1, cs2, transform)
+    tm.add_element("image1", cs1)
+    tm.add_element("image2", cs2)
 
     repr_str = repr(tm)
     assert "TransformationManager" in repr_str
-    assert cs.name in repr_str
+    assert "cs1" in repr_str
+    assert "cs2" in repr_str
+    assert repr_str.find(repr(transform))
     assert "image1" in repr_str
+    assert "image2" in repr_str

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+
+"""
+Unit tests for the TransformationManager class in _core/transformation_manager/__init__.py.
+
+This module tests all the functionality of the TransformationManager class to achieve 100% coverage.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from spatialdata import TransformationManager
+from spatialdata._types import ELEMENT_TYPE
+
+
+def test_initialization():
+    """Test that TransformationManager initializes correctly."""
+    tm = TransformationManager()
+    assert tm._coordinate_systems == {}
+    assert tm._coordinate_transforms == {}
+    assert tm._element_to_cs_mapping == {}
+
+
+def test_add_coordinate_system(one_point_graph):
+    """Test adding a coordinate system."""
+    tm = TransformationManager()
+    coordinate_systems, _ = one_point_graph
+    cs = coordinate_systems[0]
+    tm.add_coordinate_system(cs)
+    assert cs.name in tm._coordinate_systems
+    assert tm._coordinate_systems[cs.name] == cs
+
+
+def test_add_coordinate_system_duplicate(one_point_graph):
+    """Test that adding a duplicate coordinate system raises ValueError."""
+    tm = TransformationManager()
+    coordinate_systems, _ = one_point_graph
+    cs = coordinate_systems[0]
+    tm.add_coordinate_system(cs)
+    with pytest.raises(ValueError, match=f"Coordinate system with name '{cs.name}' already exists"):
+        tm.add_coordinate_system(cs)
+
+
+def test_get_transformations_associated_with_cs(fully_connected_two_point_graph):
+    """Test getting transformations associated with a coordinate system."""
+    tm = TransformationManager()
+    coordinate_systems, transformations = fully_connected_two_point_graph
+    cs1, cs2 = coordinate_systems
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+
+    transform = transformations[0]
+    tm.add_transformation(cs1.name, cs2.name, transform)
+
+    associated = tm._get_transformations_associated_with_cs(cs1.name)
+    assert associated == [(cs1.name, cs2.name)]
+
+
+def test_get_elements_associated_with_cs(one_point_graph):
+    """Test getting elements associated with a coordinate system."""
+    tm = TransformationManager()
+    coordinate_systems, _ = one_point_graph
+    cs = coordinate_systems[0]
+    tm.add_coordinate_system(cs)
+    tm.add_element(ELEMENT_TYPE.IMAGE, "image1", cs.name)
+
+    associated = tm._get_elements_associated_with_cs(cs.name)
+    assert associated == [(ELEMENT_TYPE.IMAGE, "image1")]
+
+
+def test_remove_coordinate_system(one_point_graph):
+    """Test removing a coordinate system."""
+    tm = TransformationManager()
+
+    coordinate_systems, _ = one_point_graph
+    cs = coordinate_systems[0]
+    tm.add_coordinate_system(cs)
+    tm.remove_coordinate_system(cs.name)
+    assert cs.name not in tm._coordinate_systems
+
+
+def test_remove_coordinate_system_nonexistent():
+    """Test that removing a non-existent coordinate system raises KeyError."""
+    tm = TransformationManager()
+    with pytest.raises(KeyError, match="Coordinate system with name 'cs1' not found"):
+        tm.remove_coordinate_system("cs1")
+
+
+def test_remove_coordinate_system_with_associations(fully_connected_two_point_graph):
+    """Test that removing a coordinate system with associations raises ValueError."""
+    tm = TransformationManager()
+    coordinate_systems, _transformations = fully_connected_two_point_graph
+    cs1, cs2 = coordinate_systems
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+
+    transform = _transformations[0]
+    tm.add_transformation(cs1.name, cs2.name, transform)
+
+    with pytest.raises(ValueError, match="Cannot remove coordinate system"):
+        tm.remove_coordinate_system(cs1.name)
+
+
+def test_remove_coordinate_system_with_element_associations(one_point_graph):
+    """Test that removing a coordinate system with element associations raises ValueError."""
+    tm = TransformationManager()
+    coordinate_systems, _ = one_point_graph
+    cs = coordinate_systems[0]
+    tm.add_coordinate_system(cs)
+    tm.add_element(ELEMENT_TYPE.IMAGE, "image1", cs.name)
+
+    with pytest.raises(ValueError, match="Cannot remove coordinate system"):
+        tm.remove_coordinate_system(cs.name)
+
+
+@pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
+def test_list_coordinate_systems(fully_connected_two_point_graph, cs_names):
+    """Test listing all coordinate systems."""
+    tm = TransformationManager()
+    coordinate_systems, _ = fully_connected_two_point_graph
+    cs1, cs2 = coordinate_systems
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+
+    systems = tm.list_coordinate_systems()
+    assert set(systems) == {cs1.name, cs2.name}
+
+
+def test_add_element(one_point_graph):
+    """Test adding an element with an existing coordinate system."""
+    tm = TransformationManager()
+    coordinate_systems, _ = one_point_graph
+    cs = coordinate_systems[0]
+    tm.add_coordinate_system(cs)
+    tm.add_element(ELEMENT_TYPE.IMAGE, "image1", cs.name)
+
+    mapping = tm._element_to_cs_mapping
+    assert (ELEMENT_TYPE.IMAGE, "image1") in mapping
+    assert mapping[(ELEMENT_TYPE.IMAGE, "image1")] == cs.name
+
+
+def test_add_element_nonexistent_cs():
+    """Test that adding an element with a non-existent coordinate system raises KeyError."""
+    tm = TransformationManager()
+    with pytest.raises(KeyError, match="Cannot set coordinate system"):
+        tm.add_element(ELEMENT_TYPE.IMAGE, "image1", "nonexistent_cs")
+
+
+def test_get_element_coordinate_system(one_point_graph):
+    """Test getting the coordinate system of an element."""
+    tm = TransformationManager()
+    coordinate_systems, _ = one_point_graph
+    cs = coordinate_systems[0]
+    tm.add_coordinate_system(cs)
+    tm.add_element(ELEMENT_TYPE.IMAGE, "image1", cs.name)
+
+    cs_name = tm.get_element_coordinate_system(ELEMENT_TYPE.IMAGE, "image1")
+    assert cs_name == cs.name
+
+
+def test_get_element_coordinate_system_nonexistent():
+    """Test getting the coordinate system of a non-existent element."""
+    tm = TransformationManager()
+    cs_name = tm.get_element_coordinate_system(ELEMENT_TYPE.IMAGE, "nonexistent")
+    assert cs_name is None
+
+
+@pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
+def test_add_transformation(fully_connected_two_point_graph, cs_names):
+    """Test adding a transformation between coordinate systems."""
+    tm = TransformationManager()
+    coordinate_systems, transformations = fully_connected_two_point_graph
+    cs1, cs2 = coordinate_systems
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+
+    transform = transformations[0]
+    tm.add_transformation(cs1.name, cs2.name, transform)
+
+    key = (cs1.name, cs2.name)
+    assert key in tm._coordinate_transforms
+    assert tm._coordinate_transforms[key] == transform
+
+
+@pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
+def test_add_transformation_nonexistent_cs(fully_connected_two_point_graph, cs_names):
+    """Test that adding a transformation with non-existent coordinate systems raises ValueError."""
+    tm = TransformationManager()
+    coordinate_systems, transformations = fully_connected_two_point_graph
+    transform = transformations[0]
+    cs1, cs2 = coordinate_systems
+
+    with pytest.raises(ValueError, match=f"Input coordinate system '{cs1.name}' does not exist"):
+        tm.add_transformation(cs1.name, cs2.name, transform)
+
+    # Add one coordinate system
+    tm.add_coordinate_system(cs1)
+
+    with pytest.raises(ValueError, match=f"Output coordinate system '{cs2.name}' does not exist"):
+        tm.add_transformation(cs1.name, cs2.name, transform)
+
+
+@pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
+def test_get_existing_transformation(fully_connected_two_point_graph, cs_names):
+    """Test getting an existing transformation."""
+    tm = TransformationManager()
+    coordinate_systems, transformations = fully_connected_two_point_graph
+    cs1, cs2 = coordinate_systems
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+
+    transform = transformations[0]
+    tm.add_transformation(cs1.name, cs2.name, transform)
+
+    retrieved = tm.get_existing_transformation(cs1.name, cs2.name)
+    assert retrieved == transform
+
+
+def test_get_existing_transformation_nonexistent(fully_connected_two_point_graph):
+    """Test getting a non-existent transformation."""
+    tm = TransformationManager()
+    coordinate_systems, _transformations = fully_connected_two_point_graph
+    cs1, cs2 = coordinate_systems
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+
+    retrieved = tm.get_existing_transformation(cs1.name, cs2.name)
+    assert retrieved is None
+
+
+@pytest.mark.parametrize("cs_names", [["cs1", "cs2"]])
+def test_remove_transformation(fully_connected_two_point_graph, cs_names):
+    """Test removing a transformation."""
+    tm = TransformationManager()
+    coordinate_systems, transformations = fully_connected_two_point_graph
+    cs1, cs2 = coordinate_systems
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+
+    transform = transformations[0]
+    tm.add_transformation(cs1.name, cs2.name, transform)
+
+    tm.remove_transformation(cs1.name, cs2.name)
+    assert (cs1.name, cs2.name) not in tm._coordinate_transforms
+
+
+def test_remove_transformation_nonexistent():
+    """Test that removing a non-existent transformation raises KeyError."""
+    tm = TransformationManager()
+    with pytest.raises(KeyError, match="Transformation from 'cs1' to 'cs2' not found"):
+        tm.remove_transformation("cs1", "cs2")
+
+
+def test_build_nx_graph(four_point_graph):
+    """Test building a networkx graph from the transformation manager."""
+    tm = TransformationManager()
+    coordinate_systems, transformations = four_point_graph
+    cs1, cs2, cs3, cs4 = coordinate_systems
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
+
+    transform1 = transformations[0]  # cs1 -> cs2
+    transform2 = transformations[1]  # cs2 -> cs3
+    transform3 = transformations[2]  # cs3 -> cs4
+    transform4 = transformations[3]  # cs1 -> cs3
+    tm.add_transformation(cs1.name, cs2.name, transform1)
+    tm.add_transformation(cs2.name, cs3.name, transform2)
+    tm.add_transformation(cs3.name, cs4.name, transform3)
+    tm.add_transformation(cs1.name, cs3.name, transform4)
+
+    g = tm.build_nx_graph()
+    assert g.has_node(cs1.name)
+    assert g.has_node(cs2.name)
+    assert g.has_node(cs3.name)
+    assert g.has_node(cs4.name)
+    assert g.has_edge(cs1.name, cs2.name)
+    assert g.has_edge(cs2.name, cs3.name)
+    assert g.has_edge(cs3.name, cs4.name)
+    assert g.has_edge(cs1.name, cs3.name)
+    assert g[cs1.name][cs2.name]["transformation"] == transform1
+    assert g[cs2.name][cs3.name]["transformation"] == transform2
+    assert g[cs3.name][cs4.name]["transformation"] == transform3
+    assert g[cs1.name][cs3.name]["transformation"] == transform4
+
+
+def test_get_shortest_transformation_sequence_direct(four_point_graph):
+    """Test getting the shortest transformation sequence for a direct transformation."""
+    tm = TransformationManager()
+    coordinate_systems, transformations = four_point_graph
+    cs1, cs2, cs3, cs4 = coordinate_systems
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
+
+    transform1 = transformations[0]  # cs1 -> cs2
+    transform2 = transformations[1]  # cs2 -> cs3
+    transform4 = transformations[3]  # cs1 -> cs3
+    tm.add_transformation(cs1.name, cs2.name, transform1)
+    tm.add_transformation(cs2.name, cs3.name, transform2)
+    tm.add_transformation(cs1.name, cs3.name, transform4)
+
+    sequence = tm.get_shortest_transformation_sequence(cs1.name, cs3.name)
+    assert sequence == [transform4]
+
+
+def test_get_shortest_transformation_sequence_indirect(four_point_graph):
+    """Test getting the shortest transformation sequence for an indirect transformation."""
+    tm = TransformationManager()
+    coordinate_systems, transformations = four_point_graph
+    cs1, cs2, cs3, cs4 = coordinate_systems
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
+
+    transform1 = transformations[0]  # cs1 -> cs2
+    transform2 = transformations[1]  # cs2 -> cs3
+    transform3 = transformations[2]  # cs3 -> cs4
+    tm.add_transformation(cs1.name, cs2.name, transform1)
+    tm.add_transformation(cs2.name, cs3.name, transform2)
+    tm.add_transformation(cs3.name, cs4.name, transform3)
+
+    sequence = tm.get_shortest_transformation_sequence(cs1.name, cs3.name)
+    assert sequence == [transform1, transform2]
+
+
+def test_get_shortest_transformation_sequence_no_path(four_point_graph):
+    """Test that getting a transformation sequence with no path raises ValueError."""
+    tm = TransformationManager()
+    coordinate_systems, transformations = four_point_graph
+    cs1, cs2, cs3, cs4 = coordinate_systems
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
+
+    transform1 = transformations[0]  # cs1 -> cs2
+    transform2 = transformations[1]  # cs2 -> cs3
+
+    tm.add_transformation(cs1.name, cs2.name, transform1)
+    tm.add_transformation(cs2.name, cs3.name, transform2)
+
+    with pytest.raises(ValueError, match=f"No path found from {cs1.name} to {cs4.name}"):
+        tm.get_shortest_transformation_sequence(cs1.name, cs4.name)
+
+
+def test_get_all_transformation_sequences(four_point_graph):
+    """Test getting all transformation sequences."""
+    tm = TransformationManager()
+    coordinate_systems, transformations = four_point_graph
+    cs1, cs2, cs3, cs4 = coordinate_systems
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
+
+    transform1 = transformations[0]  # cs1 -> cs2
+    transform2 = transformations[1]  # cs2 -> cs3
+    transform3 = transformations[2]  # cs3 -> cs4
+    transform4 = transformations[3]  # cs1 -> cs3
+    tm.add_transformation(cs1.name, cs2.name, transform1)
+    tm.add_transformation(cs2.name, cs3.name, transform2)
+    tm.add_transformation(cs3.name, cs4.name, transform3)
+    tm.add_transformation(cs1.name, cs3.name, transform4)
+
+    sequences = tm.get_all_transformation_sequences(cs1.name, cs4.name)
+    assert len(sequences) == 2
+    assert [transform1, transform2, transform3] in sequences
+    assert [transform4, transform3] in sequences
+
+
+def test_get_all_transformation_sequences_no_path(four_point_graph):
+    """Test that getting all transformation sequences with no path returns an empty list."""
+    tm = TransformationManager()
+    coordinate_systems, transformations = four_point_graph
+    cs1, cs2, cs3, cs4 = coordinate_systems
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
+
+    transform1 = transformations[0]  # cs1 -> cs2
+    transform2 = transformations[1]  # cs2 -> cs3
+
+    tm.add_transformation(cs1.name, cs2.name, transform1)
+    tm.add_transformation(cs2.name, cs3.name, transform2)
+
+    sequences = tm.get_all_transformation_sequences(cs1.name, cs4.name)
+    assert sequences == []
+
+
+def test_repr(one_point_graph):
+    """Test the string representation of TransformationManager."""
+    tm = TransformationManager()
+    coordinate_systems, _ = one_point_graph
+    cs = coordinate_systems[0]
+    tm.add_coordinate_system(cs)
+    tm.add_element(ELEMENT_TYPE.IMAGE, "image1", cs.name)
+
+    repr_str = repr(tm)
+    assert "TransformationManager" in repr_str
+    assert cs.name in repr_str
+    assert "image1" in repr_str

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -213,7 +213,7 @@ def test_add_transformation_nonexistent_cs(fully_connected_two_point_graph):
         tm.add_transformation(cs1, cs2, transform)
 
 
-def test_get_existing_transformation(fully_connected_two_point_graph):
+def test_get_direct_transformations(fully_connected_two_point_graph):
     """Test getting an existing transformation."""
     tm = TransformationManager()
     [cs1, cs2], [transform] = fully_connected_two_point_graph
@@ -226,7 +226,7 @@ def test_get_existing_transformation(fully_connected_two_point_graph):
     assert retrieved == [transform]
 
 
-def test_get_existing_transformation_nonexistent(fully_connected_two_point_graph):
+def test_get_direct_transformations_nonexistent(fully_connected_two_point_graph):
     """Test getting a non-existent transformation."""
     tm = TransformationManager()
     coordinate_systems, _transformations = fully_connected_two_point_graph
@@ -234,13 +234,11 @@ def test_get_existing_transformation_nonexistent(fully_connected_two_point_graph
     tm.add_coordinate_system(cs1)
     tm.add_coordinate_system(cs2)
 
-    with pytest.raises(
-        TransformationNotFoundError, match=f"Transformation from '{cs1.name}' to '{cs2.name}' not found"
-    ):
-        tm.get_direct_transformations(cs1, cs2)
+    retrieved = tm.get_direct_transformations(cs1, cs2)
+    assert retrieved == []
 
 
-def test_remove_all_transformations_between_coordinate_systems(fully_connected_two_point_graph):
+def test_remove_all_transformations_between_coordinate_systems(fully_connected_two_point_graph, mocker):
     """Test removing all transformations  between coordinate systems."""
 
     tm = TransformationManager()
@@ -250,21 +248,23 @@ def test_remove_all_transformations_between_coordinate_systems(fully_connected_t
 
     tm.add_transformation(cs1, cs2, transform)
 
+    spy = mocker.spy(tm.graph, "remove_edge")
     tm.remove_all_transformations_between_coordinate_systems(cs1, cs2)
+    assert spy.call_count == 1
     assert not tm.graph.has_edge(cs1, cs2)
 
 
-def test_remove_all_transformation_nonexistent(fully_connected_two_point_graph):
+def test_remove_all_transformation_nonexistent(fully_connected_two_point_graph, mocker):
     """Test that removing non-existent transformations between coordinate systems raises TransformationNotFoundError."""
 
     tm = TransformationManager()
     [cs1, cs2], _ = fully_connected_two_point_graph
     tm.graph.add_node(cs1)
     tm.graph.add_node(cs2)
-    with pytest.raises(
-        TransformationNotFoundError, match=f"Transformation from '{cs1.name}' to '{cs2.name}' not found"
-    ):
-        tm.remove_all_transformations_between_coordinate_systems(cs1, cs2)
+
+    spy = mocker.spy(tm.graph, "remove_edge")
+    tm.remove_all_transformations_between_coordinate_systems(cs1, cs2)
+    assert spy.call_count == 0
 
 
 def test_remove_specific_transformation_between_coordinate_systems(five_point_graph):

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -16,7 +16,7 @@ from spatialdata._core.transformation_manager.exceptions import (
     CoordinateSystemAlreadyExistsError,
     CoordinateSystemNotFoundError,
     ElementAlreadyExistsError,
-    ElementNotFoundError,
+    ElementNotRegisteredToAnyCoordinateSystemError,
     TransformationNotFoundError,
     TransformationPathAmbiguousError,
     TransformationPathAmbiguousMultipleEdgeExpectedError,
@@ -173,9 +173,7 @@ def test_unset_element_nonexistent(one_point_graph):
     element_name = "image1"
 
     # Try to unset non-existent element
-    with pytest.raises(
-        ElementNotFoundError, match=f"Element '{element_name}' not found in the transformation manager."
-    ):
+    with pytest.raises(ElementNotRegisteredToAnyCoordinateSystemError):
         tm._unset_element(element_name)
 
 
@@ -218,17 +216,14 @@ def test_add_transformation_nonexistent_cs(fully_connected_two_point_graph):
     tm = TransformationManager()
     [cs1, cs2], [transform] = fully_connected_two_point_graph
 
-    with pytest.raises(
-        CoordinateSystemNotFoundError, match=f"Coordinate system '{cs1.name}' not found in the transformation manager"
-    ):
+    expected_msg = "Coordinate system .* not found in the transformation manager."
+    with pytest.raises(CoordinateSystemNotFoundError, match=expected_msg):
         tm.add_transformation(cs1, cs2, transform)
 
     # Add one coordinate system
     tm.add_coordinate_system(cs1)
 
-    with pytest.raises(
-        CoordinateSystemNotFoundError, match=f"Coordinate system '{cs2.name}' not found in the transformation manager"
-    ):
+    with pytest.raises(CoordinateSystemNotFoundError, match=expected_msg):
         tm.add_transformation(cs1, cs2, transform)
 
 
@@ -386,7 +381,7 @@ def test_get_all_shortest_transformation_sequences_no_path(four_point_graph):
     tm.add_transformation(cs1, cs2, transform1)
     tm.add_transformation(cs2, cs3, transform2)
 
-    expected_error_msg = "No transformation path found from"
+    expected_error_msg = f"No transformation path found from {cs1.name} to {cs4.name}"
     with pytest.raises(TransformationPathNotFoundError, match=expected_error_msg):
         tm.get_all_shortest_transformation_sequences(cs1, cs4)
 
@@ -437,7 +432,8 @@ def test_get_all_shortest_transformation_sequences_multiple_paths_multiple_edges
     tm.add_transformation(cs3, cs5, transform4)
     tm.add_transformation(cs3, cs5, transform5)
 
-    with pytest.raises(TransformationPathAmbiguousError, match="Transformation Path ambiguous"):
+    expected_msg = f"Transformation Path ambiguous from {cs1.name} to {cs5.name}."
+    with pytest.raises(TransformationPathAmbiguousError, match=expected_msg):
         tm.get_all_shortest_transformation_sequences(cs1, cs5)
 
 
@@ -527,9 +523,8 @@ def test_get_all_transformation_sequences_multiple_paths_multiple_edges_no_edge_
     tm.add_transformation(cs3, cs5, transform4)
     tm.add_transformation(cs3, cs5, transform5)
 
-    with pytest.raises(
-        TransformationPathAmbiguousNoEdgeExpectedError, match="None of the edges were specified to be expected"
-    ):
+    expected_msg = f"Transformation Path ambiguous from {cs3.name} to {cs5.name}."
+    with pytest.raises(TransformationPathAmbiguousNoEdgeExpectedError, match=expected_msg):
         tm.get_all_transformation_sequences(cs1, cs5)
 
 
@@ -556,9 +551,8 @@ def test_get_all_transformation_sequences_multiple_paths_multiple_edges_multiple
         (cs3, cs5, transform5),
     ]
 
-    with pytest.raises(
-        TransformationPathAmbiguousMultipleEdgeExpectedError, match="Multiple.*edges were specified to be expected"
-    ):
+    expected_msg = f"Transformation Path ambiguous from {cs3.name} to {cs5.name}."
+    with pytest.raises(TransformationPathAmbiguousMultipleEdgeExpectedError, match=expected_msg):
         tm.get_all_transformation_sequences(cs1, cs5, expected_intermediate_edges=expected_intermediate_edges)
 
 
@@ -571,7 +565,7 @@ def test_get_all_transformation_sequences_no_path(four_point_graph):
     tm.add_coordinate_system(cs3)
     tm.add_coordinate_system(cs4)
 
-    expected_error_msg = "No transformation path found from"
+    expected_error_msg = f"No transformation path found from {cs1.name} to {cs4.name}"
     with pytest.raises(TransformationPathNotFoundError, match=expected_error_msg):
         tm.get_all_shortest_transformation_sequences(cs1, cs4)
 

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -194,6 +194,23 @@ def test_add_transformation(fully_connected_two_point_graph):
     assert tm.graph[cs1][cs2][edge_key][TRANSFORM_KEY] == transform
 
 
+def test_add_transformation_existing_edge(fully_connected_two_point_graph):
+    """Test adding a transformation between coordinate systems that already have an edge."""
+    tm = TransformationManager()
+    [cs1, cs2], [transform] = fully_connected_two_point_graph
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+
+    tm.add_transformation(cs1, cs2, transform)
+    assert tm.graph.has_edge(cs1, cs2)
+
+    # Add same transformation again between the same coordinate systems
+    tm.add_transformation(cs1, cs2, transform)
+    # Should have just rewritten the edge
+    assert tm.graph.has_edge(cs1, cs2)
+    assert len(tm.graph[cs1][cs2]) == 1
+
+
 def test_add_transformation_nonexistent_cs(fully_connected_two_point_graph):
     """Test that adding a transformation with non-existent coordinate systems raises CoordinateSystemNotFoundError."""
     tm = TransformationManager()

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -530,7 +530,7 @@ def test_get_all_transformation_sequences_multiple_paths_multiple_edges_no_edge_
     with pytest.raises(
         TransformationPathAmbiguousNoEdgeExpectedError, match="None of the edges were specified to be expected"
     ):
-        tm.get_all_transformation_sequences(cs1, cs5, expected_intermediate_edges=[])
+        tm.get_all_transformation_sequences(cs1, cs5)
 
 
 def test_get_all_transformation_sequences_multiple_paths_multiple_edges_multiple_expected(five_point_graph):

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -160,7 +160,7 @@ def test_unset_element(one_point_graph):
     [cs1], _ = one_point_graph
     tm.add_coordinate_system(cs1)
     tm.add_element("image1", cs1)
-    tm.unset_element("image1")
+    tm._unset_element("image1")
 
     assert "image1" not in tm._element_to_cs_mapping
 
@@ -176,7 +176,7 @@ def test_unset_element_nonexistent(one_point_graph):
     with pytest.raises(
         ElementNotFoundError, match=f"Element '{element_name}' not found in the transformation manager."
     ):
-        tm.unset_element(element_name)
+        tm._unset_element(element_name)
 
 
 def test_add_transformation(fully_connected_two_point_graph):

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -30,9 +30,9 @@ def test_initialization():
     """Test that TransformationManager initializes correctly."""
 
     tm = TransformationManager()
-    assert len(tm.graph.nodes()) == 0
-    assert len(tm.graph.edges()) == 0
-    assert tm.element_to_cs_mapping == {}
+    assert len(tm._graph.nodes()) == 0
+    assert len(tm._graph.edges()) == 0
+    assert tm._element_to_cs_mapping == {}
 
 
 def test_add_coordinate_system(one_point_graph):
@@ -42,7 +42,7 @@ def test_add_coordinate_system(one_point_graph):
     [cs1], _ = one_point_graph
 
     tm.add_coordinate_system(cs1)
-    assert cs1 in tm.graph.nodes()
+    assert cs1 in tm._graph.nodes()
 
 
 def test_add_coordinate_system_duplicate(one_point_graph):
@@ -63,7 +63,7 @@ def test_remove_coordinate_system(one_point_graph):
     tm.add_coordinate_system(cs1)
     tm.remove_coordinate_system(cs1)
 
-    assert cs1 not in tm.graph.nodes()
+    assert cs1 not in tm._graph.nodes()
 
 
 def test_remove_coordinate_system_nonexistent(one_point_graph):
@@ -134,7 +134,7 @@ def test_add_element(one_point_graph):
     tm.add_coordinate_system(cs1)
     tm.add_element("image1", cs1)
 
-    mapping = tm.element_to_cs_mapping
+    mapping = tm._element_to_cs_mapping
     assert "image1" in mapping
     assert mapping["image1"] == cs1
 
@@ -162,7 +162,7 @@ def test_unset_element(one_point_graph):
     tm.add_element("image1", cs1)
     tm.unset_element("image1")
 
-    assert "image1" not in tm.element_to_cs_mapping
+    assert "image1" not in tm._element_to_cs_mapping
 
 
 def test_unset_element_nonexistent(one_point_graph):
@@ -190,10 +190,10 @@ def test_add_transformation(fully_connected_two_point_graph):
 
     tm.add_transformation(cs1, cs2, transform)
 
-    assert tm.graph.has_edge(cs1, cs2)
+    assert tm._graph.has_edge(cs1, cs2)
     # Get the first edge key and check the transformation
     edge_key = tm._get_edge_key((cs1, cs2, transform))
-    assert tm.graph[cs1][cs2][edge_key][TRANSFORM_KEY] == transform
+    assert tm._graph[cs1][cs2][edge_key][TRANSFORM_KEY] == transform
 
 
 def test_add_transformation_existing_edge(fully_connected_two_point_graph):
@@ -204,13 +204,13 @@ def test_add_transformation_existing_edge(fully_connected_two_point_graph):
     tm.add_coordinate_system(cs2)
 
     tm.add_transformation(cs1, cs2, transform)
-    assert tm.graph.has_edge(cs1, cs2)
+    assert tm._graph.has_edge(cs1, cs2)
 
     # Add same transformation again between the same coordinate systems
     tm.add_transformation(cs1, cs2, transform)
     # Should have just rewritten the edge
-    assert tm.graph.has_edge(cs1, cs2)
-    assert len(tm.graph[cs1][cs2]) == 1
+    assert tm._graph.has_edge(cs1, cs2)
+    assert len(tm._graph[cs1][cs2]) == 1
 
 
 def test_add_transformation_nonexistent_cs(fully_connected_two_point_graph):
@@ -267,10 +267,10 @@ def test_remove_all_transformations_between_coordinate_systems(fully_connected_t
 
     tm.add_transformation(cs1, cs2, transform)
 
-    spy = mocker.spy(tm.graph, "remove_edge")
+    spy = mocker.spy(tm._graph, "remove_edge")
     tm.remove_all_transformations_between_coordinate_systems(cs1, cs2)
     assert spy.call_count == 1
-    assert not tm.graph.has_edge(cs1, cs2)
+    assert not tm._graph.has_edge(cs1, cs2)
 
 
 def test_remove_all_transformation_nonexistent(fully_connected_two_point_graph, mocker):
@@ -278,10 +278,10 @@ def test_remove_all_transformation_nonexistent(fully_connected_two_point_graph, 
 
     tm = TransformationManager()
     [cs1, cs2], _ = fully_connected_two_point_graph
-    tm.graph.add_node(cs1)
-    tm.graph.add_node(cs2)
+    tm._graph.add_node(cs1)
+    tm._graph.add_node(cs2)
 
-    spy = mocker.spy(tm.graph, "remove_edge")
+    spy = mocker.spy(tm._graph, "remove_edge")
     tm.remove_all_transformations_between_coordinate_systems(cs1, cs2)
     assert spy.call_count == 0
 
@@ -299,7 +299,7 @@ def test_remove_specific_transformation_between_coordinate_systems(five_point_gr
 
     tm.remove_specific_transformation(cs3, cs5, transform4)
     edge_key = tm._get_edge_key((cs3, cs5, transform4))
-    assert not tm.graph.has_edge(cs3, cs5, key=edge_key)
+    assert not tm._graph.has_edge(cs3, cs5, key=edge_key)
 
 
 def test_remove_specific_transformation_between_coordinate_systems_non_existent(five_point_graph):

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -222,7 +222,7 @@ def test_get_existing_transformation(fully_connected_two_point_graph):
 
     tm.add_transformation(cs1, cs2, transform)
 
-    retrieved = tm.get_existing_direct_transformations(cs1, cs2)
+    retrieved = tm.get_direct_transformations(cs1, cs2)
     assert retrieved == [transform]
 
 
@@ -237,7 +237,7 @@ def test_get_existing_transformation_nonexistent(fully_connected_two_point_graph
     with pytest.raises(
         TransformationNotFoundError, match=f"Transformation from '{cs1.name}' to '{cs2.name}' not found"
     ):
-        tm.get_existing_direct_transformations(cs1, cs2)
+        tm.get_direct_transformations(cs1, cs2)
 
 
 def test_remove_all_transformations_between_coordinate_systems(fully_connected_two_point_graph):

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -20,28 +20,27 @@ from spatialdata._core.transformation_manager.exceptions import (
     TransformationNotFoundError,
     TransformationPathAmbiguousError,
     TransformationPathNotFoundError,
-    suppress_direct_internal_attribute_access_warning,
 )
 from spatialdata.transformations.transformations import Sequence
 
 
 def test_initialization():
     """Test that TransformationManager initializes correctly."""
-    with suppress_direct_internal_attribute_access_warning():
-        tm = TransformationManager()
-        assert len(tm.graph.nodes()) == 0
-        assert len(tm.graph.edges()) == 0
-        assert tm.element_to_cs_mapping == {}
+
+    tm = TransformationManager()
+    assert len(tm.graph.nodes()) == 0
+    assert len(tm.graph.edges()) == 0
+    assert tm.element_to_cs_mapping == {}
 
 
 def test_add_coordinate_system(one_point_graph):
     """Test adding a coordinate system."""
-    with suppress_direct_internal_attribute_access_warning():
-        tm = TransformationManager()
-        [cs1], _ = one_point_graph
 
-        tm.add_coordinate_system(cs1)
-        assert cs1 in tm.graph.nodes()
+    tm = TransformationManager()
+    [cs1], _ = one_point_graph
+
+    tm.add_coordinate_system(cs1)
+    assert cs1 in tm.graph.nodes()
 
 
 def test_add_coordinate_system_duplicate(one_point_graph):
@@ -62,8 +61,7 @@ def test_remove_coordinate_system(one_point_graph):
     tm.add_coordinate_system(cs1)
     tm.remove_coordinate_system(cs1)
 
-    with suppress_direct_internal_attribute_access_warning():
-        assert cs1 not in tm.graph.nodes()
+    assert cs1 not in tm.graph.nodes()
 
 
 def test_remove_coordinate_system_nonexistent(one_point_graph):
@@ -134,10 +132,9 @@ def test_add_element(one_point_graph):
     tm.add_coordinate_system(cs1)
     tm.add_element("image1", cs1)
 
-    with suppress_direct_internal_attribute_access_warning():
-        mapping = tm.element_to_cs_mapping
-        assert "image1" in mapping
-        assert mapping["image1"] == cs1
+    mapping = tm.element_to_cs_mapping
+    assert "image1" in mapping
+    assert mapping["image1"] == cs1
 
 
 def test_add_element_duplicate(one_point_graph):
@@ -163,8 +160,7 @@ def test_unset_element(one_point_graph):
     tm.add_element("image1", cs1)
     tm.unset_element("image1")
 
-    with suppress_direct_internal_attribute_access_warning():
-        assert "image1" not in tm.element_to_cs_mapping
+    assert "image1" not in tm.element_to_cs_mapping
 
 
 def test_unset_element_nonexistent(one_point_graph):
@@ -183,19 +179,19 @@ def test_unset_element_nonexistent(one_point_graph):
 
 def test_add_transformation(fully_connected_two_point_graph):
     """Test adding a transformation between coordinate systems."""
-    with suppress_direct_internal_attribute_access_warning():
-        tm = TransformationManager()
-        [cs1, cs2], [transform] = fully_connected_two_point_graph
 
-        tm.add_coordinate_system(cs1)
-        tm.add_coordinate_system(cs2)
+    tm = TransformationManager()
+    [cs1, cs2], [transform] = fully_connected_two_point_graph
 
-        tm.add_transformation(cs1, cs2, transform)
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
 
-        assert tm.graph.has_edge(cs1, cs2)
-        # Get the first edge key and check the transformation
-        edge_key = tm._get_edge_key_from_transform(transform)
-        assert tm.graph[cs1][cs2][edge_key][TRANSFORM_KEY] == transform
+    tm.add_transformation(cs1, cs2, transform)
+
+    assert tm.graph.has_edge(cs1, cs2)
+    # Get the first edge key and check the transformation
+    edge_key = tm._get_edge_key_from_transform(transform)
+    assert tm.graph[cs1][cs2][edge_key][TRANSFORM_KEY] == transform
 
 
 def test_add_transformation_nonexistent_cs(fully_connected_two_point_graph):
@@ -246,45 +242,44 @@ def test_get_existing_transformation_nonexistent(fully_connected_two_point_graph
 
 def test_remove_all_transformations_between_coordinate_systems(fully_connected_two_point_graph):
     """Test removing all transformations  between coordinate systems."""
-    with suppress_direct_internal_attribute_access_warning():
-        tm = TransformationManager()
-        [cs1, cs2], [transform] = fully_connected_two_point_graph
-        tm.add_coordinate_system(cs1)
-        tm.add_coordinate_system(cs2)
 
-        tm.add_transformation(cs1, cs2, transform)
+    tm = TransformationManager()
+    [cs1, cs2], [transform] = fully_connected_two_point_graph
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
 
-        tm.remove_all_transformations_between_coordinate_systems(cs1, cs2)
-        assert not tm.graph.has_edge(cs1, cs2)
+    tm.add_transformation(cs1, cs2, transform)
+
+    tm.remove_all_transformations_between_coordinate_systems(cs1, cs2)
+    assert not tm.graph.has_edge(cs1, cs2)
 
 
 def test_remove_all_transformation_nonexistent(fully_connected_two_point_graph):
     """Test that removing non-existent transformations between coordinate systems raises TransformationNotFoundError."""
-    with suppress_direct_internal_attribute_access_warning():
-        tm = TransformationManager()
-        [cs1, cs2], _ = fully_connected_two_point_graph
-        tm.graph.add_node(cs1)
-        tm.graph.add_node(cs2)
-        with pytest.raises(
-            TransformationNotFoundError, match=f"Transformation from '{cs1.name}' to '{cs2.name}' not found"
-        ):
-            tm.remove_all_transformations_between_coordinate_systems(cs1, cs2)
+
+    tm = TransformationManager()
+    [cs1, cs2], _ = fully_connected_two_point_graph
+    tm.graph.add_node(cs1)
+    tm.graph.add_node(cs2)
+    with pytest.raises(
+        TransformationNotFoundError, match=f"Transformation from '{cs1.name}' to '{cs2.name}' not found"
+    ):
+        tm.remove_all_transformations_between_coordinate_systems(cs1, cs2)
 
 
 def test_remove_specific_transformation_between_coordinate_systems(five_point_graph):
     """Test removing specific transformation between coordinate systems."""
 
-    with suppress_direct_internal_attribute_access_warning():
-        tm = TransformationManager()
-        [_cs1, _cs2, cs3, _cs4, cs5], [_transform1, _transform2, _transform3, transform4, transform5] = five_point_graph
-        tm.add_coordinate_system(cs3)
-        tm.add_coordinate_system(cs5)
+    tm = TransformationManager()
+    [_cs1, _cs2, cs3, _cs4, cs5], [_transform1, _transform2, _transform3, transform4, transform5] = five_point_graph
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs5)
 
-        tm.add_transformation(cs3, cs5, transform4)
-        tm.add_transformation(cs3, cs5, transform5)
+    tm.add_transformation(cs3, cs5, transform4)
+    tm.add_transformation(cs3, cs5, transform5)
 
-        tm.remove_specific_transformation(cs3, cs5, transform4)
-        assert not tm.graph.has_edge(cs3, cs5, key=tm._get_edge_key_from_transform(transform4))
+    tm.remove_specific_transformation(cs3, cs5, transform4)
+    assert not tm.graph.has_edge(cs3, cs5, key=tm._get_edge_key_from_transform(transform4))
 
 
 def test_remove_specific_transformation_between_coordinate_systems_non_existent(five_point_graph):
@@ -293,16 +288,15 @@ def test_remove_specific_transformation_between_coordinate_systems_non_existent(
     TransformationNotFoundError.
     """
 
-    with suppress_direct_internal_attribute_access_warning():
-        tm = TransformationManager()
-        [_cs1, _cs2, cs3, _cs4, cs5], [_transform1, _transform2, _transform3, transform4, transform5] = five_point_graph
-        tm.add_coordinate_system(cs3)
-        tm.add_coordinate_system(cs5)
+    tm = TransformationManager()
+    [_cs1, _cs2, cs3, _cs4, cs5], [_transform1, _transform2, _transform3, transform4, transform5] = five_point_graph
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs5)
 
-        with pytest.raises(
-            TransformationNotFoundError, match=f"Transformation from '{cs3.name}' to '{cs5.name}' not found"
-        ):
-            tm.remove_specific_transformation(cs3, cs5, transform4)
+    with pytest.raises(
+        TransformationNotFoundError, match=f"Transformation from '{cs3.name}' to '{cs5.name}' not found"
+    ):
+        tm.remove_specific_transformation(cs3, cs5, transform4)
 
 
 def test_get_all_shortest_transformation_sequences_direct(four_point_graph):

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -19,6 +19,8 @@ from spatialdata._core.transformation_manager.exceptions import (
     ElementNotFoundError,
     TransformationNotFoundError,
     TransformationPathAmbiguousError,
+    TransformationPathAmbiguousMultipleEdgeExpectedError,
+    TransformationPathAmbiguousNoEdgeExpectedError,
     TransformationPathNotFoundError,
 )
 from spatialdata.transformations.transformations import Sequence
@@ -503,8 +505,8 @@ def test_get_all_transformation_sequences_multiple_paths_multiple_edges_success(
     assert Sequence([transform3, transform4]) in sequences
 
 
-def test_get_all_transformation_sequences_multiple_paths_multiple_edges_failure(five_point_graph):
-    """Test getting all transformation sequences, with multiple paths and multiple edges between nodes."""
+def test_get_all_transformation_sequences_multiple_paths_multiple_edges_no_edge_expected(five_point_graph):
+    """Test getting all transformation sequences with multiple paths and multiple edges, no edge expected."""
     tm = TransformationManager()
     [cs1, cs2, cs3, cs4, cs5], [transform1, transform2, transform3, transform4, transform5] = five_point_graph
     tm.add_coordinate_system(cs1)
@@ -521,8 +523,34 @@ def test_get_all_transformation_sequences_multiple_paths_multiple_edges_failure(
     tm.add_transformation(cs3, cs5, transform4)
     tm.add_transformation(cs3, cs5, transform5)
 
-    with pytest.raises(TransformationPathAmbiguousError, match="Transformation Path ambiguous"):
-        tm.get_all_transformation_sequences(cs1, cs5)
+    with pytest.raises(
+        TransformationPathAmbiguousNoEdgeExpectedError, match="None of the edges were specified to be expected"
+    ):
+        tm.get_all_transformation_sequences(cs1, cs5, expected_intermediate_transformations=[])
+
+
+def test_get_all_transformation_sequences_multiple_paths_multiple_edges_multiple_expected(five_point_graph):
+    """Test getting all transformation sequences with multiple paths and multiple edges, multiple edges expected."""
+    tm = TransformationManager()
+    [cs1, cs2, cs3, cs4, cs5], [transform1, transform2, transform3, transform4, transform5] = five_point_graph
+    tm.add_coordinate_system(cs1)
+    tm.add_coordinate_system(cs2)
+    tm.add_coordinate_system(cs3)
+    tm.add_coordinate_system(cs4)
+    tm.add_coordinate_system(cs5)
+
+    tm.add_transformation(cs1, cs2, transform1)
+    tm.add_transformation(cs2, cs3, transform2)
+    tm.add_transformation(cs1, cs4, transform2)
+    tm.add_transformation(cs4, cs3, transform1)
+    tm.add_transformation(cs1, cs3, transform3)
+    tm.add_transformation(cs3, cs5, transform4)
+    tm.add_transformation(cs3, cs5, transform5)
+
+    with pytest.raises(
+        TransformationPathAmbiguousMultipleEdgeExpectedError, match="Multiple.*edges were specified to be expected"
+    ):
+        tm.get_all_transformation_sequences(cs1, cs5, expected_intermediate_transformations=[transform4, transform5])
 
 
 def test_get_all_transformation_sequences_no_path(four_point_graph):

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -17,11 +17,13 @@ from spatialdata._core.transformation_manager.exceptions import (
     CoordinateSystemNotFoundError,
     ElementAlreadyExistsError,
     ElementNotRegisteredToAnyCoordinateSystemError,
+    InvalidPathError,
     TransformationNotFoundError,
     TransformationPathAmbiguousError,
     TransformationPathAmbiguousMultipleEdgeExpectedError,
     TransformationPathAmbiguousNoEdgeExpectedError,
     TransformationPathNotFoundError,
+    TransformationPathNotSimple,
 )
 from spatialdata.transformations.transformations import Sequence
 
@@ -554,6 +556,35 @@ def test_get_all_transformation_sequences_multiple_paths_multiple_edges_multiple
     expected_msg = f"Transformation Path ambiguous from {cs3.name} to {cs5.name}."
     with pytest.raises(TransformationPathAmbiguousMultipleEdgeExpectedError, match=expected_msg):
         tm.get_all_transformation_sequences(cs1, cs5, expected_intermediate_edges=expected_intermediate_edges)
+
+
+def test_get_transformation_sequences_from_simple_paths_after_disambiguation_with_non_simple_paths(
+    fully_connected_two_point_graph,
+):
+    """Test _get_transformation_sequences_from_simple_paths_after_disambiguation with non-simple paths."""
+    tm = TransformationManager()
+    [cs1, cs2], _ = fully_connected_two_point_graph
+
+    tm.add_coordinate_system(cs1)
+
+    paths = [[cs1, cs2, cs1, cs2]]
+
+    with pytest.raises(TransformationPathNotSimple):
+        tm._get_transformation_sequences_from_simple_paths_after_disambiguation(paths, ())
+
+
+def test_get_transformation_sequences_from_simple_paths_after_disambiguation_with_single_node_path(
+    fully_connected_two_point_graph,
+):
+    """Test _get_transformation_sequences_from_simple_paths_after_disambiguation with a path with only one node."""
+    tm = TransformationManager()
+    [cs1, cs2], [transformation] = fully_connected_two_point_graph
+
+    tm.add_coordinate_system(cs1)
+
+    paths = [[cs1]]
+    with pytest.raises(InvalidPathError):
+        tm._get_transformation_sequences_from_simple_paths_after_disambiguation(paths, ())
 
 
 def test_get_all_transformation_sequences_no_path(four_point_graph):

--- a/tests/core/transformation_manager/test_transformation_manager.py
+++ b/tests/core/transformation_manager/test_transformation_manager.py
@@ -192,7 +192,7 @@ def test_add_transformation(fully_connected_two_point_graph):
 
     assert tm.graph.has_edge(cs1, cs2)
     # Get the first edge key and check the transformation
-    edge_key = tm._get_edge_key_from_transform(transform)
+    edge_key = tm._get_edge_key((cs1, cs2, transform))
     assert tm.graph[cs1][cs2][edge_key][TRANSFORM_KEY] == transform
 
 
@@ -298,7 +298,8 @@ def test_remove_specific_transformation_between_coordinate_systems(five_point_gr
     tm.add_transformation(cs3, cs5, transform5)
 
     tm.remove_specific_transformation(cs3, cs5, transform4)
-    assert not tm.graph.has_edge(cs3, cs5, key=tm._get_edge_key_from_transform(transform4))
+    edge_key = tm._get_edge_key((cs3, cs5, transform4))
+    assert not tm.graph.has_edge(cs3, cs5, key=edge_key)
 
 
 def test_remove_specific_transformation_between_coordinate_systems_non_existent(five_point_graph):
@@ -308,7 +309,7 @@ def test_remove_specific_transformation_between_coordinate_systems_non_existent(
     """
 
     tm = TransformationManager()
-    [_cs1, _cs2, cs3, _cs4, cs5], [_transform1, _transform2, _transform3, transform4, transform5] = five_point_graph
+    [_cs1, _cs2, cs3, _cs4, cs5], [_transform1, _transform2, _transform3, transform4, _transform5] = five_point_graph
     tm.add_coordinate_system(cs3)
     tm.add_coordinate_system(cs5)
 
@@ -408,8 +409,10 @@ def test_get_all_shortest_transformation_sequences_multiple_paths_multiple_edges
     tm.add_transformation(cs3, cs5, transform4)
     tm.add_transformation(cs3, cs5, transform5)
 
+    expected_intermediate_edges = [(cs3, cs5, transform4)]
+
     sequences = tm.get_all_shortest_transformation_sequences(
-        cs1, cs5, expected_intermediate_transformations=[transform4]
+        cs1, cs5, expected_intermediate_edges=expected_intermediate_edges
     )
     assert len(sequences) == 2
     assert Sequence([transform1, transform2, transform4]) in sequences
@@ -498,7 +501,8 @@ def test_get_all_transformation_sequences_multiple_paths_multiple_edges_success(
     tm.add_transformation(cs3, cs5, transform4)
     tm.add_transformation(cs3, cs5, transform5)
 
-    sequences = tm.get_all_transformation_sequences(cs1, cs5, expected_intermediate_transformations=[transform4])
+    expected_intermediate_edges = [(cs3, cs5, transform4)]
+    sequences = tm.get_all_transformation_sequences(cs1, cs5, expected_intermediate_edges=expected_intermediate_edges)
     assert len(sequences) == 3
     assert Sequence([transform1, transform2, transform4]) in sequences
     assert Sequence([transform2, transform1, transform4]) in sequences
@@ -526,7 +530,7 @@ def test_get_all_transformation_sequences_multiple_paths_multiple_edges_no_edge_
     with pytest.raises(
         TransformationPathAmbiguousNoEdgeExpectedError, match="None of the edges were specified to be expected"
     ):
-        tm.get_all_transformation_sequences(cs1, cs5, expected_intermediate_transformations=[])
+        tm.get_all_transformation_sequences(cs1, cs5, expected_intermediate_edges=[])
 
 
 def test_get_all_transformation_sequences_multiple_paths_multiple_edges_multiple_expected(five_point_graph):
@@ -547,10 +551,15 @@ def test_get_all_transformation_sequences_multiple_paths_multiple_edges_multiple
     tm.add_transformation(cs3, cs5, transform4)
     tm.add_transformation(cs3, cs5, transform5)
 
+    expected_intermediate_edges = [
+        (cs3, cs5, transform4),
+        (cs3, cs5, transform5),
+    ]
+
     with pytest.raises(
         TransformationPathAmbiguousMultipleEdgeExpectedError, match="Multiple.*edges were specified to be expected"
     ):
-        tm.get_all_transformation_sequences(cs1, cs5, expected_intermediate_transformations=[transform4, transform5])
+        tm.get_all_transformation_sequences(cs1, cs5, expected_intermediate_edges=expected_intermediate_edges)
 
 
 def test_get_all_transformation_sequences_no_path(four_point_graph):


### PR DESCRIPTION
Part of tbd

## Increment 1: TransformationManager Class Foundation

Implement `TransformationManager` with coordinate system, element, and transformation management.
Validate against duplicate names and ensure elements belong to a CS before registration (i.e. create if not specified).
Add `transformation_manager: TransformationManager` as an attributed to `SpatialData` (not yet used).
This delivers the core data model and API for centralized transformation storage,
enabling inspection of transformation graphs without changing any existing behavior.

### Proposed Architecture

#### TransformationManager Internal Model

```python
import networkx as nx


class TransformationManager:
    def __init__(self):
        self.graph: nx.MultiDiGraph
        # has coordinate systems as `NgffCoordinateSystem` objects as nodes;
        # transforms as instances of BaseTransform are passed as attributes while adding edges
        self.element_to_cs_mapping: dict[str, NgffCoordinateSystem] = {}
        # maps `element_name` to the coordinate system to which the element belongs.
```

#### Notes:

- attributes of `TransformationManager` should be private (propery pattern)
- `element_name` is unique across all elements of a spatialdata object

#### TransformationManager API

##### Coordinate System Management

- [x] `add_coordinate_system(cs: NgffCoordinateSystem) -> None`
    - Register a new coordinate system.
    - Make sure to throw error if coordinate system already exists
- [x]  `remove_coordinate_system(cs: NgffCoordinateSystem) -> None`:
    - Remove an existing coordinate system.
    - Throw error if coordinate system has not yet been added
- [x] `list_coordinate_systems() -> list[NgffCoordinateSystem]`:
    - List all registered coordinate systems.

##### Element Management

- [x] `add_element(element_name: str) -> None`:
    - Register an element to an existing coordinate system
    - throw warning and do nothing if the element has already been registered
- [x] `unset_element(element_name: str) -> None`:
    - Unregister an element from the coordinate system to which it belongs
    - throw warning and do nothing if element has not been registered to any coordinate system
- [x] `get_element_coordinate_system(element_name: str) -> NgffCoordinateSystem`:
    - Get the name of the coordinate system to which an element belongs.
    - Throw error if `element_name` doesn't belong to any existing coordinate system

##### Transformation Management

- [x] `add_transformation(input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem, transformation: BaseTransformation) -> None`:

- Add a transformation between coordinate systems.
- throw error if either coordinate systems have not been added

- [x] `get_existing_transformation(input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem) -> BaseTransformation | None`:

- Retrieve a transformation between coordinate systems.
- throw error if either coordinate systems have not been added or if there is no direct transformation defined between
  them

- [x] `remove_transformation(input_cs: NgffCoordinateSystem, output_cs: NgffCoordinateSystem) -> None`:
    - Remove a transformation between coordinate systems.
    - throw error if either coordinate systems have not been added
