### PR TITLE
fix: support raster labels above uint16

### DIFF
--- a/src/spatialdata/_core/operations/rasterize.py
+++ b/src/spatialdata/_core/operations/rasterize.py
@@ -30,7 +30,7 @@ from spatialdata.models import (
     get_axes_names,
     get_model,
 )
-from spatialdata.models._utils import get_spatial_axes
+from spatialdata.models._utils import _get_uint_dtype, get_spatial_axes
 from spatialdata.transformations._utils import _get_scale, compute_coordinates
 from spatialdata.transformations.operations import get_transformation, remove_transformation, set_transformation
 from spatialdata.transformations.transformations import (
@@ -733,10 +733,7 @@ def rasterize_shapes_points(
             max_label = next(iter(reversed(label_index_to_category.keys())))
         else:
             max_label = int(agg.max().values)
-        max_uint16 = np.iinfo(np.uint16).max
-        if max_label > max_uint16:
-            raise ValueError(f"Maximum label index is {max_label}. Values higher than {max_uint16} are not supported.")
-        agg = agg.astype(np.uint16)
+        agg = agg.astype(_get_uint_dtype(max_label))
         return Labels2DModel.parse(agg, transformations=transformations)
 
     agg = agg.expand_dims(dim={"c": 1}).transpose("c", "y", "x")

--- a/tests/core/operations/test_rasterize.py
+++ b/tests/core/operations/test_rasterize.py
@@ -446,6 +446,29 @@ def test_rasterize_points():
     assert d[res[1, 2]] == 4
 
 
+def test_rasterize_points_selects_label_dtype():
+    n_points = np.iinfo(np.uint16).max + 1
+    points = PointsModel.parse(
+        dd.from_pandas(
+            pd.DataFrame({"x": np.arange(n_points), "y": np.zeros(n_points)}),
+            npartitions=1,
+        )
+    )
+
+    result = rasterize(
+        points,
+        axes=("x", "y"),
+        min_coordinate=[0, 0],
+        max_coordinate=[n_points, 1],
+        target_coordinate_system="global",
+        target_width=n_points,
+        return_regions_as_labels=True,
+    )
+
+    assert result.dtype == np.uint32
+    assert result.max().compute() == n_points
+
+
 def test_rasterize_spatialdata(full_sdata):
     sdata = full_sdata.subset(
         ["image2d", "image2d_multiscale", "labels2d", "labels2d_multiscale", "points_0", "circles"]


### PR DESCRIPTION
2 implementations exist. This implementation uses 1 canvas and only removes the label-count limit. The [other implementation](https://github.com/scverse/spatialdata/pull/1166) adds opt-in output tiles after this commit to limit output memory. Compare the limitations.

### Summary

In [issue 987](https://github.com/scverse/spatialdata/issues/987), `rasterize(..., return_regions_as_labels=True)` rejects more than `65,535` labels. Select the output dtype from the maximum label. Closes #987.

### Design

Use the existing `_get_uint_dtype()` helper, as proposed in the [maintainer direction](https://github.com/scverse/spatialdata/issues/187#issuecomment-4508838126). Small outputs remain `uint16`. Larger outputs use `uint32` or `uint64` only when required.

The implementation changes [`src/spatialdata/_core/operations/rasterize.py`](https://github.com/stanbot8/spatialdata/blob/72250aa686c4be535f6d19038f9e0c13a0f2fb9e/src/spatialdata/_core/operations/rasterize.py).

### Limitations

This implementation uses 1 canvas. It removes the label-count limit, but it does not bound output memory.

### Tests

1 boundary test rasterizes `65,536` indexed points. It preserves label `65,536` in `uint32` output.

The focused rasterization suites pass with `28` tests. The complete suite passes with `1,365` tests, `7` skips, and `1` expected failure. An isolated installed wheel passes the same boundary case.

The test is in [`tests/core/operations/test_rasterize.py`](https://github.com/stanbot8/spatialdata/blob/72250aa686c4be535f6d19038f9e0c13a0f2fb9e/tests/core/operations/test_rasterize.py).

<details>
<summary>Commands</summary>

```console
uv run pytest tests/core/operations/test_rasterize.py::test_rasterize_points_selects_label_dtype -q
```

</details>
