### PR TITLE
Do not erase the anndata encoding metadata from the table group

### DIFF
--- a/src/spatialdata/_io/io_table.py
+++ b/src/spatialdata/_io/io_table.py
@@ -119,6 +119,12 @@ def write_table(
 
         write_adata(group, name, table)
 
+    # Re-fetch the group before setting the attributes below: the handle obtained above was cached while the group
+    # was still empty, and zarr writes attributes as a whole document based on the handle's cached view, so writing
+    # through the stale handle would erase the `encoding-type`/`encoding-version` metadata that anndata just wrote
+    # (https://github.com/scverse/spatialdata/issues/1183).
+    table_group = group[name]
+
     table_group.attrs["spatialdata-encoding-type"] = group_type
     table_group.attrs["region"] = region
     table_group.attrs["region_key"] = region_key

--- a/tests/io/test_readwrite.py
+++ b/tests/io/test_readwrite.py
@@ -16,6 +16,7 @@ import pyarrow.parquet as pq
 import pytest
 import zarr
 from anndata import AnnData
+from anndata.io import read_elem
 from numpy.random import default_rng
 from packaging.version import Version
 from pandas.testing import assert_series_equal
@@ -685,6 +686,24 @@ def test_incremental_io_in_memory(
         sdata.tables[f"additional_{k}"] = v
         with pytest.raises(KeyError, match="Key `poly` is not unique"):
             sdata["poly"] = v
+
+
+def test_table_group_keeps_anndata_encoding_metadata(tmp_path: str, table_single_annotation: SpatialData) -> None:
+    # https://github.com/scverse/spatialdata/issues/1183
+    # Writing the spatialdata attributes on the table group must not erase the
+    # `encoding-type`/`encoding-version` metadata that anndata writes on the same
+    # group; anndata-level readers (read_elem, read_lazy) dispatch on it.
+    tmpdir = Path(tmp_path) / "tmp.zarr"
+    table_single_annotation.write(tmpdir)
+
+    on_disk = json.loads((tmpdir / "tables" / "table" / "zarr.json").read_text())["attributes"]
+    assert on_disk["encoding-type"] == "anndata"
+    assert on_disk["encoding-version"] == "0.1.0"
+    # the spatialdata attributes must be present alongside, not instead
+    assert on_disk["spatialdata-encoding-type"] == "ngff:regions_table"
+
+    table_group = zarr.open_group(tmpdir, mode="r")["tables/table"]
+    assert isinstance(read_elem(table_group), AnnData)
 
 
 def test_bug_rechunking_after_queried_raster():


### PR DESCRIPTION
Fixes #1183.

`write_table` acquires the table group handle with `group.require_group(name)`
before the anndata write and sets the spatialdata attributes through that
handle afterwards. zarr v3 writes attributes as a whole document from the
handle's cached view, which was captured while the group was still empty, so
the first attribute assignment erased the `encoding-type` and
`encoding-version` attributes that anndata had just written. As a result
`anndata.io.read_elem` and `anndata.experimental.read_lazy` silently returned
a plain dict instead of an AnnData when given the table group.

The fix re-fetches the handle after the write, which is the ordering 0.8.0
used (`tables_group = group[name]` after `write_adata`). It sits after the
if/else so it covers both the `write_zarr` and the `write_adata` branch.

Also adds a regression test asserting the anndata encoding metadata and the
spatialdata attributes are both present on the written table group, and that
`read_elem` on the group returns an AnnData. The test fails on current main
with `KeyError: 'encoding-type'` and passes with the fix.

Verified against the downstream converter that hit this (Thyra): its
previously failing read_lazy contract test passes with this branch, and its
converted stores are byte-identical to 0.8.0 output again.

Note on local testing: on my Windows machine some io tests flake with
`PermissionError: [WinError 5]` on the atomic `.zattrs` rename in zarr v2
raster writes. That happens at the same rate on unmodified main, so it is
unrelated, but worth knowing when comparing local runs to CI.

Let me know if you would like a changelog entry or any changes.
