### PR TITLE
Fix numba JIT disable patch targeting wrong config attribute

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import sys
 os.environ["NUMBA_DISABLE_JIT"] = "1"
 # If a pytest plugin already imported numba before this conftest ran, patch the cached config value too.
 if "numba.core.config" in sys.modules:
-    sys.modules["numba.core.config"].NUMBA_DISABLE_JIT = 1
+    sys.modules["numba.core.config"].DISABLE_JIT = 1
 
 import copy as _copy
 from collections.abc import Callable, Sequence


### PR DESCRIPTION
Test suite tried to force-disable numba JIT when already imported by patching `NUMBA_DISABLE_JIT` on numba.core.config, but numba internally reads the env var into an attribute named `DISABLE_JIT` (no prefix).

We should find a less hacky solution to this, but for now, running the tests sequentially (`pytest -x`) always pass.