### PR TITLE
docs: add docstrings to BaseTransformation.inverse() and to_affine_ma…

### DIFF
--- a/src/spatialdata/transformations/transformations.py
+++ b/src/spatialdata/transformations/transformations.py
@@ -127,7 +127,6 @@ class BaseTransformation(ABC):
 
     @abstractmethod
     def to_affine_matrix(self, input_axes: tuple[ValidAxis_t, ...], output_axes: tuple[ValidAxis_t, ...]) -> ArrayLike:
-       
         """
         Return the affine matrix representation of the transformation.
 
@@ -145,6 +144,7 @@ class BaseTransformation(ABC):
             The last row is always ``[0, 0, ..., 1]``.
         """
         pass
+
     def to_affine(self, input_axes: tuple[ValidAxis_t, ...], output_axes: tuple[ValidAxis_t, ...]) -> Affine:
         affine_matrix = self.to_affine_matrix(input_axes, output_axes)
         return Affine(affine_matrix, input_axes, output_axes)

--- a/src/spatialdata/transformations/transformations.py
+++ b/src/spatialdata/transformations/transformations.py
@@ -133,7 +133,7 @@ class BaseTransformation(ABC):
         Parameters
         ----------
         input_axes
-            The axes of the input coordinate system, e.g. ``("x", "y")`` or ``("x", "y", "z")``.
+            The axes of the input coordinate system, e.g. ``("x", "y")`` or ``("c", "z", "y", "x")``.
         output_axes
             The axes of the output coordinate system.
 
@@ -141,7 +141,7 @@ class BaseTransformation(ABC):
         -------
         ArrayLike
             A homogeneous affine matrix of shape ``(len(output_axes) + 1, len(input_axes) + 1)``.
-            The last row is always ``[0, 0, ..., 1]``.
+            The last row is always ``[0, 0, ..., 1]`` (homogeneity).
         """
         pass
 

--- a/src/spatialdata/transformations/transformations.py
+++ b/src/spatialdata/transformations/transformations.py
@@ -110,6 +110,15 @@ class BaseTransformation(ABC):
 
     @abstractmethod
     def inverse(self) -> BaseTransformation:
+        """
+        Return the inverse of the transformation.
+
+        Returns
+        -------
+        BaseTransformation
+            A new transformation that is the inverse of this one, such that applying
+            both in sequence yields the identity transformation.
+        """
         pass
 
     # @abstractmethod
@@ -118,8 +127,24 @@ class BaseTransformation(ABC):
 
     @abstractmethod
     def to_affine_matrix(self, input_axes: tuple[ValidAxis_t, ...], output_axes: tuple[ValidAxis_t, ...]) -> ArrayLike:
-        pass
+       
+        """
+        Return the affine matrix representation of the transformation.
 
+        Parameters
+        ----------
+        input_axes
+            The axes of the input coordinate system, e.g. ``("x", "y")`` or ``("x", "y", "z")``.
+        output_axes
+            The axes of the output coordinate system.
+
+        Returns
+        -------
+        ArrayLike
+            A homogeneous affine matrix of shape ``(len(output_axes) + 1, len(input_axes) + 1)``.
+            The last row is always ``[0, 0, ..., 1]``.
+        """
+        pass
     def to_affine(self, input_axes: tuple[ValidAxis_t, ...], output_axes: tuple[ValidAxis_t, ...]) -> Affine:
         affine_matrix = self.to_affine_matrix(input_axes, output_axes)
         return Affine(affine_matrix, input_axes, output_axes)


### PR DESCRIPTION
Closes #836

## Changes
- Added NumPy-style docstring to `BaseTransformation.inverse()` describing the return value
- Added NumPy-style docstring to `BaseTransformation.to_affine_matrix()` describing parameters and return value

Both methods are abstract and previously had no documentation beyond the method signature.