### PR TITLE
Fix contributor dependency installation instructions (docs only)

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -13,8 +13,7 @@ In addition to the packages needed to _use_ this package, you need additional py
 the documentation_. It's easy to install them using `pip`:
 
 ```bash
-cd spatialdata-io
-pip install -e ".[dev,test,doc]"
+pip install -e . --group dev --group test --group docs
 ```
 
 ## Code-style
@@ -51,7 +50,7 @@ and [prettier][prettier-editors].
 ## Writing tests
 
 ```{note}
-Remember to first install the package with `pip install '-e[dev,test]'`
+Remember to first install the package with `pip install -e . --group dev --group test`
 ```
 
 This package uses [pytest][] for automated testing. Please [write tests][scanpy-test-docs] for every function added to the package.


### PR DESCRIPTION
The current contribution install instructions:

```bash
pip install -e ".[dev,test,doc]"
```

warn:

```text
WARNING: spatialdata 0.8.1.dev2+geb4fb3d23 does not provide the extra 'dev'
WARNING: spatialdata 0.8.1.dev2+geb4fb3d23 does not provide the extra 'test'
WARNING: spatialdata 0.8.1.dev2+geb4fb3d23 does not provide the extra 'doc'
```
and do not install the development dependencies. This PR updates the instructions to use pip dependency groups, following [their introduction](https://github.com/scverse/spatialdata/commit/cdf3435f18ea87a05565cc0a20c0860aba74d0aa#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) in `cdf3435f`.