### PR TITLE
fix: point table validation to public sanitizer

### DIFF
--- a/src/spatialdata/_core/validation.py
+++ b/src/spatialdata/_core/validation.py
@@ -388,7 +388,7 @@ class raise_validation_errors:
         # Exceptions were collected that we want to raise as a combined validation error.
         if self._collector.errors:
             raise ValidationError(
-                title=self._message + "\nTo fix, run `spatialdata.utils.sanitize_table(adata)`.",
+                title=self._message + "\nTo fix, run `spatialdata.sanitize_table(adata)`.",
                 errors=self._collector.errors,
             )
         return True

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -26,6 +26,7 @@ from shapely.io import to_ragged_array
 from spatial_image import to_spatial_image
 from xarray import DataArray, DataTree
 
+import spatialdata
 from spatialdata._core.spatialdata import SpatialData
 from spatialdata._core.validation import ValidationError
 from spatialdata._types import ArrayLike
@@ -623,6 +624,18 @@ class TestModels:
                         TableModel.parse(adata)
                     else:
                         TableModel.validate(adata)
+
+    def test_table_model_invalid_name_suggests_public_sanitizer(self):
+        adata = AnnData(np.array([[0]]), uns={"invalid name": {}})
+
+        with pytest.raises(
+            ValidationError,
+            match=r"`spatialdata\.sanitize_table\(adata\)`",
+        ):
+            TableModel.validate(adata)
+
+        spatialdata.sanitize_table(adata)
+        TableModel.validate(adata)
 
     @pytest.mark.parametrize(
         "keys",


### PR DESCRIPTION
### Summary

The table-name validation error in issue [#1154](https://github.com/scverse/spatialdata/issues/1154) points to `spatialdata.utils.sanitize_table(adata)`. This path does not exist. The error now points to `spatialdata.sanitize_table(adata)`. Closes #1154.

### Design

Use the top-level function that `spatialdata` exports. Keep validation and sanitization behavior unchanged.

The implementation changes [`src/spatialdata/_core/validation.py`](https://github.com/scverse/spatialdata/blob/63a5780f29580ca98bdb26dbb44ef596a04e43e0/src/spatialdata/_core/validation.py).

### Tests

The regression test fails on `main` and passes on this branch. The full suite passes with 1,365 tests, 7 skips, and 1 expected failure. The installed wheel passes the reported sanitize-and-validate workflow.

The tests are in [`tests/models/test_models.py`](https://github.com/scverse/spatialdata/blob/63a5780f29580ca98bdb26dbb44ef596a04e43e0/tests/models/test_models.py).

All 7 [CPU matrix jobs](https://github.com/scverse/spatialdata/actions/runs/30096221602) passed.

<details>
<summary>Commands</summary>

```console
uv run pytest tests/models/test_models.py::TestModels::test_table_model_invalid_name_suggests_public_sanitizer -q
```

</details>
