### PR TITLE
docs: add interoperability page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -110,6 +110,7 @@ tutorials/notebooks/notebooks.md
 tutorials/notebooks/datasets/README.md
 glossary.md
 design_doc.md
+interoperability.md
 contributing.md
 changelog.md
 references.md

--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -1,0 +1,16 @@
+# Interoperability
+
+The on-disk representation of SpatialData can be read from other languages. Here we list interfaces for working with SpatialData from your language of choice:
+
+## R
+
+- [spatialdataR](https://helenalc.github.io/spatialdataR/) provides an R implementation of the `SpatialData` object, with out-of-memory images and labels, `duckdb`-backed points and shapes, and tables represented as `SingleCellExperiment` objects.
+
+## JavaScript and TypeScript
+
+- [SpatialData.js](https://github.com/Taylor-CCB-Group/SpatialData.js) provides a TypeScript and JavaScript library for interfacing with SpatialData stores.
+- [Vitessce](https://vitessce.io/docs/data-file-types/#spatialdatazarr) reads `spatialdata.zarr` stores directly and uses them for interactive visualization.
+
+## File format
+
+The SpatialData on-disk format builds on [OME-NGFF](https://ngff.openmicroscopy.org/latest/). See the [design document](design_doc.md) for details of the current on-disk layout.

--- a/src/spatialdata/_io/io_zarr.py
+++ b/src/spatialdata/_io/io_zarr.py
@@ -5,7 +5,7 @@ import warnings
 from collections.abc import Callable
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 import zarr.storage
 from anndata import AnnData
@@ -71,7 +71,7 @@ def _read_zarr_group_spatialdata_element(
                         reader_format = get_raster_format_for_read(elem_group, sdata_version)
                         element = read_func(
                             elem_group_path,
-                            cast(Literal["image", "labels"], element_type),
+                            element_type,
                             reader_format,
                         )
                     elif element_type in ["shapes", "points", "tables"]:


### PR DESCRIPTION
Closes scverse/spatialdata#1176. Preview: [https://scverse-spatialdata--1180.org.readthedocs.build/en/1180/interoperability.html](<https://scverse-spatialdata--1180.org.readthedocs.build/en/1180/interoperability.html>)

Adds a short `Interoperability` page listing the non-Python interfaces to the SpatialData on-disk format, following the structure of the [equivalent page in mudata](<https://github.com/scverse/mudata/commit/f97ad24e981cb2e5e5149c511073195c4771a05d>) and the one in [anndata](<https://github.com/scverse/anndata/blob/main/docs/interoperability.md>), as requested by @Zethson so the style is consistent across the three data structures.

Sections: **R** ([spatialdataR](<https://github.com/HelenaLC/spatialdataR>)), **JavaScript and TypeScript** ([SpatialData.js](<https://github.com/Taylor-CCB-Group/SpatialData.js>), [Vitessce](<https://vitessce.io/docs/data-file-types/#spatialdatazarr>)), and a short **File format** note (to be expanded into its osn tab later).

`napari-spatialdata` is not listed as it's python, relies on the spatialdata python package and does not read on-disk data directly